### PR TITLE
fix(executions): show input context for failed steps in execution review

### DIFF
--- a/packages/admin-shell/src/features/executions/components/StandardStepAccordionItem.tsx
+++ b/packages/admin-shell/src/features/executions/components/StandardStepAccordionItem.tsx
@@ -108,6 +108,11 @@ export function StandardStepAccordionItem({ step, stepNumber, onOpenDiff, onOpen
                     <Group justify="center" p="xl"><Loader size="sm" /><Text size="sm" c="dimmed">Loading large step details...</Text></Group>
                 ) : fetchError ? (
                     <Alert color="red" title="Failed to load details">{fetchError.message}</Alert>
+                ) : isDetailsOmitted && !fetchedStepData ? (
+                    <Alert color="orange" title="Step details unavailable">
+                        The detailed record for this step could not be loaded. Its summary is shown above, but the
+                        full input/output context is not available.
+                    </Alert>
                 ) : (displayStep as any)._large_payload_link ? (
                      <Alert color="blue" title="Step Record Too Large">
                         <Text size="sm" mb="sm">{(displayStep as any)._s3_error}</Text>

--- a/packages/admin-shell/src/features/executions/components/StepDetailsPanel.tsx
+++ b/packages/admin-shell/src/features/executions/components/StepDetailsPanel.tsx
@@ -1,5 +1,5 @@
-import { Accordion, Button, Group, SimpleGrid, Stack, Text, Tooltip } from "@mantine/core";
-import { IconGitCompare, IconPlayerPlay, IconSettings } from "@tabler/icons-react";
+import { Accordion, Alert, Button, Group, SimpleGrid, Stack, Text, Tooltip } from "@mantine/core";
+import { IconAlertTriangle, IconGitCompare, IconPlayerPlay, IconSettings } from "@tabler/icons-react";
 import { AllmaStepExecutionRecord, MappingEvent } from '@allma/core-types';
 import { EditableJsonView } from "@allma/ui-components";
 import { MappingEventsDisplay } from "./MappingEventsDisplay";
@@ -17,6 +17,25 @@ const ContextAccordionItem = ({ title, data, value }: { title: string; data: any
     );
 };
 
+/**
+ * Renders a context object, distinguishing three cases so the UI never silently shows an
+ * empty `{}` when context is actually unavailable:
+ *  - `undefined`/`null`  -> the context was not recorded for this step (e.g. a step that
+ *    failed before its output context was produced, or whose detailed record could not be loaded).
+ *  - an empty object     -> rendered as-is (the context genuinely was empty).
+ *  - a populated object  -> rendered via the JSON viewer.
+ */
+const ContextView = ({ value, missingLabel }: { value: unknown; missingLabel: string }) => {
+    if (value === undefined || value === null) {
+        return (
+            <Alert color="gray" variant="light" icon={<IconAlertTriangle size="1rem" />}>
+                {missingLabel}
+            </Alert>
+        );
+    }
+    return <EditableJsonView value={value} readOnly />;
+};
+
 interface StepDetailsPanelProps {
     step: AllmaStepExecutionRecord;
     onOpenDiff: () => void;
@@ -31,9 +50,17 @@ export function StepDetailsPanel({ step, onOpenDiff, onOpenConfig, onRedrive, is
     const logDetails = fullStepRecord.logDetails as Record<string, any> | undefined;
     const inputContext = fullStepRecord.inputMappingContext;
     const outputContext = fullStepRecord.outputMappingContext;
+    // Set by the backend when the full step record could not be hydrated from S3. Surfaced here so a
+    // partially-loaded step explains itself instead of silently showing empty context sections.
+    const s3Error = fullStepRecord._s3_error as string | undefined;
 
     return (
         <Stack>
+            {s3Error && !fullStepRecord._large_payload_link && (
+                <Alert color="orange" title="Some step details could not be loaded" icon={<IconAlertTriangle size="1rem" />}>
+                    {s3Error}
+                </Alert>
+            )}
             {!isSandbox && (
                 <Group justify="flex-end">
                     <Tooltip label="View the step's configuration from this flow version">
@@ -75,13 +102,13 @@ export function StepDetailsPanel({ step, onOpenDiff, onOpenConfig, onRedrive, is
                         </Tooltip>
                     </Group>
                     <Text size="xs" c="dimmed">The state of the entire flow *before* this step ran.</Text>
-                    <EditableJsonView value={inputContext || {}} readOnly />
+                    <ContextView value={inputContext} missingLabel="No input context was recorded for this step." />
                 </Stack>
-    
+
                 <Stack gap="xs">
                     <Text fw={500}>Final Context After Step</Text>
                     <Text size="xs" c="dimmed">The state of the entire flow *after* this step&apos;s output was merged.</Text>
-                    <EditableJsonView value={outputContext ?? {}} readOnly />
+                    <ContextView value={outputContext} missingLabel="No output context was recorded — the step did not complete successfully." />
                 </Stack>
             </SimpleGrid>
     

--- a/packages/app-logic/src/allma-admin/services/execution-monitoring.service.ts
+++ b/packages/app-logic/src/allma-admin/services/execution-monitoring.service.ts
@@ -214,33 +214,29 @@ export const ExecutionMonitoringService = {
         }) as AllmaStepExecutionRecord[];
 
         if (matchingSteps.length === 0) return null;
-        
-        // Take the latest attempt if attemptNumber wasn't specified
+
+        // Take the latest attempt if attemptNumber wasn't specified.
         matchingSteps.sort((a, b) => b.eventTimestamp.localeCompare(a.eventTimestamp));
-        const stepToFetch = matchingSteps[0];
+        const latestEvent = matchingSteps[0];
 
-        if (stepToFetch.fullRecordS3Pointer) {
-            try {
-                // EXPLICIT FALSE: Enforce 4MB limit to protect the API Gateway endpoint
-                const fullRecordFromS3 = await resolveS3Pointer(stepToFetch.fullRecordS3Pointer, correlationId, false);
-                
-                if (fullRecordFromS3?._is_large_s3_payload) {
-                    return { 
-                        ...stepToFetch, 
-                        _detailsOmittedForSize: true, 
-                        _large_payload_link: fullRecordFromS3.presignedUrl,
-                        _s3_error: `Step details too large (${(fullRecordFromS3.sizeBytes / 1024 / 1024).toFixed(2)} MB) to load inline. Please download the log file.` 
-                    } as any;
-                }
+        // A single logical step is logged as MULTIPLE events (e.g. STARTED, then COMPLETED/FAILED,
+        // plus any retry events), each with its own eventTimestamp, sort key and S3 pointer. The input
+        // context (`inputMappingContext`) is captured on the STARTED event, while output/error context
+        // lives on the terminal event. Resolving a single event's record therefore drops whichever
+        // context lives on the others — which is why a failed step previously rendered with an empty
+        // input context. Resolve and consolidate ALL events for this step, identically to
+        // getExecutionDetails, so the returned record carries the full merged context.
+        const fullEvents = await resolveFullStepRecords(matchingSteps, correlationId ?? flowExecutionId);
+        const consolidatedSteps = consolidateStepEvents(fullEvents);
 
-                return { ...fullRecordFromS3, ...stepToFetch };
-            } catch (e: any) {
-                log_error(`Failed to resolve S3 pointer for specific step record`, { pointer: stepToFetch.fullRecordS3Pointer, error: e.message }, correlationId);
-                return { ...stepToFetch, _s3_error: `Failed to load full record from S3: ${e.message}` } as any;
-            }
-        }
-        
-        return stepToFetch;
+        // Return the consolidated record for the same attempt/branch as the latest event.
+        const target = consolidatedSteps.find(s =>
+            s.stepInstanceId === latestEvent.stepInstanceId &&
+            (s.attemptNumber ?? 1) === (latestEvent.attemptNumber ?? 1) &&
+            (s.branchExecutionId ?? null) === (latestEvent.branchExecutionId ?? null)
+        );
+
+        return target ?? consolidatedSteps[0] ?? latestEvent ?? null;
     },
 
     /**

--- a/packages/app-logic/src/allma-flows/iterative-step-processor/index.ts
+++ b/packages/app-logic/src/allma-flows/iterative-step-processor/index.ts
@@ -375,6 +375,13 @@ export const handler: Handler<ProcessorInput, ProcessorOutput | void> = async (e
                     durationMs: runtimeState._internal?.currentStepStartTime ? (new Date(stepEndTime).getTime() - new Date(runtimeState._internal.currentStepStartTime).getTime()) : 0,
                     attemptNumber: runtimeState.stepRetryAttempts?.[runtimeState.currentStepInstanceId] || 1,
                     errorInfo: errorInfo,
+                    // Persist the input context so a failed step is always reviewable, even when the
+                    // failure occurred OUTSIDE executeStandardStep (e.g. input-mapping, parallel-fork
+                    // or sync-flow-start errors) and this is therefore the only record written. On
+                    // failure the step never mutates currentContextData, so it still holds the
+                    // "before step" state. This is the contextful counterpart of the FAILED record
+                    // written in executeStandardStep.
+                    inputMappingContext: runtimeState.currentContextData,
                     stepInstanceConfig: stepInstance,
                 });
             }


### PR DESCRIPTION
## Problem

In the Admin execution-review UI, when a step **errored** (e.g. a Lambda failed) its **input context was not shown** — the panel rendered an empty `{}`, and in some cases the step appeared to "disappear" when its details were loaded.

## Root cause

Two compounding bugs — one on the read path, one on the write path.

### Read side — only the latest event was fetched
A single logical step is logged as **multiple events** (`STARTED`, then `COMPLETED`/`FAILED`, plus any retries), each with its own timestamp and S3 pointer. `inputMappingContext` is captured on the `STARTED` event, while output/error context lives on the terminal event.

`getStepRecordDetails` (used when a step's details were omitted for payload size) sorted events by timestamp and resolved **only the single latest one** — the terminal failure record — so the input context was dropped. The main view (`getExecutionDetails`) never had this problem because it **consolidates all events**.

**Fix:** `getStepRecordDetails` now resolves and consolidates *all* of a step's events using the same `resolveFullStepRecords` + `consolidateStepEvents` helpers as the main view, so the returned record always carries the full merged context.

### Write side — failure record omitted the input context
The processor-level catch in the iterative step processor (`index.ts`) wrote a second `FAILED` record (later timestamp) that **omitted `inputMappingContext`**. For failures that happen **outside** `executeStandardStep` — input-mapping, parallel-fork, sync-flow-start and config errors — this was the *only* record written, so the input context was **never persisted** and no read-side fix could recover it.

**Fix:** that record now persists `inputMappingContext` from the (unmutated-on-failure) current context, making every failed step self-contained and reviewable.

### Frontend hardening
- `StepDetailsPanel` distinguishes *unavailable* context (`null`/`undefined`) from a genuinely empty `{}`, and surfaces backend S3-load errors instead of silently showing `{}`.
- `StandardStepAccordionItem` shows a clear message when an omitted-for-size step's details cannot be loaded.

## Testing
- `tsc` and ESLint pass on all touched packages (`app-logic`, `admin-shell`).
- Integration tests require a live deployed AWS `dev` stage (per `tests/integration/README.md`) and are not runnable in this environment; they fail identically with or without these changes.

## Notes
- `@allma/*` packages remain product-agnostic; no example/consumer code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)