### PR TITLE
test(admin-shell): establish the Vitest test suite (Phases 0–6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
     "examples/basic-deployment": {
       "version": "0.1.1",
       "dependencies": {
-        "@allma/admin-shell": "2.0.4",
+        "@allma/admin-shell": "3.0.0",
         "@allma/core-cdk": "1.1.8",
         "aws-cdk-lib": "^2.130.0",
         "constructs": "^10.0.0",
@@ -246,6 +246,48 @@
         "ts-jest": "^29.1.2",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3"
+      }
+    },
+    "examples/optiroq/node_modules/@allma/admin-shell": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@allma/admin-shell/-/admin-shell-2.0.4.tgz",
+      "integrity": "sha512-D25TXYhmcrjr+edi8vacDYG50RmfePXDedxynOQl4ECIEJGm/pasAhIKaaltxMIGCMpxQG7sdax0/dT0Xy66sA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@xstate/react": "^4.1.3",
+        "file-saver": "^2.0.5",
+        "use-debounce": "^10.0.6",
+        "uuid": "^11.1.0"
+      },
+      "peerDependencies": {
+        "@allma/core-sdk": "^1.0.11",
+        "@allma/core-types": "1.1.3",
+        "@aws-amplify/ui-react": "^6.13.0",
+        "@emotion/react": "^11.14.0",
+        "@mantine/core": "^8.0.0",
+        "@mantine/dates": "^8.0.0",
+        "@mantine/form": "^8.0.0",
+        "@mantine/hooks": "^8.0.0",
+        "@mantine/modals": "^8.1.3",
+        "@mantine/notifications": "^8.0.0",
+        "@tabler/icons-react": "^3.31.0",
+        "@tanstack/react-query": "^5.75.7",
+        "@tanstack/react-query-devtools": "^5.75.7",
+        "amazon-cognito-identity-js": "^6.3.15",
+        "aws-amplify": "^6.15.7",
+        "axios": "^1.9.0",
+        "dagre": "^0.8.5",
+        "date-fns": "^4.1.0",
+        "lodash-es": "^4.17.21",
+        "react": "^19.1.0",
+        "react-diff-viewer-continued": "^4.0.6",
+        "react-dom": "^19.1.0",
+        "react-markdown": "^10.1.0",
+        "react-router-dom": "^7.6.0",
+        "reactflow": "^11.11.4",
+        "recharts": "^3.2.0",
+        "remark-gfm": "^4.0.1",
+        "zustand": "^5.0.5"
       }
     },
     "examples/optiroq/node_modules/@esbuild/aix-ppc64": {
@@ -749,6 +791,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "examples/optiroq/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "examples/optiroq/packages/optiroq-convert": {
@@ -1540,6 +1595,27 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@aws-amplify/analytics": {
       "version": "7.0.94",
@@ -4192,6 +4268,121 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -9001,6 +9192,78 @@
         "@tensorflow/tfjs-core": "4.22.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -9019,6 +9282,34 @@
         "node": ">=14",
         "npm": ">=6",
         "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@testing-library/user-event": {
@@ -9609,6 +9900,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.162",
@@ -13107,6 +13405,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -13319,6 +13638,57 @@
         "node": ">= 12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -13414,6 +13784,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
@@ -15976,6 +16353,19 @@
         "react-is": "^16.7.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -16041,6 +16431,30 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -16662,6 +17076,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -17689,6 +18110,121 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/jsdom/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/jsdom/node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/jsep": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
@@ -18442,6 +18978,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -19766,6 +20312,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -20283,6 +20836,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/parseley": {
@@ -22101,6 +22680,13 @@
       "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
       "license": "MIT"
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-applescript": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
@@ -23233,6 +23819,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tabbable": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
@@ -23406,6 +23999,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
@@ -23432,6 +24045,19 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -26989,6 +27615,19 @@
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -27013,6 +27652,43 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -27268,6 +27944,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xml-naming": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
@@ -27504,7 +28190,7 @@
     },
     "packages/admin-shell": {
       "name": "@allma/admin-shell",
-      "version": "2.0.4",
+      "version": "3.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@xstate/react": "^4.1.3",
@@ -27513,8 +28199,12 @@
         "uuid": "^11.1.0"
       },
       "devDependencies": {
-        "@allma/core-types": "1.1.3",
+        "@allma/core-types": "1.2.0",
         "@tanstack/react-query-devtools": "^5.75.7",
+        "@testing-library/dom": "^10.4.0",
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/dagre": "^0.7.53",
         "@types/file-saver": "^2.0.7",
         "@types/lodash-es": "^4.17.12",
@@ -27522,22 +28212,25 @@
         "@types/react-dom": "^19.1.2",
         "@types/uuid": "^10.0.0",
         "@vitejs/plugin-react": "^4.4.1",
+        "@vitest/coverage-v8": "^1.6.1",
         "eslint": "^9.8.0",
         "eslint-plugin-react": "^7.34.1",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^16.0.0",
+        "jsdom": "^25.0.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.0",
         "tsup": "^8.5.0",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.0.0",
-        "vite": "^6.3.5"
+        "vite": "^6.3.5",
+        "vitest": "^1.6.1"
       },
       "peerDependencies": {
         "@allma/core-sdk": "^1.0.11",
-        "@allma/core-types": "1.1.3",
+        "@allma/core-types": "1.2.0",
         "@aws-amplify/ui-react": "^6.13.0",
         "@emotion/react": "^11.14.0",
         "@mantine/core": "^8.0.0",
@@ -27584,7 +28277,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@allma/core-sdk": "^1.0.11",
-        "@allma/core-types": "^1.1.3",
+        "@allma/core-types": "^1.2.0",
         "@aws-sdk/client-bedrock-runtime": "^3.614.0",
         "@aws-sdk/client-dynamodb": "^3.500.0",
         "@aws-sdk/client-scheduler": "^3.614.0",
@@ -27735,10 +28428,10 @@
     },
     "packages/cdk-integration-utils": {
       "name": "@allma/cdk-integration-utils",
-      "version": "1.0.21",
+      "version": "1.0.22",
       "license": "Apache-2.0",
       "dependencies": {
-        "@allma/core-types": "1.1.3",
+        "@allma/core-types": "1.2.0",
         "aws-cdk-lib": "^2.200.1",
         "constructs": "^10.0.0"
       },
@@ -27978,7 +28671,7 @@
     },
     "packages/core-types": {
       "name": "@allma/core-types",
-      "version": "1.1.3",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "eslint": "^9.8.0",

--- a/packages/admin-shell/TEST_PLAN.md
+++ b/packages/admin-shell/TEST_PLAN.md
@@ -1,0 +1,193 @@
+# `@allma/admin-shell` — Test Coverage Plan
+
+> Scope: this plan covers **only `packages/admin-shell`** (the React Admin Panel
+> shell/framework). It mirrors the proven approach already shipped in
+> [`packages/app-logic/TEST_PLAN.md`](../app-logic/TEST_PLAN.md): a hermetic Vitest suite,
+> a unit/integration project split, and a coverage ratchet. Other packages
+> (`ui-components`, `core-sdk`, `core-cdk`, …) are a deliberate follow-up and out of scope.
+
+## 1. Current state (why this plan exists)
+
+- **~110 source files** under `src/` (~3.4k lines `.ts`, ~7.8k lines `.tsx`); **zero test
+  files**.
+- **No test runner is configured for this package**: `package.json` has no `test` script,
+  no `vitest`, no DOM environment (`jsdom`/`happy-dom`), and no `@testing-library/react`.
+  The monorepo root already has `vitest`, `@testing-library/jest-dom`, and
+  `@testing-library/user-event` available, so tooling is a small delta — not a greenfield.
+- The package is a **React 19 + Mantine 8 + React Query 5 + reactflow + Zustand** app. It is
+  a published library (`@allma/admin-shell`), so its public surface
+  (`createAllmaAdminApp`, the `AllmaPlugin` contract, exported services/hooks) is a real
+  contract worth protecting.
+- Consequently the **highest-value logic is completely uncovered**: the flow-editor Zustand
+  store, the graph/layout utilities, the Zod↔form mappers, and the API service layer.
+
+### Key architectural constraints (these shape the strategy)
+
+1. **A large fraction of the logic is framework-free** and can be tested with little or no
+   DOM. The Zustand store (`useFlowEditorStore.ts`, 599 lines) is driven entirely through
+   `store.getState().<action>(…)` — no React render needed. The graph utils, mappers, and
+   formatters are pure functions.
+2. **Components depend on heavy providers**: Mantine (`MantineProvider`), React Query
+   (`QueryClientProvider`), React Router (`<MemoryRouter>`), and Amplify auth. Component
+   tests need a shared `renderWithProviders` wrapper or they drown in setup.
+3. **The API layer is `axios` + React Query**. Services wrap an `AdminApiResponse<T>`
+   envelope (`{ success, data, error }`) and fire Mantine notifications. The right seam is
+   to mock the shared `axiosInstance` (one module) — not the network — and assert request
+   shape, envelope unwrapping, and error mapping.
+4. **reactflow / Dagre visual layout** (canvas geometry, node rendering) is the lowest-ROI,
+   highest-cost surface and is deliberately deferred.
+
+## 2. Strategy — a testing pyramid, hermetic by default
+
+| Layer | What | Environment | Runs on |
+| --- | --- | --- | --- |
+| **Unit — pure logic** (bulk) | Store actions, graph/layout utils, mappers, formatters, form-utils | `node` (no DOM) | Every PR |
+| **Unit — API/hooks** | Service fns + React Query hooks; `axiosInstance` mocked | `jsdom` + `renderHook` | Every PR |
+| **Component** (selective) | Forms, tables, modals, `ErrorBoundary`, shell composition | `jsdom` + `renderWithProviders` | Every PR |
+| **Integration** (thin, opt-in) | Full pages against a mock API server (MSW) | `jsdom` + MSW | On demand / nightly |
+
+**Decisions:**
+- PR CI runs **only the hermetic layers** (unit + component). No live API, no AWS, no auth.
+- Use **Vitest projects** to split `unit` (node env) from `dom` (jsdom env) so pure-logic
+  tests stay fast and don't pay the jsdom tax.
+- Prefer **Mock Service Worker (MSW)** for any page-level integration test; mock the single
+  `axiosInstance` module for the cheaper service/hook unit tests.
+- **No source changes to make a test pass.** If a test reveals a real bug, stop and report
+  it — do not "fix" the product under cover of a test. (Same rule as `app-logic`.)
+
+## 3. Tooling & scaffolding (Phase 0)
+
+Add to `packages/admin-shell`:
+
+- **Dev deps:** `vitest`, `@vitest/coverage-v8`, `jsdom` (or `happy-dom`),
+  `@testing-library/react`, `@testing-library/user-event`, `@testing-library/jest-dom`,
+  `@testing-library/dom`. For Phase 4 only: `msw`.
+- **`vitest.config.ts`** with two projects:
+  - `unit` — `environment: 'node'`, `include: ['tests/unit/**/*.test.ts']`. Pure logic.
+  - `dom` — `environment: 'jsdom'`, `include: ['tests/dom/**/*.test.{ts,tsx}']`,
+    `setupFiles: ['tests/_setup/jsdom.setup.ts']`.
+  - Root-level coverage with `all: true`, `include: ['src/**/*.{ts,tsx}']`,
+    `exclude: ['src/**/*.d.ts', 'src/**/index.ts', 'src/types/**', 'src/harness/**']`.
+    Thresholds start low and ratchet up (Phase 6).
+- **`tests/_setup/jsdom.setup.ts`** — `import '@testing-library/jest-dom/vitest'`; stub
+  `window.matchMedia` and `ResizeObserver` (Mantine/reactflow need them).
+- **`tests/_helpers/`**:
+  - `render.tsx` — `renderWithProviders` wrapping `MantineProvider` + fresh
+    `QueryClientProvider` (retries off) + `<MemoryRouter>`.
+  - `axios-mock.ts` — helper to `vi.mock('../src/api/axiosInstance.js')` and queue
+    responses; reset in `beforeEach`.
+  - `fixtures/` — builders for `FlowDefinition`, `StepInstance`, execution records, the
+    `AllmaStepNode`/`AllmaTransitionEdge` graph shapes, and `AdminApiResponse<T>` envelopes
+    (success + error).
+- **npm scripts:**
+  - `test` → both projects (the CI gate / default).
+  - `test:unit`, `test:dom`, `test:coverage`, `test:watch`.
+- **ESLint:** ensure the flat config lints `tests/**` (or carves out test globals); keep
+  ES-module `.js` extensions on relative imports, matching the rest of the repo.
+- **`turbo.json`** already declares `coverage/**` as a `test` output — no change needed.
+- **CI:** add `admin-shell` to the PR test matrix (it currently runs no tests).
+
+## 4. Phased coverage targets
+
+### Phase 1 — Pure logic, no DOM (highest ROI; do this first)
+Unit tests under `tests/unit/`, `node` env, little/no mocking:
+
+- **`utils/formatters.ts`** — `formatPreciseDuration` boundary table (`null`/negative/`<1s`/
+  seconds/minutes/hours), plus any relative-time/byte formatters.
+- **`features/executions/utils.tsx`** — `getStatusColor` / `getStatusIcon` for every status
+  + the unknown-status fallback.
+- **`features/shared/step-form/form-utils.ts`** — `getDefaultsFromShape` across every Zod
+  type branch (`ZodDefault`, string/effects, object/record, array, enum/number/boolean →
+  `null`).
+- **`features/flows/editor/zod-schema-mappers.ts`** — schema selection per `StepType`,
+  round-trip mapping, and the unknown/unmapped fallback (153 lines, table-driven).
+- **`features/shared/step-form/moduleOptions.ts`** and feature `constants.ts` — option/label
+  derivation where it carries logic.
+
+**Exit:** ~85%+ line coverage on these files.
+
+### Phase 2 — The flow-editor Zustand store (high ROI, still no DOM)
+`useFlowEditorStore.ts` is 599 lines of the most important client logic and is testable
+**without React** — call actions on `useFlowEditorStore.getState()` and assert the next
+state. Reset the store in `beforeEach`. Cover:
+- `onNodesChange` / `onEdgesChange` (selection, position, removal) and dirty-state flips.
+- `onConnect` — valid connection creates an edge; invalid/self/duplicate is rejected.
+- `addNode`, `deleteNodes`, `onNodesDelete` — and cascade deletion of attached edges.
+- `updateNodeConfig`, `updateEdgeCondition`, `updateEdgeHandles`, `setStartNode`,
+  `updateFlowProperties`, `deselectAll`, `clearDirtyState`.
+- Parallel-branch invariants where the store enforces them.
+
+**Exit:** ~80%+ line coverage on the store.
+
+### Phase 3 — Graph / layout utilities
+`features/flows/editor/flow-utils.ts` (219 lines): `findBranchSteps`, node/edge
+construction from a `FlowDefinition`, and the Dagre layout pass. Assert **structure**
+(nodes/edges produced, branch grouping, parent/child wiring), not pixel geometry. Feed it
+fixture flow definitions (linear, conditional, parallel-fork). Also cover
+`step-configs.ts` / `step-documentation.ts` where they map types → config.
+
+### Phase 4 — API service layer + React Query hooks (`jsdom`)
+One spec per service under `tests/dom/api/`. Mock the single `axiosInstance` module; for
+hooks use `renderHook` with the `QueryClientProvider` wrapper. Per service assert:
+- **Request shape** — correct method, the versioned route
+  (`/${ALLMA_ADMIN_API_VERSION}${ALLMA_ADMIN_API_ROUTES.*}`), query params, and body.
+- **Envelope unwrapping** — `success:true` → `data`; `success:false`/`error` → thrown
+  `Error` with the server message.
+- **Side effects** — success/error Mantine `notifications`, and query invalidation /
+  navigation on mutations.
+
+Services: `flowService`, `flowControlService`, `executionService`, `promptTemplateService`,
+`agentService`, `mcpConnectionService`, `stepDefinitionService`, `systemToolsService`,
+`dashboardService`, `importExportService`, and `axiosInstance` (auth-header/interceptor
+behavior). The shared envelope/notification logic should be covered once and reused.
+
+### Phase 5 — Selective component tests (`jsdom` + `renderWithProviders`)
+Render only **behavior-bearing** components; skip pure presentational shells. Priorities:
+- **`components/ErrorBoundary.tsx`** — renders fallback on a thrown child; recovers on reset.
+- **Forms** — `AgentForm`, `PromptForm`, `McpConnectionForm`, `FlowSettingsForm`,
+  `shared/step-form/StepConfigurationForm`: validation errors, controlled values, submit
+  payload shape (driven by `@mantine/form` + Zod).
+- **Tables/modals with logic** — `ExecutionsTable`, `ContextDiffModal`,
+  `StatefulRedriveModal`, `ImportModal`/`ExportModal`: filtering, row actions, diff
+  rendering, file in/out.
+- **Shell composition** — `createAllmaAdminApp` assembles routes/nav from a stub
+  `AllmaPlugin`; assert the plugin contract (routes, nav items, app wrappers, header
+  widgets) is honored. This protects the package's public API.
+
+### Phase 6 — Ratchet & guardrails (ongoing)
+- Raise coverage thresholds incrementally; fail CI on regression (mirrors `app-logic`
+  Phase 5).
+- Document conventions in `tests/README.md`.
+- Optional thin **integration** layer: a few full-page flows behind MSW (load list → open
+  detail → submit), gated/nightly — never blocking PRs on network shape.
+
+## 5. Conventions (enforced as tests are written)
+
+- **One test file per source module**, mirroring `src/` under `tests/unit/` or `tests/dom/`.
+- **ES Modules**, `.js` extension on relative imports; **kebab-case** test file names.
+- **Pure logic lives in the `unit` (node) project**; anything touching React/DOM lives in
+  the `dom` (jsdom) project. Don't pull jsdom into pure-logic tests.
+- **Zustand store**: test via `getState()` actions + `setState` reset in `beforeEach`; never
+  render a component just to exercise store logic.
+- **API**: mock the single `axiosInstance` module (or MSW for page tests) — never real
+  network. Assert the route constants from `@allma/core-types`, not hardcoded strings.
+- **Components**: always go through `renderWithProviders`; query by role/label
+  (`@testing-library` user-centric queries), drive interaction with `user-event`.
+- **Test behavior and contracts, not implementation** — props in / rendered output /
+  emitted requests, not internal call counts.
+- **No source changes to make a test pass.** Real bug → stop and report.
+
+## 6. Effort & sequencing (suggested)
+
+| Phase | Surface | Rel. effort | Why first/last |
+| --- | --- | --- | --- |
+| 0 | Tooling/scaffold | S | Unblocks everything; small delta on existing monorepo tooling. |
+| 1 | Pure utils | S | Fast wins, no mocking, immediate coverage. |
+| 2 | Zustand store | M | Highest-value client logic; still no DOM. |
+| 3 | Graph utils | M | Pure-ish; needs flow fixtures. |
+| 4 | API + hooks | M | Protects the service contract; one mock seam. |
+| 5 | Components | L | Real value but slowest; do after the cheap layers land. |
+| 6 | Ratchet/MSW | ongoing | Locks in gains; guards against regression. |
+
+Phases 0–4 are achievable as a focused first push and deliver the bulk of the value
+(client logic + API contract) before paying the component-render tax in Phase 5.

--- a/packages/admin-shell/package.json
+++ b/packages/admin-shell/package.json
@@ -20,7 +20,12 @@
     "dev:harness": "vite --config vite.harness.config.ts",
     "build": "tsup",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:unit": "vitest run --project unit",
+    "test:dom": "vitest run --project dom",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest"
   },
   "author": "@webjema",
   "license": "Apache-2.0",
@@ -81,6 +86,10 @@
   "devDependencies": {
     "@allma/core-types": "1.2.0",
     "@tanstack/react-query-devtools": "^5.75.7",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/dagre": "^0.7.53",
     "@types/file-saver": "^2.0.7",
     "@types/lodash-es": "^4.17.12",
@@ -96,9 +105,12 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.0",
+    "@vitest/coverage-v8": "^1.6.1",
+    "jsdom": "^25.0.1",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.0.0",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^1.6.1"
   }
 }

--- a/packages/admin-shell/tests/README.md
+++ b/packages/admin-shell/tests/README.md
@@ -1,0 +1,51 @@
+# `@allma/admin-shell` test conventions & guardrails
+
+Working guide for writing tests in this package. The full rationale and phase plan live in
+[`../TEST_PLAN.md`](../TEST_PLAN.md).
+
+## Layout
+
+```
+tests/
+├── _setup/                   # jsdom setup (matchMedia / ResizeObserver stubs, jest-dom matchers)
+├── _helpers/                 # fixtures + (later) render wrapper, axios mock
+│   └── fixtures/             # flow-editor node/edge/flow builders, API envelope builders
+├── unit/                     # hermetic, `node` env. Pure logic — mirrors src/ one file per module.
+└── dom/                      # `jsdom` env. React hooks + component tests.
+```
+
+Two Vitest projects ([`../vitest.workspace.ts`](../vitest.workspace.ts)):
+- **`unit`** — `node` environment, no DOM. The bulk of the suite (store, mappers, utils).
+  `npm run test:unit`.
+- **`dom`** — `jsdom` environment with the shared setup file. API hooks + components.
+  `npm run test:dom`.
+- `npm test` runs both; `npm run test:coverage` runs the gate.
+
+## Conventions
+
+- **One test file per source module**, mirroring the `src/` path under `tests/unit/` or
+  `tests/dom/`.
+- **ES Modules**, `.js` extension on relative imports (matches source and Node ESM);
+  **kebab-case**/source-matching file names.
+- **Put pure logic in the `unit` (node) project.** Only pull jsdom in (`dom` project) when a
+  test actually renders React or uses the DOM. reactflow's pure helpers (`addEdge`,
+  `applyNodeChanges`) import fine under `node`, so the flow-editor store is a `unit` test.
+- **Zustand store** (`useFlowEditorStore`): drive it through `getState().<action>(…)` and
+  assert the next state. Reset the data slice in `beforeEach` with
+  `store.setState({ flowDefinition: null, nodes: [], edges: [], isDirty: false })` — the
+  action functions are stable singletons, so never re-create the store.
+- **API layer**: mock the single `axiosInstance` module (or MSW for page tests) — never real
+  network. Assert the route constants from `@allma/core-types`, not hardcoded strings, and
+  the `AdminApiResponse` envelope unwrapping (`success` → `data`; `error` → thrown).
+- **Components**: render through the shared `renderWithProviders` (Mantine + QueryClient +
+  MemoryRouter); query by role/label and drive interaction with `@testing-library/user-event`.
+- **Test behavior and contracts, not implementation** — state out / rendered output /
+  emitted requests, not internal call counts.
+- **No source changes to make a test pass.** If a test reveals a real bug, stop and report it.
+
+## Coverage ratchet (Phase 6 guardrail)
+
+Coverage is configured once at the root ([`../vitest.config.ts`](../vitest.config.ts)) with
+`all: true`, so the **whole `src/` tree** is the denominator. `index.ts` files, `src/types/**`,
+and `src/harness/**` are excluded. Floors sit just under the current actuals and are raised as
+each phase lands — they must never regress.

--- a/packages/admin-shell/tests/_helpers/fixtures/flow-editor.ts
+++ b/packages/admin-shell/tests/_helpers/fixtures/flow-editor.ts
@@ -1,0 +1,66 @@
+import { StepType, type StepInstance } from '@allma/core-types';
+import type { AllmaStepNode, AllmaTransitionEdge } from '../../../src/features/flows/editor/types.js';
+
+/**
+ * Fixture builders for the flow-editor Zustand store tests. They produce loosely-typed
+ * objects shaped like the real entities — the store performs no Zod validation, so minimal
+ * fixtures are sufficient and keep each test readable.
+ */
+
+type FlowEditorDefinition = Parameters<
+  import('../../../src/features/flows/editor/hooks/useFlowEditorStore.js').RFState['setFlow']
+>[0];
+
+export const makeStep = (id: string, over: Partial<StepInstance> = {}): StepInstance =>
+  ({
+    stepInstanceId: id,
+    stepType: StepType.NO_OP,
+    displayName: id,
+    position: { x: 0, y: 0 },
+    ...over,
+  }) as StepInstance;
+
+export const makeNode = (
+  id: string,
+  config: StepInstance = makeStep(id),
+  over: Partial<AllmaStepNode> = {},
+): AllmaStepNode =>
+  ({
+    id,
+    position: { x: 0, y: 0 },
+    type: 'stepNode',
+    data: {
+      label: id,
+      stepType: config.stepType,
+      config,
+      isStartNode: false,
+    },
+    ...over,
+  }) as AllmaStepNode;
+
+export const makeEdge = (
+  id: string,
+  source: string,
+  target: string,
+  over: Partial<AllmaTransitionEdge> = {},
+): AllmaTransitionEdge => ({
+  id,
+  source,
+  target,
+  type: 'conditionalEdge',
+  data: { edgeType: 'default' },
+  ...over,
+});
+
+export const makeFlow = (
+  steps: Record<string, StepInstance>,
+  over: Partial<FlowEditorDefinition> = {},
+): FlowEditorDefinition =>
+  ({
+    id: 'flow-1',
+    version: 1,
+    name: 'Test Flow',
+    startStepInstanceId: Object.keys(steps)[0] ?? '',
+    steps,
+    ...over,
+  }) as FlowEditorDefinition;

--- a/packages/admin-shell/tests/_helpers/query.tsx
+++ b/packages/admin-shell/tests/_helpers/query.tsx
@@ -1,0 +1,42 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import type { ReactNode } from 'react';
+
+/**
+ * A QueryClient with retries disabled so failing queries/mutations settle on the first
+ * attempt — tests assert the error path without waiting out backoff.
+ */
+export const makeTestQueryClient = (): QueryClient =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+
+/**
+ * Wrapper for `renderHook` covering the API-layer hooks: a fresh QueryClient plus a
+ * MemoryRouter (some mutation hooks call `useNavigate`).
+ */
+export const createHookWrapper = (): ((props: { children: ReactNode }) => JSX.Element) => {
+  const client = makeTestQueryClient();
+  const HookWrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+    <QueryClientProvider client={client}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
+  HookWrapper.displayName = 'HookWrapper';
+  return HookWrapper;
+};
+
+/** Build a successful `AdminApiResponse` envelope (`{ success: true, data }`). */
+export const apiOk = <T,>(data: T): { data: { success: true; data: T } } => ({
+  data: { success: true, data },
+});
+
+/** Build a failed `AdminApiResponse` envelope (`{ success: false, error }`). */
+export const apiFail = (
+  message: string,
+): { data: { success: false; error: { message: string } } } => ({
+  data: { success: false, error: { message } },
+});

--- a/packages/admin-shell/tests/_helpers/render.tsx
+++ b/packages/admin-shell/tests/_helpers/render.tsx
@@ -1,0 +1,24 @@
+import { render, type RenderOptions, type RenderResult } from '@testing-library/react';
+import { MantineProvider } from '@mantine/core';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import type { ReactElement, ReactNode } from 'react';
+import { makeTestQueryClient } from './query.js';
+
+/**
+ * Renders a component inside the providers the admin shell relies on: Mantine (theme +
+ * portals), React Query, and a router. Use for component tests; service/hook tests should
+ * use the lighter `createHookWrapper`.
+ */
+export const renderWithProviders = (ui: ReactElement, options?: RenderOptions): RenderResult => {
+  const client = makeTestQueryClient();
+  const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+    <MantineProvider>
+      <QueryClientProvider client={client}>
+        <MemoryRouter>{children}</MemoryRouter>
+      </QueryClientProvider>
+    </MantineProvider>
+  );
+  Wrapper.displayName = 'TestProviders';
+  return render(ui, { wrapper: Wrapper, ...options });
+};

--- a/packages/admin-shell/tests/_setup/jsdom.setup.ts
+++ b/packages/admin-shell/tests/_setup/jsdom.setup.ts
@@ -1,5 +1,12 @@
 import '@testing-library/jest-dom/vitest';
-import { vi } from 'vitest';
+import { afterEach, vi } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+// Without `globals: true` Testing Library's automatic afterEach cleanup is never registered,
+// so mounted trees leak across tests. Register it once here for every dom-project spec.
+afterEach(() => {
+  cleanup();
+});
 
 /**
  * jsdom lacks a few browser APIs that Mantine and reactflow touch on mount. Stub them so

--- a/packages/admin-shell/tests/_setup/jsdom.setup.ts
+++ b/packages/admin-shell/tests/_setup/jsdom.setup.ts
@@ -1,0 +1,30 @@
+import '@testing-library/jest-dom/vitest';
+import { vi } from 'vitest';
+
+/**
+ * jsdom lacks a few browser APIs that Mantine and reactflow touch on mount. Stub them so
+ * component tests don't explode on render. Kept minimal — add only what a real test needs.
+ */
+
+// Mantine reads matchMedia for color-scheme / responsive hooks.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }),
+});
+
+// reactflow / Mantine ScrollArea observe element size.
+class ResizeObserverStub {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+window.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver;

--- a/packages/admin-shell/tests/dom/_smoke.test.tsx
+++ b/packages/admin-shell/tests/dom/_smoke.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Phase 0 smoke test: proves the `dom` project boots — jsdom environment, the setup file
+ * (matchMedia / ResizeObserver stubs), React 19 render, and jest-dom matchers all wire up.
+ * Real component tests land in Phase 5; this just guards the harness itself.
+ */
+describe('dom test harness', () => {
+  it('renders a React element into jsdom', () => {
+    render(<button type="button">click me</button>);
+    expect(screen.getByRole('button', { name: 'click me' })).toBeInTheDocument();
+  });
+
+  it('exposes the browser API stubs from the setup file', () => {
+    expect(window.matchMedia('(min-width: 0px)').matches).toBe(false);
+    expect(typeof window.ResizeObserver).toBe('function');
+  });
+});

--- a/packages/admin-shell/tests/dom/api/agentService.test.tsx
+++ b/packages/admin-shell/tests/dom/api/agentService.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { ALLMA_ADMIN_API_VERSION, ALLMA_ADMIN_API_ROUTES } from '@allma/core-types';
+
+// The real axiosInstance throws at import time without VITE_API_BASE_URL and pulls in
+// Amplify auth — replace the whole module with a method stub. This is the one API seam.
+vi.mock('../../../src/api/axiosInstance.js', () => ({
+  default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('@mantine/notifications', () => ({ notifications: { show: vi.fn() } }));
+
+import axiosInstance from '../../../src/api/axiosInstance.js';
+import { notifications } from '@mantine/notifications';
+import {
+  useGetAgents,
+  useGetAgent,
+  useCreateAgent,
+  useUpdateAgent,
+  useDeleteAgent,
+} from '../../../src/api/agentService.js';
+import { createHookWrapper, apiOk, apiFail } from '../../_helpers/query.js';
+
+const mockGet = vi.mocked(axiosInstance.get);
+const mockPost = vi.mocked(axiosInstance.post);
+const mockPut = vi.mocked(axiosInstance.put);
+const mockDelete = vi.mocked(axiosInstance.delete);
+const mockNotify = vi.mocked(notifications.show);
+
+const V = ALLMA_ADMIN_API_VERSION;
+const R = ALLMA_ADMIN_API_ROUTES;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useGetAgents', () => {
+  it('requests the versioned agents route and unwraps the envelope', async () => {
+    mockGet.mockResolvedValue(apiOk([{ id: 'a1' }]));
+
+    const { result } = renderHook(() => useGetAgents(), { wrapper: createHookWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([{ id: 'a1' }]);
+    expect(mockGet).toHaveBeenCalledWith(`/${V}${R.AGENTS}`);
+  });
+
+  it('surfaces the server error message on failure', async () => {
+    mockGet.mockResolvedValue(apiFail('boom'));
+
+    const { result } = renderHook(() => useGetAgents(), { wrapper: createHookWrapper() });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('boom');
+  });
+});
+
+describe('useGetAgent', () => {
+  it('stays idle while the agentId is undefined (disabled query)', () => {
+    const { result } = renderHook(() => useGetAgent(undefined), {
+      wrapper: createHookWrapper(),
+    });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('requests the detail route once an agentId is supplied', async () => {
+    mockGet.mockResolvedValue(apiOk({ id: 'a1', name: 'Agent One' }));
+
+    const { result } = renderHook(() => useGetAgent('a1'), { wrapper: createHookWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGet).toHaveBeenCalledWith(`/${V}${R.AGENT_DETAIL('a1')}`);
+  });
+});
+
+describe('useCreateAgent', () => {
+  it('posts the new agent and notifies on success', async () => {
+    mockPost.mockResolvedValue(apiOk({ id: 'a1', name: 'New' }));
+
+    const { result } = renderHook(() => useCreateAgent(), { wrapper: createHookWrapper() });
+    result.current.mutate({ name: 'New' } as never);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockPost).toHaveBeenCalledWith(`/${V}${R.AGENTS}`, { name: 'New' });
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Agent Created', color: 'green' }),
+    );
+  });
+
+  it('shows an error notification when creation fails', async () => {
+    mockPost.mockResolvedValue(apiFail('duplicate'));
+
+    const { result } = renderHook(() => useCreateAgent(), { wrapper: createHookWrapper() });
+    result.current.mutate({ name: 'dupe' } as never);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Creation Failed', color: 'red' }),
+    );
+  });
+});
+
+describe('useUpdateAgent', () => {
+  it('puts to the detail route and notifies on success', async () => {
+    mockPut.mockResolvedValue(apiOk({ id: 'a1', name: 'Renamed' }));
+
+    const { result } = renderHook(() => useUpdateAgent(), { wrapper: createHookWrapper() });
+    result.current.mutate({ agentId: 'a1', data: { name: 'Renamed' } } as never);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockPut).toHaveBeenCalledWith(`/${V}${R.AGENT_DETAIL('a1')}`, { name: 'Renamed' });
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Agent Updated', color: 'blue' }),
+    );
+  });
+});
+
+describe('useDeleteAgent', () => {
+  it('deletes the detail route and notifies on success', async () => {
+    mockDelete.mockResolvedValue(apiOk(undefined));
+
+    const { result } = renderHook(() => useDeleteAgent(), { wrapper: createHookWrapper() });
+    result.current.mutate('a1');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockDelete).toHaveBeenCalledWith(`/${V}${R.AGENT_DETAIL('a1')}`);
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Agent Deleted', color: 'orange' }),
+    );
+  });
+
+  it('throws and notifies when the envelope reports failure', async () => {
+    mockDelete.mockResolvedValue(apiFail('in use'));
+
+    const { result } = renderHook(() => useDeleteAgent(), { wrapper: createHookWrapper() });
+    result.current.mutate('a1');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Deletion Failed', color: 'red' }),
+    );
+  });
+});

--- a/packages/admin-shell/tests/dom/api/dashboardService.test.tsx
+++ b/packages/admin-shell/tests/dom/api/dashboardService.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { ALLMA_ADMIN_API_VERSION, ALLMA_ADMIN_API_ROUTES } from '@allma/core-types';
+
+vi.mock('../../../src/api/axiosInstance.js', () => ({
+  default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+}));
+
+import axiosInstance from '../../../src/api/axiosInstance.js';
+import { useGetDashboardStats } from '../../../src/api/dashboardService.js';
+import { createHookWrapper, apiOk, apiFail } from '../../_helpers/query.js';
+
+const mockGet = vi.mocked(axiosInstance.get);
+
+const V = ALLMA_ADMIN_API_VERSION;
+const R = ALLMA_ADMIN_API_ROUTES;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useGetDashboardStats', () => {
+  it('requests the dashboard stats route and unwraps the envelope', async () => {
+    mockGet.mockResolvedValue(apiOk({ totalFlows: 3 }));
+
+    const { result } = renderHook(() => useGetDashboardStats(), {
+      wrapper: createHookWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ totalFlows: 3 });
+    expect(mockGet).toHaveBeenCalledWith(`/${V}${R.DASHBOARD_STATS}`);
+  });
+
+  it('surfaces the server error message on failure', async () => {
+    mockGet.mockResolvedValue(apiFail('stats down'));
+
+    const { result } = renderHook(() => useGetDashboardStats(), {
+      wrapper: createHookWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('stats down');
+  });
+});

--- a/packages/admin-shell/tests/dom/api/executionService.test.tsx
+++ b/packages/admin-shell/tests/dom/api/executionService.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { ALLMA_ADMIN_API_VERSION, ALLMA_ADMIN_API_ROUTES } from '@allma/core-types';
+
+vi.mock('../../../src/api/axiosInstance.js', () => ({
+  default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+}));
+
+import axiosInstance from '../../../src/api/axiosInstance.js';
+import {
+  useGetFlowExecutions,
+  useGetExecutionDetail,
+  useGetBranchSteps,
+} from '../../../src/api/executionService.js';
+import { createHookWrapper, apiOk, apiFail } from '../../_helpers/query.js';
+
+const mockGet = vi.mocked(axiosInstance.get);
+const V = ALLMA_ADMIN_API_VERSION;
+const R = ALLMA_ADMIN_API_ROUTES;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useGetFlowExecutions', () => {
+  it('stays idle until a flowId is provided', () => {
+    const { result } = renderHook(() => useGetFlowExecutions({ flowId: '' }), {
+      wrapper: createHookWrapper(),
+    });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('builds the execution-list query string from the optional filters', async () => {
+    mockGet.mockResolvedValue(apiOk({ items: [], nextToken: null }));
+
+    const { result } = renderHook(
+      () => useGetFlowExecutions({ flowId: 'f1', flowVersion: 2, status: 'FAILED', limit: 10 }),
+      { wrapper: createHookWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGet).toHaveBeenCalledWith(
+      `/${V}${R.FLOW_EXECUTIONS}?flowDefinitionId=f1&flowVersion=2&status=FAILED&limit=10`,
+    );
+  });
+});
+
+describe('useGetExecutionDetail', () => {
+  it('requests the detail route and unwraps the payload', async () => {
+    mockGet.mockResolvedValue(apiOk({ flowExecutionId: 'ex1' }));
+
+    const { result } = renderHook(() => useGetExecutionDetail('ex1'), {
+      wrapper: createHookWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ flowExecutionId: 'ex1' });
+    expect(mockGet).toHaveBeenCalledWith(`/${V}${R.FLOW_EXECUTION_DETAIL('ex1')}`);
+  });
+
+  it('propagates the server error message', async () => {
+    mockGet.mockResolvedValue(apiFail('not found'));
+
+    const { result } = renderHook(() => useGetExecutionDetail('missing'), {
+      wrapper: createHookWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('not found');
+  });
+});
+
+describe('useGetBranchSteps', () => {
+  it('is disabled until every required parameter is present', () => {
+    const { result } = renderHook(
+      () =>
+        useGetBranchSteps(
+          { flowExecutionId: 'ex1', parentStepInstanceId: '', parentStepStartTime: '' },
+          true,
+        ),
+      { wrapper: createHookWrapper() },
+    );
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('applies default limit/offset in the query string when omitted', async () => {
+    mockGet.mockResolvedValue(apiOk({ steps: [] }));
+
+    const { result } = renderHook(
+      () =>
+        useGetBranchSteps(
+          { flowExecutionId: 'ex1', parentStepInstanceId: 'fork1', parentStepStartTime: '2020-01-01' },
+          true,
+        ),
+      { wrapper: createHookWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGet).toHaveBeenCalledWith(
+      `/${V}${R.FLOW_EXECUTION_BRANCH_STEPS('ex1')}?parentStepInstanceId=fork1&parentStepStartTime=2020-01-01&limit=30&offset=0`,
+    );
+  });
+});

--- a/packages/admin-shell/tests/dom/api/flowControlService.test.tsx
+++ b/packages/admin-shell/tests/dom/api/flowControlService.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { ALLMA_ADMIN_API_VERSION, ALLMA_ADMIN_API_ROUTES } from '@allma/core-types';
+
+vi.mock('../../../src/api/axiosInstance.js', () => ({
+  default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('@mantine/notifications', () => ({ notifications: { show: vi.fn() } }));
+
+// useStatefulRedrive navigates to the new execution on success — assert on the mock.
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+import axiosInstance from '../../../src/api/axiosInstance.js';
+import { notifications } from '@mantine/notifications';
+import { useStatefulRedrive, useSandboxStep } from '../../../src/api/flowControlService.js';
+import { createHookWrapper, apiOk, apiFail } from '../../_helpers/query.js';
+
+const mockPost = vi.mocked(axiosInstance.post);
+const mockNotify = vi.mocked(notifications.show);
+
+const V = ALLMA_ADMIN_API_VERSION;
+const R = ALLMA_ADMIN_API_ROUTES;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useStatefulRedrive', () => {
+  it('posts to the redrive route, notifies, and navigates to the new execution', async () => {
+    mockPost.mockResolvedValue(apiOk({ newFlowExecutionId: 'ex2' }));
+
+    const { result } = renderHook(() => useStatefulRedrive(), {
+      wrapper: createHookWrapper(),
+    });
+    result.current.mutate({ executionId: 'ex1', data: { stepId: 's3' } } as never);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockPost).toHaveBeenCalledWith(
+      `/${V}${R.FLOW_EXECUTION_STATEFUL_REDRIVE('ex1')}`,
+      { stepId: 's3' },
+    );
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Redrive Initiated', color: 'green' }),
+    );
+    expect(mockNavigate).toHaveBeenCalledWith('/executions/ex2');
+  });
+
+  it('notifies and does not navigate when the redrive fails', async () => {
+    mockPost.mockResolvedValue(apiFail('bad context'));
+
+    const { result } = renderHook(() => useStatefulRedrive(), {
+      wrapper: createHookWrapper(),
+    });
+    result.current.mutate({ executionId: 'ex1', data: {} } as never);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Redrive Failed', color: 'red' }),
+    );
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});
+
+describe('useSandboxStep', () => {
+  it('posts to the sandbox route and notifies on success', async () => {
+    mockPost.mockResolvedValue(apiOk({ output: {} }));
+
+    const { result } = renderHook(() => useSandboxStep(), { wrapper: createHookWrapper() });
+    result.current.mutate({ stepInstance: {}, mockContext: {} } as never);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockPost).toHaveBeenCalledWith(`/${V}${R.FLOW_SANDBOX_STEP}`, {
+      stepInstance: {},
+      mockContext: {},
+    });
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Sandbox Run Successful', color: 'green' }),
+    );
+  });
+
+  it('notifies on a sandbox failure', async () => {
+    mockPost.mockResolvedValue(apiFail('step threw'));
+
+    const { result } = renderHook(() => useSandboxStep(), { wrapper: createHookWrapper() });
+    result.current.mutate({ stepInstance: {}, mockContext: {} } as never);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Sandbox Run Failed', color: 'red' }),
+    );
+  });
+});

--- a/packages/admin-shell/tests/dom/api/flowService.test.tsx
+++ b/packages/admin-shell/tests/dom/api/flowService.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { ALLMA_ADMIN_API_VERSION, ALLMA_ADMIN_API_ROUTES } from '@allma/core-types';
+
+// The real axiosInstance throws at import time if VITE_API_BASE_URL is unset and pulls in
+// Amplify auth — replace the whole module with a method stub. This is the one API seam.
+vi.mock('../../../src/api/axiosInstance.js', () => ({
+  default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+}));
+// Notifications need a provider to render for real; assert on the call instead.
+vi.mock('@mantine/notifications', () => ({ notifications: { show: vi.fn() } }));
+
+import axiosInstance from '../../../src/api/axiosInstance.js';
+import { notifications } from '@mantine/notifications';
+import { useGetFlows, useGetFlowConfig, useCreateFlow } from '../../../src/api/flowService.js';
+import { createHookWrapper, apiOk, apiFail } from '../../_helpers/query.js';
+
+const mockGet = vi.mocked(axiosInstance.get);
+const mockPost = vi.mocked(axiosInstance.post);
+const mockNotify = vi.mocked(notifications.show);
+
+const V = ALLMA_ADMIN_API_VERSION;
+const R = ALLMA_ADMIN_API_ROUTES;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useGetFlows', () => {
+  it('requests the versioned flows route with query params and unwraps the envelope', async () => {
+    mockGet.mockResolvedValue(apiOk([{ id: 'f1' }]));
+
+    const { result } = renderHook(() => useGetFlows({ searchText: 'abc', tag: 't1' }), {
+      wrapper: createHookWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([{ id: 'f1' }]);
+    expect(mockGet).toHaveBeenCalledWith(`/${V}${R.FLOWS}?searchText=abc&tag=t1`);
+  });
+
+  it('surfaces the server error message when the envelope reports failure', async () => {
+    mockGet.mockResolvedValue(apiFail('boom'));
+
+    const { result } = renderHook(() => useGetFlows({}), { wrapper: createHookWrapper() });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('boom');
+  });
+});
+
+describe('useGetFlowConfig', () => {
+  it('does not fire while the flowId is undefined (disabled query)', async () => {
+    const { result } = renderHook(() => useGetFlowConfig(undefined), {
+      wrapper: createHookWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('requests the detail route once a flowId is supplied', async () => {
+    mockGet.mockResolvedValue(apiOk({ id: 'f1', name: 'Flow One' }));
+
+    const { result } = renderHook(() => useGetFlowConfig('f1'), { wrapper: createHookWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGet).toHaveBeenCalledWith(`/${V}${R.FLOW_CONFIG_DETAIL('f1')}`);
+  });
+});
+
+describe('useCreateFlow', () => {
+  it('posts the new flow and shows a success notification on success', async () => {
+    mockPost.mockResolvedValue(apiOk({ id: 'f1', name: 'My Flow' }));
+
+    const { result } = renderHook(() => useCreateFlow(), { wrapper: createHookWrapper() });
+    result.current.mutate({ name: 'My Flow' } as never);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockPost).toHaveBeenCalledWith(`/${V}${R.FLOWS}`, { name: 'My Flow' });
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Flow Created', color: 'green' }),
+    );
+  });
+
+  it('shows an error notification when creation fails', async () => {
+    mockPost.mockResolvedValue(apiFail('duplicate name'));
+
+    const { result } = renderHook(() => useCreateFlow(), { wrapper: createHookWrapper() });
+    result.current.mutate({ name: 'dupe' } as never);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Creation Failed', color: 'red' }),
+    );
+  });
+});

--- a/packages/admin-shell/tests/dom/api/importExportService.test.tsx
+++ b/packages/admin-shell/tests/dom/api/importExportService.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { ALLMA_ADMIN_API_VERSION, ALLMA_ADMIN_API_ROUTES } from '@allma/core-types';
+
+vi.mock('../../../src/api/axiosInstance.js', () => ({
+  default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('@mantine/notifications', () => ({ notifications: { show: vi.fn() } }));
+// A successful export triggers a browser download — stub the saver so nothing touches the DOM.
+vi.mock('file-saver', () => ({ saveAs: vi.fn() }));
+
+import axiosInstance from '../../../src/api/axiosInstance.js';
+import { notifications } from '@mantine/notifications';
+import { saveAs } from 'file-saver';
+import { useExportMutation, useImportMutation } from '../../../src/api/importExportService.js';
+import { createHookWrapper, apiOk, apiFail } from '../../_helpers/query.js';
+
+const mockPost = vi.mocked(axiosInstance.post);
+const mockNotify = vi.mocked(notifications.show);
+const mockSaveAs = vi.mocked(saveAs);
+
+const V = ALLMA_ADMIN_API_VERSION;
+const R = ALLMA_ADMIN_API_ROUTES;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useExportMutation', () => {
+  it('posts to the export route, saves the file, and notifies on success', async () => {
+    mockPost.mockResolvedValue(apiOk({ flows: [], version: '1' }));
+
+    const { result } = renderHook(() => useExportMutation(), { wrapper: createHookWrapper() });
+    result.current.mutate({ flowIds: ['f1'] } as never);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockPost).toHaveBeenCalledWith(`/${V}${R.EXPORT}`, { flowIds: ['f1'] });
+    expect(mockSaveAs).toHaveBeenCalledTimes(1);
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Export Successful', color: 'green' }),
+    );
+  });
+
+  it('notifies and does not save when export fails', async () => {
+    mockPost.mockResolvedValue(apiFail('export error'));
+
+    const { result } = renderHook(() => useExportMutation(), { wrapper: createHookWrapper() });
+    result.current.mutate({ flowIds: [] } as never);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockSaveAs).not.toHaveBeenCalled();
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Export Failed', color: 'red' }),
+    );
+  });
+});
+
+describe('useImportMutation', () => {
+  it('posts to the import route and notifies with the created/updated counts', async () => {
+    mockPost.mockResolvedValue(
+      apiOk({
+        created: { flows: 1, steps: 2, prompts: 0, agents: 0 },
+        updated: { flows: 0, steps: 0, prompts: 0, agents: 0 },
+      }),
+    );
+
+    const { result } = renderHook(() => useImportMutation(), { wrapper: createHookWrapper() });
+    result.current.mutate({ flows: [] } as never);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockPost).toHaveBeenCalledWith(`/${V}${R.IMPORT}`, { flows: [] });
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Import Successful', color: 'green' }),
+    );
+  });
+
+  it('appends the server error details to the thrown message and notifies', async () => {
+    mockPost.mockResolvedValue({
+      data: { success: false, error: { message: 'invalid', details: { line: 4 } } },
+    });
+
+    const { result } = renderHook(() => useImportMutation(), { wrapper: createHookWrapper() });
+    result.current.mutate({ flows: [] } as never);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toContain('invalid');
+    expect(result.current.error?.message).toContain('"line":4');
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Import Failed', color: 'red' }),
+    );
+  });
+});

--- a/packages/admin-shell/tests/dom/api/mcpConnectionService.test.tsx
+++ b/packages/admin-shell/tests/dom/api/mcpConnectionService.test.tsx
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { ALLMA_ADMIN_API_VERSION, ALLMA_ADMIN_API_ROUTES } from '@allma/core-types';
+
+vi.mock('../../../src/api/axiosInstance.js', () => ({
+  default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('@mantine/notifications', () => ({ notifications: { show: vi.fn() } }));
+
+import axiosInstance from '../../../src/api/axiosInstance.js';
+import { notifications } from '@mantine/notifications';
+import {
+  useGetMcpConnections,
+  useGetMcpConnection,
+  useCreateMcpConnection,
+  useUpdateMcpConnection,
+  useDeleteMcpConnection,
+  useDiscoverTools,
+} from '../../../src/api/mcpConnectionService.js';
+import { createHookWrapper, apiOk, apiFail } from '../../_helpers/query.js';
+
+const mockGet = vi.mocked(axiosInstance.get);
+const mockPost = vi.mocked(axiosInstance.post);
+const mockPut = vi.mocked(axiosInstance.put);
+const mockDelete = vi.mocked(axiosInstance.delete);
+const mockNotify = vi.mocked(notifications.show);
+
+const V = ALLMA_ADMIN_API_VERSION;
+const R = ALLMA_ADMIN_API_ROUTES;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useGetMcpConnections', () => {
+  it('requests the versioned connections route and unwraps the envelope', async () => {
+    mockGet.mockResolvedValue(apiOk([{ id: 'm1' }]));
+
+    const { result } = renderHook(() => useGetMcpConnections(), {
+      wrapper: createHookWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([{ id: 'm1' }]);
+    expect(mockGet).toHaveBeenCalledWith(`/${V}${R.MCP_CONNECTIONS}`);
+  });
+
+  it('surfaces the server error message on failure', async () => {
+    mockGet.mockResolvedValue(apiFail('boom'));
+
+    const { result } = renderHook(() => useGetMcpConnections(), {
+      wrapper: createHookWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('boom');
+  });
+});
+
+describe('useGetMcpConnection', () => {
+  it('stays idle while the id is undefined (disabled query)', () => {
+    const { result } = renderHook(() => useGetMcpConnection(undefined), {
+      wrapper: createHookWrapper(),
+    });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('requests the detail route once an id is supplied', async () => {
+    mockGet.mockResolvedValue(apiOk({ id: 'm1' }));
+
+    const { result } = renderHook(() => useGetMcpConnection('m1'), {
+      wrapper: createHookWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGet).toHaveBeenCalledWith(`/${V}${R.MCP_CONNECTION_DETAIL('m1')}`);
+  });
+});
+
+describe('useCreateMcpConnection', () => {
+  it('posts the new connection and notifies on success', async () => {
+    mockPost.mockResolvedValue(apiOk({ id: 'm1' }));
+
+    const { result } = renderHook(() => useCreateMcpConnection(), {
+      wrapper: createHookWrapper(),
+    });
+    result.current.mutate({ name: 'conn' } as never);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockPost).toHaveBeenCalledWith(`/${V}${R.MCP_CONNECTIONS}`, { name: 'conn' });
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Success', color: 'green' }),
+    );
+  });
+
+  it('shows an error notification when creation fails', async () => {
+    mockPost.mockResolvedValue(apiFail('nope'));
+
+    const { result } = renderHook(() => useCreateMcpConnection(), {
+      wrapper: createHookWrapper(),
+    });
+    result.current.mutate({ name: 'conn' } as never);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Creation Failed', color: 'red' }),
+    );
+  });
+});
+
+describe('useUpdateMcpConnection', () => {
+  it('puts to the detail route and notifies on success', async () => {
+    mockPut.mockResolvedValue(apiOk({ id: 'm1' }));
+
+    const { result } = renderHook(() => useUpdateMcpConnection(), {
+      wrapper: createHookWrapper(),
+    });
+    result.current.mutate({ id: 'm1', data: { name: 'updated' } } as never);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockPut).toHaveBeenCalledWith(`/${V}${R.MCP_CONNECTION_DETAIL('m1')}`, {
+      name: 'updated',
+    });
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Success', color: 'green' }),
+    );
+  });
+});
+
+describe('useDeleteMcpConnection', () => {
+  it('deletes the detail route and notifies on success', async () => {
+    mockDelete.mockResolvedValue(apiOk(undefined));
+
+    const { result } = renderHook(() => useDeleteMcpConnection(), {
+      wrapper: createHookWrapper(),
+    });
+    result.current.mutate('m1');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockDelete).toHaveBeenCalledWith(`/${V}${R.MCP_CONNECTION_DETAIL('m1')}`);
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Success', color: 'green' }),
+    );
+  });
+
+  it('throws and notifies when the envelope reports failure', async () => {
+    mockDelete.mockResolvedValue(apiFail('busy'));
+
+    const { result } = renderHook(() => useDeleteMcpConnection(), {
+      wrapper: createHookWrapper(),
+    });
+    result.current.mutate('m1');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Deletion Failed', color: 'red' }),
+    );
+  });
+});
+
+describe('useDiscoverTools', () => {
+  it('posts to the discover route and returns the tool list', async () => {
+    mockPost.mockResolvedValue(apiOk([{ name: 'tool-a' }]));
+
+    const { result } = renderHook(() => useDiscoverTools(), { wrapper: createHookWrapper() });
+    result.current.mutate('m1');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([{ name: 'tool-a' }]);
+    expect(mockPost).toHaveBeenCalledWith(`/${V}${R.MCP_CONNECTION_DISCOVER('m1')}`);
+  });
+
+  it('notifies on a discovery failure', async () => {
+    mockPost.mockResolvedValue(apiFail('unreachable'));
+
+    const { result } = renderHook(() => useDiscoverTools(), { wrapper: createHookWrapper() });
+    result.current.mutate('m1');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Discovery Failed', color: 'red' }),
+    );
+  });
+});

--- a/packages/admin-shell/tests/dom/api/promptTemplateService.test.tsx
+++ b/packages/admin-shell/tests/dom/api/promptTemplateService.test.tsx
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { ALLMA_ADMIN_API_VERSION, ALLMA_ADMIN_API_ROUTES } from '@allma/core-types';
+
+vi.mock('../../../src/api/axiosInstance.js', () => ({
+  default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('@mantine/notifications', () => ({ notifications: { show: vi.fn() } }));
+
+import axiosInstance from '../../../src/api/axiosInstance.js';
+import { notifications } from '@mantine/notifications';
+import {
+  useGetPrompts,
+  useListPromptVersions,
+  useGetPromptByVersion,
+  useCreatePrompt,
+  useClonePrompt,
+  useCreatePromptVersion,
+  useUpdatePromptVersion,
+  usePublishPromptVersion,
+  useUnpublishPromptVersion,
+  useDeletePromptVersion,
+} from '../../../src/api/promptTemplateService.js';
+import { createHookWrapper, apiOk, apiFail } from '../../_helpers/query.js';
+
+const mockGet = vi.mocked(axiosInstance.get);
+const mockPost = vi.mocked(axiosInstance.post);
+const mockPut = vi.mocked(axiosInstance.put);
+const mockDelete = vi.mocked(axiosInstance.delete);
+const mockNotify = vi.mocked(notifications.show);
+
+// These services build routes WITHOUT a leading slash (`${V}${R...}`), unlike the others.
+const V = ALLMA_ADMIN_API_VERSION;
+const R = ALLMA_ADMIN_API_ROUTES;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useGetPrompts', () => {
+  it('requests the prompt-templates route and unwraps the envelope', async () => {
+    mockGet.mockResolvedValue(apiOk([{ id: 'p1' }]));
+
+    const { result } = renderHook(() => useGetPrompts(), { wrapper: createHookWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([{ id: 'p1' }]);
+    expect(mockGet).toHaveBeenCalledWith(`${V}${R.PROMPT_TEMPLATES}`);
+  });
+
+  it('surfaces the server error message on failure', async () => {
+    mockGet.mockResolvedValue(apiFail('boom'));
+
+    const { result } = renderHook(() => useGetPrompts(), { wrapper: createHookWrapper() });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('boom');
+  });
+});
+
+describe('useListPromptVersions', () => {
+  it('stays idle while the promptId is undefined (disabled query)', () => {
+    const { result } = renderHook(() => useListPromptVersions(undefined), {
+      wrapper: createHookWrapper(),
+    });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('requests the versions route once a promptId is supplied', async () => {
+    mockGet.mockResolvedValue(apiOk([{ id: 'p1', version: 1 }]));
+
+    const { result } = renderHook(() => useListPromptVersions('p1'), {
+      wrapper: createHookWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGet).toHaveBeenCalledWith(`${V}${R.PROMPT_TEMPLATE_VERSIONS('p1')}`);
+  });
+});
+
+describe('useGetPromptByVersion', () => {
+  it('stays idle until both promptId and version are present (disabled query)', () => {
+    const { result } = renderHook(() => useGetPromptByVersion('p1', undefined), {
+      wrapper: createHookWrapper(),
+    });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('requests the version-detail route once both are supplied', async () => {
+    mockGet.mockResolvedValue(apiOk({ id: 'p1', version: 2 }));
+
+    const { result } = renderHook(() => useGetPromptByVersion('p1', '2'), {
+      wrapper: createHookWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGet).toHaveBeenCalledWith(`${V}${R.PROMPT_TEMPLATE_VERSION_DETAIL('p1', '2')}`);
+  });
+});
+
+describe('useCreatePrompt', () => {
+  it('posts the new prompt and notifies on success', async () => {
+    mockPost.mockResolvedValue(apiOk({ id: 'p1', name: 'New' }));
+
+    const { result } = renderHook(() => useCreatePrompt(), { wrapper: createHookWrapper() });
+    result.current.mutate({ name: 'New' } as never);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockPost).toHaveBeenCalledWith(`${V}${R.PROMPT_TEMPLATES}`, { name: 'New' });
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Prompt Created', color: 'green' }),
+    );
+  });
+
+  it('notifies on a creation failure', async () => {
+    mockPost.mockResolvedValue(apiFail('dupe'));
+
+    const { result } = renderHook(() => useCreatePrompt(), { wrapper: createHookWrapper() });
+    result.current.mutate({ name: 'dupe' } as never);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Creation Failed', color: 'red' }),
+    );
+  });
+});
+
+describe('useClonePrompt', () => {
+  it('posts to the clone route and notifies on success', async () => {
+    mockPost.mockResolvedValue(apiOk({ id: 'p2', name: 'Clone' }));
+
+    const { result } = renderHook(() => useClonePrompt(), { wrapper: createHookWrapper() });
+    result.current.mutate({ promptId: 'p1', data: { name: 'Clone' } } as never);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockPost).toHaveBeenCalledWith(`${V}${R.PROMPT_TEMPLATE_CLONE('p1')}`, {
+      name: 'Clone',
+    });
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Prompt Cloned', color: 'green' }),
+    );
+  });
+});
+
+describe('useCreatePromptVersion', () => {
+  it('posts to the versions route and notifies on success', async () => {
+    mockPost.mockResolvedValue(apiOk({ id: 'p1', name: 'P', version: 2 }));
+
+    const { result } = renderHook(() => useCreatePromptVersion(), {
+      wrapper: createHookWrapper(),
+    });
+    result.current.mutate({ promptId: 'p1', data: { body: 'x' } } as never);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockPost).toHaveBeenCalledWith(`${V}${R.PROMPT_TEMPLATE_VERSIONS('p1')}`, {
+      body: 'x',
+    });
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Version Created', color: 'green' }),
+    );
+  });
+});
+
+describe('useUpdatePromptVersion', () => {
+  it('strips id/version from the body and puts to the version-detail route', async () => {
+    mockPut.mockResolvedValue(apiOk({ id: 'p1', name: 'P', version: 2 }));
+
+    const { result } = renderHook(() => useUpdatePromptVersion(), {
+      wrapper: createHookWrapper(),
+    });
+    result.current.mutate({ id: 'p1', version: 2, body: 'updated' } as never);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockPut).toHaveBeenCalledWith(
+      `${V}${R.PROMPT_TEMPLATE_VERSION_DETAIL('p1', 2)}`,
+      { body: 'updated' },
+    );
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Draft Saved', color: 'blue' }),
+    );
+  });
+});
+
+describe('usePublishPromptVersion', () => {
+  it('posts to the publish route and notifies on success', async () => {
+    mockPost.mockResolvedValue(apiOk({ id: 'p1', name: 'P', version: 2 }));
+
+    const { result } = renderHook(() => usePublishPromptVersion(), {
+      wrapper: createHookWrapper(),
+    });
+    result.current.mutate({ promptId: 'p1', version: 2 });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockPost).toHaveBeenCalledWith(
+      `${V}${R.PROMPT_TEMPLATE_VERSION_PUBLISH('p1', 2)}`,
+    );
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Publish Successful', color: 'green' }),
+    );
+  });
+});
+
+describe('useUnpublishPromptVersion', () => {
+  it('posts to the unpublish route and notifies on success', async () => {
+    mockPost.mockResolvedValue(apiOk({ message: 'ok' }));
+
+    const { result } = renderHook(() => useUnpublishPromptVersion(), {
+      wrapper: createHookWrapper(),
+    });
+    result.current.mutate({ promptId: 'p1', version: 2 });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockPost).toHaveBeenCalledWith(
+      `${V}${R.PROMPT_TEMPLATE_VERSION_UNPUBLISH('p1', 2)}`,
+    );
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Unpublish Successful', color: 'orange' }),
+    );
+  });
+});
+
+describe('useDeletePromptVersion', () => {
+  it('deletes the version-detail route and notifies on success', async () => {
+    mockDelete.mockResolvedValue({ data: { success: true, data: undefined } });
+
+    const { result } = renderHook(() => useDeletePromptVersion(), {
+      wrapper: createHookWrapper(),
+    });
+    result.current.mutate({ promptId: 'p1', version: 2 });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockDelete).toHaveBeenCalledWith(
+      `${V}${R.PROMPT_TEMPLATE_VERSION_DETAIL('p1', 2)}`,
+    );
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Version Deleted', color: 'orange' }),
+    );
+  });
+});

--- a/packages/admin-shell/tests/dom/api/stepDefinitionService.test.tsx
+++ b/packages/admin-shell/tests/dom/api/stepDefinitionService.test.tsx
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { ALLMA_ADMIN_API_VERSION, ALLMA_ADMIN_API_ROUTES } from '@allma/core-types';
+
+vi.mock('../../../src/api/axiosInstance.js', () => ({
+  default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('@mantine/notifications', () => ({ notifications: { show: vi.fn() } }));
+
+import axiosInstance from '../../../src/api/axiosInstance.js';
+import { notifications } from '@mantine/notifications';
+import {
+  useGetStepDefinitions,
+  useGetStepDefinition,
+  useGetAvailableSteps,
+  fetchStepDefinitionById,
+  useCreateStepDefinition,
+  useUpdateStepDefinition,
+  useDeleteStepDefinition,
+} from '../../../src/api/stepDefinitionService.js';
+import { createHookWrapper, apiOk, apiFail } from '../../_helpers/query.js';
+
+const mockGet = vi.mocked(axiosInstance.get);
+const mockPost = vi.mocked(axiosInstance.post);
+const mockPut = vi.mocked(axiosInstance.put);
+const mockDelete = vi.mocked(axiosInstance.delete);
+const mockNotify = vi.mocked(notifications.show);
+
+const V = ALLMA_ADMIN_API_VERSION;
+const R = ALLMA_ADMIN_API_ROUTES;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useGetStepDefinitions', () => {
+  it('requests the user-scoped step definitions route and unwraps the envelope', async () => {
+    mockGet.mockResolvedValue(apiOk([{ id: 's1' }]));
+
+    const { result } = renderHook(() => useGetStepDefinitions(), {
+      wrapper: createHookWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([{ id: 's1' }]);
+    expect(mockGet).toHaveBeenCalledWith(`/${V}${R.STEP_DEFINITIONS}?source=user`);
+  });
+
+  it('surfaces the server error message on failure', async () => {
+    mockGet.mockResolvedValue(apiFail('boom'));
+
+    const { result } = renderHook(() => useGetStepDefinitions(), {
+      wrapper: createHookWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('boom');
+  });
+});
+
+describe('useGetAvailableSteps', () => {
+  it('requests the unscoped step definitions route', async () => {
+    mockGet.mockResolvedValue(apiOk([{ id: 's1', source: 'system' }]));
+
+    const { result } = renderHook(() => useGetAvailableSteps(), {
+      wrapper: createHookWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGet).toHaveBeenCalledWith(`/${V}${R.STEP_DEFINITIONS}`);
+  });
+});
+
+describe('useGetStepDefinition', () => {
+  it('stays idle while the id is undefined (disabled query)', () => {
+    const { result } = renderHook(() => useGetStepDefinition(undefined), {
+      wrapper: createHookWrapper(),
+    });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('requests the detail route once an id is supplied', async () => {
+    mockGet.mockResolvedValue(apiOk({ id: 's1' }));
+
+    const { result } = renderHook(() => useGetStepDefinition('s1'), {
+      wrapper: createHookWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGet).toHaveBeenCalledWith(`/${V}${R.STEP_DEFINITION_DETAIL('s1')}`);
+  });
+});
+
+describe('fetchStepDefinitionById', () => {
+  it('resolves the detail payload from the envelope', async () => {
+    mockGet.mockResolvedValue(apiOk({ id: 's1', name: 'Step One' }));
+
+    await expect(fetchStepDefinitionById('s1')).resolves.toEqual({ id: 's1', name: 'Step One' });
+    expect(mockGet).toHaveBeenCalledWith(`/${V}${R.STEP_DEFINITION_DETAIL('s1')}`);
+  });
+
+  it('throws the server error message when the envelope reports failure', async () => {
+    mockGet.mockResolvedValue(apiFail('missing'));
+
+    await expect(fetchStepDefinitionById('s1')).rejects.toThrow('missing');
+  });
+});
+
+describe('useCreateStepDefinition', () => {
+  it('posts the new definition and notifies on success', async () => {
+    mockPost.mockResolvedValue(apiOk({ id: 's1', name: 'New' }));
+
+    const { result } = renderHook(() => useCreateStepDefinition(), {
+      wrapper: createHookWrapper(),
+    });
+    result.current.mutate({ name: 'New' } as never);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockPost).toHaveBeenCalledWith(`/${V}${R.STEP_DEFINITIONS}`, { name: 'New' });
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Step Definition Created', color: 'green' }),
+    );
+  });
+
+  it('shows an error notification when creation fails', async () => {
+    mockPost.mockResolvedValue(apiFail('dupe'));
+
+    const { result } = renderHook(() => useCreateStepDefinition(), {
+      wrapper: createHookWrapper(),
+    });
+    result.current.mutate({ name: 'dupe' } as never);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Creation Failed', color: 'red' }),
+    );
+  });
+});
+
+describe('useUpdateStepDefinition', () => {
+  it('puts to the detail route and notifies on success', async () => {
+    mockPut.mockResolvedValue(apiOk({ id: 's1', name: 'Renamed' }));
+
+    const { result } = renderHook(() => useUpdateStepDefinition(), {
+      wrapper: createHookWrapper(),
+    });
+    result.current.mutate({ id: 's1', data: { name: 'Renamed' } } as never);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockPut).toHaveBeenCalledWith(`/${V}${R.STEP_DEFINITION_DETAIL('s1')}`, {
+      name: 'Renamed',
+    });
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Save Successful', color: 'blue' }),
+    );
+  });
+});
+
+describe('useDeleteStepDefinition', () => {
+  it('deletes the detail route and notifies on success', async () => {
+    mockDelete.mockResolvedValue(apiOk(undefined));
+
+    const { result } = renderHook(() => useDeleteStepDefinition(), {
+      wrapper: createHookWrapper(),
+    });
+    result.current.mutate('s1');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockDelete).toHaveBeenCalledWith(`/${V}${R.STEP_DEFINITION_DETAIL('s1')}`);
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Deleted', color: 'orange' }),
+    );
+  });
+});

--- a/packages/admin-shell/tests/dom/api/systemToolsService.test.tsx
+++ b/packages/admin-shell/tests/dom/api/systemToolsService.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { ALLMA_ADMIN_API_VERSION, ALLMA_ADMIN_API_ROUTES } from '@allma/core-types';
+
+vi.mock('../../../src/api/axiosInstance.js', () => ({
+  default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('@mantine/notifications', () => ({ notifications: { show: vi.fn() } }));
+
+import axiosInstance from '../../../src/api/axiosInstance.js';
+import { notifications } from '@mantine/notifications';
+import { useResolveS3Pointer } from '../../../src/api/systemToolsService.js';
+import { createHookWrapper, apiOk, apiFail } from '../../_helpers/query.js';
+
+const mockPost = vi.mocked(axiosInstance.post);
+const mockNotify = vi.mocked(notifications.show);
+
+const V = ALLMA_ADMIN_API_VERSION;
+const R = ALLMA_ADMIN_API_ROUTES;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useResolveS3Pointer', () => {
+  it('posts the pointer wrapped in a body and returns the resolved payload', async () => {
+    mockPost.mockResolvedValue(apiOk({ hydrated: true }));
+    const pointer = { bucket: 'b', key: 'k' };
+
+    const { result } = renderHook(() => useResolveS3Pointer(), {
+      wrapper: createHookWrapper(),
+    });
+    result.current.mutate(pointer as never);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ hydrated: true });
+    expect(mockPost).toHaveBeenCalledWith(`/${V}${R.SYSTEM_TOOLS_RESOLVE_S3}`, { pointer });
+  });
+
+  it('notifies on a resolution failure', async () => {
+    mockPost.mockResolvedValue(apiFail('no such key'));
+
+    const { result } = renderHook(() => useResolveS3Pointer(), {
+      wrapper: createHookWrapper(),
+    });
+    result.current.mutate({ bucket: 'b', key: 'k' } as never);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Resolution Failed', color: 'red' }),
+    );
+  });
+});

--- a/packages/admin-shell/tests/dom/components/ErrorBoundary.test.tsx
+++ b/packages/admin-shell/tests/dom/components/ErrorBoundary.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { ErrorBoundary } from '../../../src/components/ErrorBoundary.js';
+import { renderWithProviders } from '../../_helpers/render.js';
+
+const Boom = (): never => {
+  throw new Error('kaboom');
+};
+
+beforeEach(() => {
+  // The boundary logs the caught error via componentDidCatch; silence the expected noise.
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ErrorBoundary', () => {
+  it('renders its children when nothing throws', () => {
+    renderWithProviders(
+      <ErrorBoundary>
+        <div>healthy content</div>
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('healthy content')).toBeInTheDocument();
+  });
+
+  it('renders the fallback (with the error message) when a child throws', () => {
+    renderWithProviders(
+      <ErrorBoundary>
+        <Boom />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('Oops! Something went wrong.')).toBeInTheDocument();
+    expect(screen.getByText('kaboom')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Reload Page' })).toBeInTheDocument();
+  });
+});

--- a/packages/admin-shell/tests/dom/createAllmaAdminApp.test.tsx
+++ b/packages/admin-shell/tests/dom/createAllmaAdminApp.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import type { AllmaPlugin } from '../../src/types/plugin.js';
+
+// createAllmaAdminApp wires in auth + the whole authenticated app. Mock those boundaries so
+// the test exercises only what this module owns: AppWrapper composition and forwarding the
+// plugin list to the app. The real plugin consumption (routes/nav/header) lives in
+// AuthenticatedApp, which is stubbed here to echo back the plugins it received.
+vi.mock('aws-amplify', () => ({ Amplify: { configure: vi.fn() } }));
+vi.mock('@aws-amplify/ui-react', () => ({
+  Authenticator: { Provider: ({ children }: { children: React.ReactNode }) => children },
+}));
+vi.mock('@tanstack/react-query-devtools', () => ({ ReactQueryDevtools: () => null }));
+vi.mock('../../src/AuthenticatedApp.js', () => ({
+  AuthenticatedApp: ({ plugins }: { plugins: AllmaPlugin[] }) => (
+    <div data-testid="authenticated-app">{plugins.map((p) => p.id).join(',')}</div>
+  ),
+}));
+
+import { createAllmaAdminApp } from '../../src/createAllmaAdminApp.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.runtimeConfig = {
+    VITE_ADMIN_STAGE_NAME: 'test',
+    VITE_AWS_REGION: 'us-east-1',
+    VITE_COGNITO_USER_POOL_ID: 'pool',
+    VITE_COGNITO_USER_POOL_CLIENT_ID: 'client',
+    VITE_API_BASE_URL: 'https://api.test',
+  };
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('createAllmaAdminApp', () => {
+  it('throws a clear error when the root element is missing', () => {
+    expect(() => createAllmaAdminApp({ plugins: [] })).toThrow(/root element/i);
+  });
+
+  it('forwards the full plugin list to the authenticated app', async () => {
+    const root = document.createElement('div');
+    root.id = 'root';
+    document.body.appendChild(root);
+
+    const plugins: AllmaPlugin[] = [
+      { id: 'plugin.a', name: 'A' },
+      { id: 'plugin.b', name: 'B' },
+    ];
+
+    createAllmaAdminApp({ plugins });
+
+    const app = await screen.findByTestId('authenticated-app');
+    expect(app).toHaveTextContent('plugin.a,plugin.b');
+  });
+
+  it('composes plugin AppWrappers around the app (first plugin outermost)', async () => {
+    const root = document.createElement('div');
+    root.id = 'root';
+    document.body.appendChild(root);
+
+    const Outer = ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="outer">{children}</div>
+    );
+    const Inner = ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="inner">{children}</div>
+    );
+
+    const plugins: AllmaPlugin[] = [
+      { id: 'plugin.outer', name: 'Outer', AppWrapper: Outer },
+      { id: 'plugin.inner', name: 'Inner', AppWrapper: Inner },
+    ];
+
+    createAllmaAdminApp({ plugins });
+
+    await waitFor(() => expect(screen.getByTestId('authenticated-app')).toBeInTheDocument());
+    // reduceRight composes so the first plugin's wrapper is the outermost ancestor.
+    const outer = screen.getByTestId('outer');
+    const inner = screen.getByTestId('inner');
+    expect(outer).toContainElement(inner);
+    expect(inner).toContainElement(screen.getByTestId('authenticated-app'));
+  });
+});

--- a/packages/admin-shell/tests/dom/features/agents/AgentForm.test.tsx
+++ b/packages/admin-shell/tests/dom/features/agents/AgentForm.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useForm, zodResolver } from '@mantine/form';
+import { CreateAgentInputSchema, type CreateAgentInput } from '@allma/core-types';
+
+// AgentForm calls useGetFlows to populate the MultiSelect — keep the axios seam mocked so
+// the component mounts without hitting the network.
+vi.mock('../../../../src/api/axiosInstance.js', () => ({
+  default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+}));
+
+import axiosInstance from '../../../../src/api/axiosInstance.js';
+import { AgentForm } from '../../../../src/features/agents/components/AgentForm.js';
+import { renderWithProviders } from '../../../_helpers/render.js';
+import { apiOk } from '../../../_helpers/query.js';
+
+const mockGet = vi.mocked(axiosInstance.get);
+
+// A harness that wires AgentForm to a real @mantine/form instance with the same zod
+// validation the create page uses, so we exercise the real validation + submit contract.
+function Harness({ onSubmit }: { onSubmit: (values: CreateAgentInput) => void }): JSX.Element {
+  const form = useForm<CreateAgentInput>({
+    initialValues: { name: '', description: '', enabled: true, flowIds: [], flowVariables: {} },
+    validate: zodResolver(CreateAgentInputSchema),
+  });
+  return <AgentForm form={form} onSubmit={onSubmit} onCancel={() => {}} isSubmitting={false} />;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGet.mockResolvedValue(apiOk([{ id: 'f1', name: 'Flow One' }]));
+});
+
+describe('AgentForm', () => {
+  it('reflects typed values in the controlled name field', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Harness onSubmit={vi.fn()} />);
+
+    const name = await screen.findByLabelText(/Agent Name/i);
+    await user.type(name, 'Support Bot');
+    expect(name).toHaveValue('Support Bot');
+  });
+
+  it('blocks submit and shows a validation error when the name is empty', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWithProviders(<Harness onSubmit={onSubmit} />);
+
+    await user.click(await screen.findByRole('button', { name: /Save Agent/i }));
+
+    expect(await screen.findByText(/Agent name is required/i)).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('submits the form values once the required name is provided', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWithProviders(<Harness onSubmit={onSubmit} />);
+
+    await user.type(await screen.findByLabelText(/Agent Name/i), 'Support Bot');
+    await user.click(screen.getByRole('button', { name: /Save Agent/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0][0]).toMatchObject({ name: 'Support Bot', enabled: true });
+  });
+});

--- a/packages/admin-shell/tests/dom/features/executions/ContextDiffModal.test.tsx
+++ b/packages/admin-shell/tests/dom/features/executions/ContextDiffModal.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { ContextDiffModal } from '../../../../src/features/executions/components/ContextDiffModal.js';
+import { renderWithProviders } from '../../../_helpers/render.js';
+
+describe('ContextDiffModal', () => {
+  it('renders nothing visible while closed', () => {
+    renderWithProviders(
+      <ContextDiffModal
+        opened={false}
+        onClose={() => {}}
+        leftContext={{ a: 1 }}
+        rightContext={{ a: 2 }}
+        title="Context Diff"
+      />,
+    );
+    expect(screen.queryByText('Context Diff')).not.toBeInTheDocument();
+  });
+
+  it('renders the modal title and the default before/after column headers when open', () => {
+    renderWithProviders(
+      <ContextDiffModal
+        opened
+        onClose={() => {}}
+        leftContext={{ status: 'before-value' }}
+        rightContext={{ status: 'after-value' }}
+        title="Context Diff"
+      />,
+    );
+
+    expect(screen.getByText('Context Diff')).toBeInTheDocument();
+    // The diff viewer mounts with the default column titles when none are supplied.
+    expect(screen.getByText('Step Input Context (Before)')).toBeInTheDocument();
+    expect(screen.getByText('Final Context After Step (After)')).toBeInTheDocument();
+  });
+
+  it('uses the provided left/right column titles', () => {
+    renderWithProviders(
+      <ContextDiffModal
+        opened
+        onClose={() => {}}
+        leftContext={{}}
+        rightContext={{}}
+        title="Context Diff"
+        leftTitle="Input"
+        rightTitle="Output"
+      />,
+    );
+
+    expect(screen.getByText('Input')).toBeInTheDocument();
+    expect(screen.getByText('Output')).toBeInTheDocument();
+  });
+});

--- a/packages/admin-shell/tests/dom/features/executions/ExecutionsTable.test.tsx
+++ b/packages/admin-shell/tests/dom/features/executions/ExecutionsTable.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import type { FlowExecutionSummary } from '@allma/core-types';
+
+// useFlowRedrive (used for the row redrive action) lives behind the axios seam.
+vi.mock('../../../../src/api/axiosInstance.js', () => ({
+  default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+}));
+
+import { ExecutionsTable } from '../../../../src/features/executions/components/ExecutionsTable.js';
+import { renderWithProviders } from '../../../_helpers/render.js';
+
+const makeExec = (over: Partial<FlowExecutionSummary> = {}): FlowExecutionSummary =>
+  ({
+    flowExecutionId: 'exec-1',
+    flowDefinitionId: 'flow-1',
+    flowDefinitionVersion: 3,
+    status: 'SUCCEEDED',
+    startTime: '2024-01-01T00:00:00.000Z',
+    endTime: '2024-01-01T00:00:05.000Z',
+    ...over,
+  }) as FlowExecutionSummary;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ExecutionsTable', () => {
+  it('shows the empty-state message when there are no executions', () => {
+    renderWithProviders(
+      <ExecutionsTable executions={[]} isLoading={false} isRefetching={false} flowId="flow-1" />,
+    );
+    expect(screen.getByText(/No executions found/i)).toBeInTheDocument();
+  });
+
+  it('renders an error alert when an error is supplied', () => {
+    renderWithProviders(
+      <ExecutionsTable
+        executions={[]}
+        isLoading={false}
+        isRefetching={false}
+        flowId="flow-1"
+        error={new Error('network down')}
+      />,
+    );
+    expect(screen.getByText(/Could not load executions: network down/i)).toBeInTheDocument();
+  });
+
+  it('renders a row per execution with its id, version badge, and status', () => {
+    const executions = [
+      makeExec({ flowExecutionId: 'exec-1', status: 'SUCCEEDED', flowDefinitionVersion: 3 }),
+      makeExec({ flowExecutionId: 'exec-2', status: 'FAILED', flowDefinitionVersion: 4 }),
+    ];
+    renderWithProviders(
+      <ExecutionsTable
+        executions={executions}
+        isLoading={false}
+        isRefetching={false}
+        flowId="flow-1"
+      />,
+    );
+
+    expect(screen.getByText('exec-1')).toBeInTheDocument();
+    expect(screen.getByText('exec-2')).toBeInTheDocument();
+    expect(screen.getByText('SUCCEEDED')).toBeInTheDocument();
+    expect(screen.getByText('FAILED')).toBeInTheDocument();
+    expect(screen.getByText('v3')).toBeInTheDocument();
+    expect(screen.getByText('v4')).toBeInTheDocument();
+  });
+
+  it('marks in-progress executions (no end time) in the duration column', () => {
+    renderWithProviders(
+      <ExecutionsTable
+        executions={[makeExec({ endTime: undefined })]}
+        isLoading={false}
+        isRefetching={false}
+        flowId="flow-1"
+      />,
+    );
+    expect(screen.getByText('In-progress')).toBeInTheDocument();
+  });
+});

--- a/packages/admin-shell/tests/dom/features/executions/StatefulRedriveModal.test.tsx
+++ b/packages/admin-shell/tests/dom/features/executions/StatefulRedriveModal.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ALLMA_ADMIN_API_VERSION, ALLMA_ADMIN_API_ROUTES } from '@allma/core-types';
+
+vi.mock('../../../../src/api/axiosInstance.js', () => ({
+  default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('@mantine/notifications', () => ({ notifications: { show: vi.fn() } }));
+// EditableJsonView is a heavy editor from ui-components; stub it so the test stays focused on
+// the modal's redrive contract.
+vi.mock('@allma/ui-components', () => ({
+  EditableJsonView: ({ value }: { value: unknown }) => (
+    <div data-testid="json-view">{JSON.stringify(value)}</div>
+  ),
+}));
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+import axiosInstance from '../../../../src/api/axiosInstance.js';
+import { StatefulRedriveModal } from '../../../../src/features/executions/components/StatefulRedriveModal.js';
+import { renderWithProviders } from '../../../_helpers/render.js';
+import { apiOk } from '../../../_helpers/query.js';
+
+const mockPost = vi.mocked(axiosInstance.post);
+const V = ALLMA_ADMIN_API_VERSION;
+const R = ALLMA_ADMIN_API_ROUTES;
+
+const step = {
+  stepInstanceId: 'step-7',
+  inputMappingContext: { user: 'alice' },
+} as never;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('StatefulRedriveModal', () => {
+  it('titles itself with the step and seeds the editor with the step input context', () => {
+    renderWithProviders(
+      <StatefulRedriveModal opened onClose={() => {}} step={step} executionId="ex-1" />,
+    );
+
+    expect(screen.getByText(/Redrive from Step: step-7/i)).toBeInTheDocument();
+    expect(screen.getByTestId('json-view')).toHaveTextContent('{"user":"alice"}');
+  });
+
+  it('posts the redrive payload built from the step and closes on success', async () => {
+    mockPost.mockResolvedValue(apiOk({ newFlowExecutionId: 'ex-2' }));
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    renderWithProviders(
+      <StatefulRedriveModal opened onClose={onClose} step={step} executionId="ex-1" />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /Confirm and Redrive/i }));
+
+    await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1));
+    expect(mockPost).toHaveBeenCalledWith(`/${V}${R.FLOW_EXECUTION_STATEFUL_REDRIVE('ex-1')}`, {
+      startFromStepInstanceId: 'step-7',
+      modifiedContextData: { user: 'alice' },
+    });
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+});

--- a/packages/admin-shell/tests/dom/features/flows/FlowSettingsForm.test.tsx
+++ b/packages/admin-shell/tests/dom/features/flows/FlowSettingsForm.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ALLMA_ADMIN_API_VERSION, ALLMA_ADMIN_API_ROUTES } from '@allma/core-types';
+import type { FlowMetadataStorageItem } from '@allma/core-types';
+
+vi.mock('../../../../src/api/axiosInstance.js', () => ({
+  default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('@mantine/notifications', () => ({ notifications: { show: vi.fn() } }));
+
+import axiosInstance from '../../../../src/api/axiosInstance.js';
+import { FlowSettingsForm } from '../../../../src/features/flows/components/FlowSettingsForm.js';
+import { renderWithProviders } from '../../../_helpers/render.js';
+import { apiOk } from '../../../_helpers/query.js';
+
+const mockGet = vi.mocked(axiosInstance.get);
+const mockPut = vi.mocked(axiosInstance.put);
+const V = ALLMA_ADMIN_API_VERSION;
+const R = ALLMA_ADMIN_API_ROUTES;
+
+const flowConfig = {
+  id: 'flow-1',
+  name: 'My Flow',
+  description: 'A flow',
+  tags: ['t1'],
+  flowVariables: {},
+} as unknown as FlowMetadataStorageItem;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // useGetAllFlowTags
+  mockGet.mockResolvedValue(apiOk(['t1', 't2']));
+});
+
+describe('FlowSettingsForm', () => {
+  it('renders an error alert when the flow config could not be loaded', () => {
+    renderWithProviders(
+      <FlowSettingsForm flowId="flow-1" flowConfig={undefined} isLoading={false} />,
+    );
+    expect(screen.getByText(/Could not load flow settings/i)).toBeInTheDocument();
+  });
+
+  it('seeds the fields from the flow config and keeps Save disabled until edited', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <FlowSettingsForm flowId="flow-1" flowConfig={flowConfig} isLoading={false} />,
+    );
+
+    expect(await screen.findByDisplayValue('My Flow')).toBeInTheDocument();
+    const save = screen.getByRole('button', { name: /Save Settings/i });
+    expect(save).toBeDisabled();
+
+    await user.type(screen.getByLabelText(/Flow Name/i), ' Updated');
+    await waitFor(() => expect(save).toBeEnabled());
+  });
+
+  it('submits the edited settings to the flow-config detail route', async () => {
+    mockPut.mockResolvedValue(apiOk({ ...flowConfig, name: 'My Flow Updated' }));
+    const user = userEvent.setup();
+    renderWithProviders(
+      <FlowSettingsForm flowId="flow-1" flowConfig={flowConfig} isLoading={false} />,
+    );
+
+    await screen.findByDisplayValue('My Flow');
+    await user.type(screen.getByLabelText(/Flow Name/i), ' Updated');
+    await user.click(screen.getByRole('button', { name: /Save Settings/i }));
+
+    await waitFor(() => expect(mockPut).toHaveBeenCalledTimes(1));
+    expect(mockPut).toHaveBeenCalledWith(
+      `/${V}${R.FLOW_CONFIG_DETAIL('flow-1')}`,
+      expect.objectContaining({ name: 'My Flow Updated' }),
+    );
+  });
+});

--- a/packages/admin-shell/tests/dom/features/mcp-connections/McpConnectionForm.test.tsx
+++ b/packages/admin-shell/tests/dom/features/mcp-connections/McpConnectionForm.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useForm, zodResolver } from '@mantine/form';
+import { CreateMcpConnectionInputSchema, type CreateMcpConnectionInput } from '@allma/core-types';
+
+import { McpConnectionForm } from '../../../../src/features/mcp-connections/components/McpConnectionForm.js';
+import { renderWithProviders } from '../../../_helpers/render.js';
+
+// Mirror the create page: a real form with the same zod validation so we exercise the real
+// validation + submit contract.
+function Harness({ onSubmit }: { onSubmit: (v: CreateMcpConnectionInput) => void }): JSX.Element {
+  const form = useForm<CreateMcpConnectionInput>({
+    initialValues: {
+      name: '',
+      serverUrl: '',
+      authentication: { type: 'NONE' },
+    } as CreateMcpConnectionInput,
+    validate: zodResolver(CreateMcpConnectionInputSchema),
+  });
+  return <McpConnectionForm form={form} onSubmit={onSubmit} onCancel={() => {}} isSubmitting={false} />;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('McpConnectionForm', () => {
+  it('reflects typed values in the controlled fields', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Harness onSubmit={vi.fn()} />);
+
+    const name = screen.getByLabelText(/Connection Name/i);
+    const url = screen.getByLabelText(/Server URL/i);
+    await user.type(name, 'Internal API');
+    await user.type(url, 'https://api.example.com');
+
+    expect(name).toHaveValue('Internal API');
+    expect(url).toHaveValue('https://api.example.com');
+  });
+
+  it('reveals the secret fields only when an auth type that needs them is selected', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Harness onSubmit={vi.fn()} />);
+
+    expect(screen.queryByLabelText(/AWS Secret ARN/i)).not.toBeInTheDocument();
+
+    await user.click(screen.getByText('Bearer Token'));
+
+    expect(await screen.findByLabelText(/AWS Secret ARN/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Secret JSON Key/i)).toBeInTheDocument();
+  });
+
+  it('blocks submit and flags the invalid server URL when it is empty', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWithProviders(<Harness onSubmit={onSubmit} />);
+
+    await user.click(screen.getByRole('button', { name: /Save Connection/i }));
+
+    await waitFor(() =>
+      expect(screen.getByLabelText(/Server URL/i)).toHaveAttribute('aria-invalid', 'true'),
+    );
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('submits the values once the required fields are provided', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWithProviders(<Harness onSubmit={onSubmit} />);
+
+    await user.type(screen.getByLabelText(/Connection Name/i), 'Internal API');
+    await user.type(screen.getByLabelText(/Server URL/i), 'https://api.example.com');
+    await user.click(screen.getByRole('button', { name: /Save Connection/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0][0]).toMatchObject({
+      name: 'Internal API',
+      serverUrl: 'https://api.example.com',
+    });
+  });
+});

--- a/packages/admin-shell/tests/dom/features/prompts/PromptForm.test.tsx
+++ b/packages/admin-shell/tests/dom/features/prompts/PromptForm.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useForm } from '@mantine/form';
+
+import {
+  PromptForm,
+  type PromptFormValues,
+} from '../../../../src/features/prompts/components/PromptForm.js';
+import { renderWithProviders } from '../../../_helpers/render.js';
+
+function Harness({
+  onSubmit,
+  isEditMode = true,
+}: {
+  onSubmit: (v: PromptFormValues) => Promise<void>;
+  isEditMode?: boolean;
+}): JSX.Element {
+  const form = useForm<PromptFormValues>({
+    initialValues: { name: '', description: '', content: '', tags: [] },
+  });
+  return (
+    <PromptForm
+      form={form}
+      onSubmit={onSubmit}
+      isSubmitting={false}
+      isEditMode={isEditMode}
+      submitButtonLabel="Save Draft"
+    />
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('PromptForm', () => {
+  it('keeps the submit button disabled until the form becomes dirty', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Harness onSubmit={vi.fn()} />);
+
+    const submit = screen.getByRole('button', { name: /Save Draft/i });
+    expect(submit).toBeDisabled();
+
+    await user.type(screen.getByLabelText(/^Name/i), 'Analyzer');
+    await waitFor(() => expect(submit).toBeEnabled());
+  });
+
+  it('only renders the content field in edit mode', () => {
+    const { rerender } = renderWithProviders(<Harness onSubmit={vi.fn()} isEditMode={false} />);
+    expect(screen.queryByLabelText(/Content/i)).not.toBeInTheDocument();
+
+    rerender(<Harness onSubmit={vi.fn()} isEditMode />);
+    expect(screen.getByLabelText(/Content/i)).toBeInTheDocument();
+  });
+
+  it('submits the edited values', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderWithProviders(<Harness onSubmit={onSubmit} />);
+
+    await user.type(screen.getByLabelText(/^Name/i), 'Analyzer');
+    await user.type(screen.getByLabelText(/Content/i), 'Summarize the input');
+    await user.click(screen.getByRole('button', { name: /Save Draft/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0][0]).toMatchObject({
+      name: 'Analyzer',
+      content: 'Summarize the input',
+    });
+  });
+});

--- a/packages/admin-shell/tests/dom/features/shared/ExportModal.test.tsx
+++ b/packages/admin-shell/tests/dom/features/shared/ExportModal.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ALLMA_ADMIN_API_VERSION, ALLMA_ADMIN_API_ROUTES } from '@allma/core-types';
+
+vi.mock('../../../../src/api/axiosInstance.js', () => ({
+  default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('@mantine/notifications', () => ({ notifications: { show: vi.fn() } }));
+vi.mock('file-saver', () => ({ saveAs: vi.fn() }));
+
+import axiosInstance from '../../../../src/api/axiosInstance.js';
+import { ExportModal } from '../../../../src/features/shared/ExportModal.js';
+import { renderWithProviders } from '../../../_helpers/render.js';
+import { apiOk } from '../../../_helpers/query.js';
+
+const mockPost = vi.mocked(axiosInstance.post);
+const V = ALLMA_ADMIN_API_VERSION;
+const R = ALLMA_ADMIN_API_ROUTES;
+
+const items = [
+  { id: 'f1', name: 'Alpha Flow' },
+  { id: 'f2', name: 'Beta Flow' },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ExportModal', () => {
+  it('titles itself from the item type and lists every item', () => {
+    renderWithProviders(
+      <ExportModal opened onClose={() => {}} items={items} itemType="flow" />,
+    );
+
+    expect(screen.getByText('Export Flows')).toBeInTheDocument();
+    expect(screen.getByLabelText('Alpha Flow')).toBeInTheDocument();
+    expect(screen.getByLabelText('Beta Flow')).toBeInTheDocument();
+  });
+
+  it('filters the list by the search term', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <ExportModal opened onClose={() => {}} items={items} itemType="flow" />,
+    );
+
+    await user.type(screen.getByPlaceholderText('Search...'), 'Alpha');
+
+    expect(screen.getByLabelText('Alpha Flow')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Beta Flow')).not.toBeInTheDocument();
+  });
+
+  it('keeps the export button disabled until at least one item is selected', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <ExportModal opened onClose={() => {}} items={items} itemType="flow" />,
+    );
+
+    expect(screen.getByRole('button', { name: /Export Selected \(0\)/i })).toBeDisabled();
+
+    await user.click(screen.getByLabelText('Alpha Flow'));
+
+    expect(screen.getByRole('button', { name: /Export Selected \(1\)/i })).toBeEnabled();
+  });
+
+  it('exports the selected ids under the key matching the item type and closes', async () => {
+    mockPost.mockResolvedValue(apiOk({ flows: [], version: '1' }));
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    renderWithProviders(
+      <ExportModal opened onClose={onClose} items={items} itemType="flow" />,
+    );
+
+    await user.click(screen.getByLabelText('Beta Flow'));
+    await user.click(screen.getByRole('button', { name: /Export Selected \(1\)/i }));
+
+    await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1));
+    expect(mockPost).toHaveBeenCalledWith(`/${V}${R.EXPORT}`, { flowIds: ['f2'] });
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/packages/admin-shell/tests/dom/features/shared/ImportModal.test.tsx
+++ b/packages/admin-shell/tests/dom/features/shared/ImportModal.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ALLMA_ADMIN_API_VERSION, ALLMA_ADMIN_API_ROUTES } from '@allma/core-types';
+
+vi.mock('../../../../src/api/axiosInstance.js', () => ({
+  default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('@mantine/notifications', () => ({ notifications: { show: vi.fn() } }));
+
+import axiosInstance from '../../../../src/api/axiosInstance.js';
+import { notifications } from '@mantine/notifications';
+import { ImportModal } from '../../../../src/features/shared/ImportModal.js';
+import { renderWithProviders } from '../../../_helpers/render.js';
+import { apiOk } from '../../../_helpers/query.js';
+
+const mockPost = vi.mocked(axiosInstance.post);
+const mockNotify = vi.mocked(notifications.show);
+const V = ALLMA_ADMIN_API_VERSION;
+const R = ALLMA_ADMIN_API_ROUTES;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ImportModal', () => {
+  it('warns and does not import when no file is selected', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ImportModal opened onClose={() => {}} />);
+
+    await user.click(screen.getByRole('button', { name: /Start Import/i }));
+
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'No file selected', color: 'red' }),
+    );
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('parses a selected JSON file, posts it with the overwrite option, and closes', async () => {
+    mockPost.mockResolvedValue(
+      apiOk({
+        created: { flows: 0, steps: 0, prompts: 0, agents: 0 },
+        updated: { flows: 0, steps: 0, prompts: 0, agents: 0 },
+      }),
+    );
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    renderWithProviders(<ImportModal opened onClose={onClose} />);
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File([JSON.stringify({ flows: [{ id: 'f1' }] })], 'export.json', {
+      type: 'application/json',
+    });
+    await user.upload(fileInput, file);
+
+    await user.click(screen.getByLabelText(/Overwrite existing items/i));
+    await user.click(screen.getByRole('button', { name: /Start Import/i }));
+
+    await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1));
+    expect(mockPost).toHaveBeenCalledWith(`/${V}${R.IMPORT}`, {
+      flows: [{ id: 'f1' }],
+      options: { overwrite: true },
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('warns when the selected file is not valid JSON', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ImportModal opened onClose={() => {}} />);
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['not json at all'], 'broken.json', { type: 'application/json' });
+    await user.upload(fileInput, file);
+
+    await user.click(screen.getByRole('button', { name: /Start Import/i }));
+
+    await waitFor(() =>
+      expect(mockNotify).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Invalid File', color: 'red' }),
+      ),
+    );
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+});

--- a/packages/admin-shell/tests/dom/features/shared/step-form/StepConfigurationForm.test.tsx
+++ b/packages/admin-shell/tests/dom/features/shared/step-form/StepConfigurationForm.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useForm } from '@mantine/form';
+import { StepType, type StepDefinition } from '@allma/core-types';
+
+vi.mock('../../../../../src/api/axiosInstance.js', () => ({
+  default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('@mantine/notifications', () => ({ notifications: { show: vi.fn() } }));
+// The parameter renderer + layout pull in the full dynamic-field machinery; stub them so the
+// test stays focused on the form's own General Information fields and submit contract.
+vi.mock('../../../../../src/features/shared/step-form/StepFormRenderer.js', () => ({
+  StepFormRenderer: () => null,
+}));
+vi.mock('../../../../../src/features/shared/step-form/StepFormLayout.js', () => ({
+  StepFormLayout: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="step-form-layout">{children}</div>
+  ),
+}));
+
+import axiosInstance from '../../../../../src/api/axiosInstance.js';
+import { StepConfigurationForm } from '../../../../../src/features/shared/step-form/StepConfigurationForm.js';
+import { renderWithProviders } from '../../../../_helpers/render.js';
+import { apiOk } from '../../../../_helpers/query.js';
+
+const mockGet = vi.mocked(axiosInstance.get);
+
+function Harness({ onSubmit }: { onSubmit: (v: Partial<StepDefinition>) => void }): JSX.Element {
+  const form = useForm<Partial<StepDefinition>>({
+    initialValues: {
+      name: '',
+      description: '',
+      stepType: StepType.NO_OP,
+    },
+  });
+  return (
+    <StepConfigurationForm
+      form={form}
+      onSubmit={onSubmit}
+      isSubmitting={false}
+      variant="create-definition"
+      appliedDefinition={null}
+    />
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // useGetStepDefinitions
+  mockGet.mockResolvedValue(apiOk([]));
+});
+
+describe('StepConfigurationForm (create-definition variant)', () => {
+  it('renders the General Information fields', async () => {
+    renderWithProviders(<Harness onSubmit={vi.fn()} />);
+
+    expect(await screen.findByLabelText(/^Name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Description/i)).toBeInTheDocument();
+    expect(screen.getAllByLabelText(/Step Type/i).length).toBeGreaterThan(0);
+  });
+
+  it('keeps Save disabled until the form is edited, then submits the values', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWithProviders(<Harness onSubmit={onSubmit} />);
+
+    const save = await screen.findByRole('button', { name: /Save Changes/i });
+    // The create-definition variant resets dirty on mount, so Save starts disabled.
+    await waitFor(() => expect(save).toBeDisabled());
+
+    await user.type(screen.getByLabelText(/^Name/i), 'My Step Def');
+    await waitFor(() => expect(save).toBeEnabled());
+
+    await user.click(save);
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0][0]).toMatchObject({
+      name: 'My Step Def',
+      stepType: StepType.NO_OP,
+    });
+  });
+});

--- a/packages/admin-shell/tests/unit/features/executions/utils.test.tsx
+++ b/packages/admin-shell/tests/unit/features/executions/utils.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { IconCheck, IconInfoCircle, IconX } from '@tabler/icons-react';
+import { getStatusColor, getStatusIcon } from '../../../../src/features/executions/utils.js';
+
+describe('getStatusColor', () => {
+  it.each([
+    ['COMPLETED', 'green'],
+    ['RUNNING', 'blue'],
+    ['FAILED', 'red'],
+    ['TIMED_OUT', 'orange'],
+    ['CANCELLED', 'gray'],
+    ['RETRYING_SFN', 'yellow'],
+    ['RETRYING_CONTENT', 'yellow'],
+  ])('maps %s to %s', (status, color) => {
+    expect(getStatusColor(status)).toBe(color);
+  });
+
+  it('falls back to "dark" for unknown statuses', () => {
+    expect(getStatusColor('SOMETHING_ELSE')).toBe('dark');
+  });
+});
+
+describe('getStatusIcon', () => {
+  it('returns a check for COMPLETED', () => {
+    expect(getStatusIcon('COMPLETED').type).toBe(IconCheck);
+  });
+
+  it('returns a cross for FAILED', () => {
+    expect(getStatusIcon('FAILED').type).toBe(IconX);
+  });
+
+  it('returns the info icon for anything else', () => {
+    expect(getStatusIcon('RUNNING').type).toBe(IconInfoCircle);
+    expect(getStatusIcon('WHATEVER').type).toBe(IconInfoCircle);
+  });
+});

--- a/packages/admin-shell/tests/unit/features/flows/editor/flow-utils.test.ts
+++ b/packages/admin-shell/tests/unit/features/flows/editor/flow-utils.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { StepType } from '@allma/core-types';
+import { flowDefinitionToElements } from '../../../../../src/features/flows/editor/flow-utils.js';
+import { makeStep, makeFlow } from '../../../../_helpers/fixtures/flow-editor.js';
+
+describe('flowDefinitionToElements — nodes', () => {
+  it('creates one node per step, flagging the start node and falling back to the key for the label', () => {
+    const flow = makeFlow(
+      {
+        a: makeStep('a', { displayName: 'Alpha', position: { x: 1, y: 2 } }),
+        b: makeStep('b', { displayName: undefined, position: { x: 3, y: 4 } }),
+      },
+      { startStepInstanceId: 'a' },
+    );
+
+    const { nodes } = flowDefinitionToElements(flow);
+
+    expect(nodes.map((n) => n.id).sort()).toEqual(['a', 'b']);
+    expect(nodes.find((n) => n.id === 'a')!.data.label).toBe('Alpha');
+    expect(nodes.find((n) => n.id === 'b')!.data.label).toBe('b'); // falls back to the key
+    expect(nodes.find((n) => n.id === 'a')!.data.isStartNode).toBe(true);
+    expect(nodes.find((n) => n.id === 'b')!.data.isStartNode).toBe(false);
+  });
+
+  it('preserves saved positions and does not auto-layout when any step has a position', () => {
+    const flow = makeFlow({
+      a: makeStep('a', { position: { x: 11, y: 22 } }),
+      b: makeStep('b', { position: { x: 33, y: 44 } }),
+    });
+
+    const { nodes, flow: outFlow } = flowDefinitionToElements(flow);
+
+    expect(nodes.find((n) => n.id === 'a')!.position).toEqual({ x: 11, y: 22 });
+    expect(outFlow).toBe(flow); // unchanged reference — no layout pass
+  });
+
+  it('auto-lays-out and writes positions back when no step has a position', () => {
+    const flow = makeFlow({
+      a: makeStep('a', { position: undefined, defaultNextStepInstanceId: 'b' }),
+      b: makeStep('b', { position: undefined }),
+    });
+
+    const { nodes, flow: outFlow } = flowDefinitionToElements(flow);
+
+    for (const node of nodes) {
+      expect(Number.isFinite(node.position.x)).toBe(true);
+      expect(Number.isFinite(node.position.y)).toBe(true);
+    }
+    // Top-to-bottom layout: the downstream node sits below the source.
+    const a = nodes.find((n) => n.id === 'a')!;
+    const b = nodes.find((n) => n.id === 'b')!;
+    expect(b.position.y).toBeGreaterThan(a.position.y);
+    // Positions are written back into a fresh flow object (not the input).
+    expect(outFlow).not.toBe(flow);
+    expect(outFlow.steps.a.position).toEqual(a.position);
+  });
+});
+
+describe('flowDefinitionToElements — edges', () => {
+  it('emits a default edge for defaultNextStepInstanceId', () => {
+    const flow = makeFlow({
+      a: makeStep('a', { defaultNextStepInstanceId: 'b', position: { x: 0, y: 0 } }),
+      b: makeStep('b', { position: { x: 0, y: 1 } }),
+    });
+
+    const { edges } = flowDefinitionToElements(flow);
+    expect(edges).toHaveLength(1);
+    expect(edges[0]).toMatchObject({
+      id: 'e-a-default-b',
+      source: 'a',
+      target: 'b',
+      data: { edgeType: 'default' },
+    });
+  });
+
+  it('emits conditional edges carrying their condition', () => {
+    const flow = makeFlow({
+      a: makeStep('a', {
+        position: { x: 0, y: 0 },
+        transitions: [{ condition: '$.ok', nextStepInstanceId: 'b' }] as never,
+      }),
+      b: makeStep('b', { position: { x: 0, y: 1 } }),
+    });
+
+    const { edges } = flowDefinitionToElements(flow);
+    const cond = edges.find((e) => e.data?.edgeType === 'conditional')!;
+    expect(cond.id).toBe('e-a-cond-0-b');
+    expect(cond.target).toBe('b');
+    expect(cond.data?.condition).toBe('$.ok');
+  });
+
+  it('emits a fallback edge for an onError handler', () => {
+    const flow = makeFlow({
+      a: makeStep('a', { position: { x: 0, y: 0 }, onError: { fallbackStepInstanceId: 'b' } } as never),
+      b: makeStep('b', { position: { x: 0, y: 1 } }),
+    });
+
+    const { edges } = flowDefinitionToElements(flow);
+    expect(edges.find((e) => e.data?.edgeType === 'fallback')).toMatchObject({
+      id: 'e-a-error-b',
+      target: 'b',
+    });
+  });
+});
+
+describe('flowDefinitionToElements — parallel branches', () => {
+  const branchedFlow = () =>
+    makeFlow({
+      fork: makeStep('fork', {
+        stepType: StepType.PARALLEL_FORK_MANAGER,
+        position: { x: 0, y: 0 },
+        parallelBranches: [{ stepInstanceId: 'b1', branchId: 'br1' }],
+      } as never),
+      b1: makeStep('b1', { position: { x: 0, y: 1 }, defaultNextStepInstanceId: 'b2' }),
+      b2: makeStep('b2', { position: { x: 0, y: 2 } }),
+    });
+
+  it('emits a branch edge from the fork to each branch entry step', () => {
+    const { edges } = flowDefinitionToElements(branchedFlow());
+    expect(edges.find((e) => e.data?.edgeType === 'branch')).toMatchObject({
+      id: 'e-fork-branch-b1',
+      source: 'fork',
+      target: 'b1',
+      data: { branchId: 'br1' },
+    });
+  });
+
+  it('tags every step reachable within a branch with its fork/branch info', () => {
+    const { nodes } = flowDefinitionToElements(branchedFlow());
+    for (const id of ['b1', 'b2']) {
+      expect(nodes.find((n) => n.id === id)!.data.branchInfo).toEqual({ forkId: 'fork', branchId: 'br1' });
+    }
+  });
+
+  it('marks a terminal branch step (no outgoing flow) as a branch end', () => {
+    const { nodes } = flowDefinitionToElements(branchedFlow());
+    expect(nodes.find((n) => n.id === 'b1')!.data.isBranchEnd).toBe(false); // has a next step
+    expect(nodes.find((n) => n.id === 'b2')!.data.isBranchEnd).toBe(true); // terminal
+  });
+});

--- a/packages/admin-shell/tests/unit/features/flows/editor/hooks/useFlowEditorStore.test.ts
+++ b/packages/admin-shell/tests/unit/features/flows/editor/hooks/useFlowEditorStore.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import useFlowEditorStore from '../../../../../../src/features/flows/editor/hooks/useFlowEditorStore.js';
+import { makeStep, makeNode, makeEdge, makeFlow } from '../../../../../_helpers/fixtures/flow-editor.js';
+
+const store = useFlowEditorStore;
+const get = () => store.getState();
+
+/** Reset only the data slice between tests; the action functions are stable singletons. */
+beforeEach(() => {
+  store.setState({ flowDefinition: null, nodes: [], edges: [], isDirty: false });
+});
+
+describe('setFlow', () => {
+  it('loads the flow, clears dirty flags, and resets per-node dirty state', () => {
+    const flow = makeFlow({ a: makeStep('a') });
+    const node = makeNode('a', flow.steps.a, { data: { label: 'a', stepType: flow.steps.a.stepType, config: flow.steps.a, isStartNode: false, isDirty: true } });
+
+    get().setFlow(flow, [node], []);
+
+    expect(get().flowDefinition).toBe(flow);
+    expect(get().isDirty).toBe(false);
+    expect(get().nodes[0].data.isDirty).toBe(false);
+  });
+});
+
+describe('addNode', () => {
+  it('appends a node, registers its step, and marks the flow dirty', () => {
+    get().setFlow(makeFlow({ a: makeStep('a') }), [makeNode('a')], []);
+
+    get().addNode(
+      { type: 'stepNode', data: { label: 'New', stepType: get().flowDefinition!.steps.a.stepType, config: {} as never, isStartNode: false } },
+      { x: 50, y: 60 },
+    );
+
+    const { nodes, flowDefinition } = get();
+    expect(nodes).toHaveLength(2);
+    const added = nodes[1];
+    expect(added.id).toMatch(/^no_op_[0-9a-f]{8}$/);
+    expect(added.position).toEqual({ x: 50, y: 60 });
+    expect(flowDefinition!.steps[added.id]).toBeDefined();
+    expect(flowDefinition!.steps[added.id].stepInstanceId).toBe(added.id);
+    expect(get().isDirty).toBe(true);
+  });
+
+  it('is a no-op when no flow is loaded', () => {
+    get().addNode(
+      { type: 'stepNode', data: { label: 'x', stepType: makeStep('x').stepType, config: {} as never, isStartNode: false } },
+      { x: 0, y: 0 },
+    );
+    expect(get().nodes).toHaveLength(0);
+  });
+});
+
+describe('onConnect', () => {
+  const setup = () => {
+    const flow = makeFlow({ a: makeStep('a'), b: makeStep('b'), c: makeStep('c') });
+    get().setFlow(flow, [makeNode('a'), makeNode('b'), makeNode('c')], []);
+  };
+
+  it('makes the first connection the default next step', () => {
+    setup();
+    get().onConnect({ source: 'a', target: 'b', sourceHandle: null, targetHandle: null });
+
+    const { edges, flowDefinition, isDirty } = get();
+    expect(flowDefinition!.steps.a.defaultNextStepInstanceId).toBe('b');
+    expect(edges).toHaveLength(1);
+    expect(edges[0].data?.edgeType).toBe('default');
+    expect(isDirty).toBe(true);
+  });
+
+  it('makes a second connection from the same source a conditional transition', () => {
+    setup();
+    get().onConnect({ source: 'a', target: 'b', sourceHandle: null, targetHandle: null });
+    get().onConnect({ source: 'a', target: 'c', sourceHandle: null, targetHandle: null });
+
+    const { edges, flowDefinition } = get();
+    expect(flowDefinition!.steps.a.defaultNextStepInstanceId).toBe('b');
+    expect(flowDefinition!.steps.a.transitions).toHaveLength(1);
+    expect(flowDefinition!.steps.a.transitions![0].nextStepInstanceId).toBe('c');
+    expect(edges).toHaveLength(2);
+    expect(edges[1].data?.edgeType).toBe('conditional');
+  });
+
+  it('ignores a connection with a missing endpoint or unknown source', () => {
+    setup();
+    get().onConnect({ source: 'a', target: null, sourceHandle: null, targetHandle: null });
+    get().onConnect({ source: 'ghost', target: 'b', sourceHandle: null, targetHandle: null });
+    expect(get().edges).toHaveLength(0);
+    expect(get().isDirty).toBe(false);
+  });
+});
+
+describe('deleteNodes', () => {
+  it('removes the node, its edges, and all references to it', () => {
+    const flow = makeFlow(
+      {
+        a: makeStep('a', { defaultNextStepInstanceId: 'b' }),
+        b: makeStep('b'),
+        c: makeStep('c', { transitions: [{ condition: '$.x', nextStepInstanceId: 'b' }] as never }),
+      },
+      { startStepInstanceId: 'a' },
+    );
+    get().setFlow(
+      flow,
+      [makeNode('a'), makeNode('b'), makeNode('c')],
+      [makeEdge('e1', 'a', 'b'), makeEdge('e2', 'c', 'b')],
+    );
+
+    get().deleteNodes(['b']);
+
+    const { nodes, edges, flowDefinition } = get();
+    expect(nodes.map((n) => n.id)).toEqual(['a', 'c']);
+    expect(edges).toHaveLength(0);
+    expect(flowDefinition!.steps.b).toBeUndefined();
+    expect(flowDefinition!.steps.a.defaultNextStepInstanceId).toBeUndefined();
+    expect(flowDefinition!.steps.c.transitions).toHaveLength(0);
+    expect(get().isDirty).toBe(true);
+  });
+
+  it('clears the start step when it is deleted', () => {
+    const flow = makeFlow({ a: makeStep('a'), b: makeStep('b') }, { startStepInstanceId: 'a' });
+    get().setFlow(flow, [makeNode('a'), makeNode('b')], []);
+
+    get().deleteNodes(['a']);
+    expect(get().flowDefinition!.startStepInstanceId).toBe('');
+  });
+
+  it('onNodesDelete delegates to deleteNodes', () => {
+    const flow = makeFlow({ a: makeStep('a'), b: makeStep('b') });
+    get().setFlow(flow, [makeNode('a'), makeNode('b')], []);
+
+    get().onNodesDelete([{ id: 'a' } as never]);
+    expect(get().nodes.map((n) => n.id)).toEqual(['b']);
+  });
+});
+
+describe('updateNodeConfig', () => {
+  it('renames a step id and rewrites every reference to it', () => {
+    const flow = makeFlow(
+      {
+        a: makeStep('a', { defaultNextStepInstanceId: 'b' }),
+        b: makeStep('b'),
+      },
+      { startStepInstanceId: 'b' },
+    );
+    get().setFlow(flow, [makeNode('a'), makeNode('b')], [makeEdge('e1', 'a', 'b')]);
+
+    get().updateNodeConfig('b', { config: makeStep('b2') });
+
+    const { flowDefinition, nodes, edges } = get();
+    expect(flowDefinition!.steps.b).toBeUndefined();
+    expect(flowDefinition!.steps.b2).toBeDefined();
+    expect(flowDefinition!.steps.a.defaultNextStepInstanceId).toBe('b2');
+    expect(flowDefinition!.startStepInstanceId).toBe('b2');
+    expect(nodes.find((n) => n.id === 'b2')).toBeDefined();
+    expect(edges[0].target).toBe('b2');
+  });
+
+  it('syncs the default edge when defaultNextStepInstanceId changes (no id rename)', () => {
+    const flow = makeFlow({ a: makeStep('a'), b: makeStep('b') });
+    get().setFlow(flow, [makeNode('a'), makeNode('b')], []);
+
+    get().updateNodeConfig('a', { config: makeStep('a', { defaultNextStepInstanceId: 'b' }) });
+
+    const defaultEdges = get().edges.filter((e) => e.data?.edgeType === 'default');
+    expect(defaultEdges).toHaveLength(1);
+    expect(defaultEdges[0].source).toBe('a');
+    expect(defaultEdges[0].target).toBe('b');
+  });
+});
+
+describe('updateEdgeCondition', () => {
+  it('updates the matching transition condition and the edge data', () => {
+    const flow = makeFlow({
+      a: makeStep('a', { transitions: [{ condition: '$.old', nextStepInstanceId: 'b' }] as never }),
+      b: makeStep('b'),
+    });
+    get().setFlow(flow, [makeNode('a'), makeNode('b')], [makeEdge('e1', 'a', 'b', { data: { edgeType: 'conditional' } })]);
+
+    get().updateEdgeCondition('e1', '$.new');
+
+    expect(get().flowDefinition!.steps.a.transitions![0].condition).toBe('$.new');
+    expect(get().edges[0].data?.condition).toBe('$.new');
+    expect(get().isDirty).toBe(true);
+  });
+
+  it('is a no-op when the source has no matching transition', () => {
+    const flow = makeFlow({ a: makeStep('a'), b: makeStep('b') });
+    get().setFlow(flow, [makeNode('a'), makeNode('b')], [makeEdge('e1', 'a', 'b')]);
+    get().updateEdgeCondition('e1', '$.x');
+    expect(get().isDirty).toBe(false);
+  });
+});
+
+describe('updateEdgeHandles', () => {
+  it('updates only the handles of the targeted edge', () => {
+    const flow = makeFlow({ a: makeStep('a'), b: makeStep('b') });
+    get().setFlow(flow, [makeNode('a'), makeNode('b')], [makeEdge('e1', 'a', 'b')]);
+
+    get().updateEdgeHandles('e1', { sourceHandle: 'sh', targetHandle: 'th' });
+
+    expect(get().edges[0].sourceHandle).toBe('sh');
+    expect(get().edges[0].targetHandle).toBe('th');
+  });
+});
+
+describe('deleteEdgeById', () => {
+  it('removes the edge and cleans the source step references', () => {
+    const flow = makeFlow({
+      a: makeStep('a', { defaultNextStepInstanceId: 'b' }),
+      b: makeStep('b'),
+    });
+    get().setFlow(flow, [makeNode('a'), makeNode('b')], [makeEdge('e1', 'a', 'b')]);
+
+    get().deleteEdgeById('e1');
+
+    expect(get().edges).toHaveLength(0);
+    expect(get().flowDefinition!.steps.a.defaultNextStepInstanceId).toBeUndefined();
+  });
+});
+
+describe('setStartNode', () => {
+  it('sets the start step and flags the chosen node', () => {
+    const flow = makeFlow({ a: makeStep('a'), b: makeStep('b') }, { startStepInstanceId: 'a' });
+    get().setFlow(flow, [makeNode('a'), makeNode('b')], []);
+
+    get().setStartNode('b');
+
+    expect(get().flowDefinition!.startStepInstanceId).toBe('b');
+    expect(get().nodes.find((n) => n.id === 'b')!.data.isStartNode).toBe(true);
+    expect(get().nodes.find((n) => n.id === 'a')!.data.isStartNode).toBe(false);
+    expect(get().isDirty).toBe(true);
+  });
+
+  it('is a no-op when the node is already the start node', () => {
+    const flow = makeFlow({ a: makeStep('a') }, { startStepInstanceId: 'a' });
+    get().setFlow(flow, [makeNode('a')], []);
+    get().setStartNode('a');
+    expect(get().isDirty).toBe(false);
+  });
+});
+
+describe('updateFlowProperties', () => {
+  it('merges properties and recomputes which node is the start node', () => {
+    const flow = makeFlow({ a: makeStep('a'), b: makeStep('b') }, { startStepInstanceId: 'a' });
+    get().setFlow(flow, [makeNode('a'), makeNode('b')], []);
+
+    get().updateFlowProperties({ startStepInstanceId: 'b', name: 'Renamed' });
+
+    expect(get().flowDefinition!.name).toBe('Renamed');
+    expect(get().nodes.find((n) => n.id === 'b')!.data.isStartNode).toBe(true);
+    expect(get().isDirty).toBe(true);
+  });
+});
+
+describe('clearDirtyState', () => {
+  it('clears the global flag and every per-node dirty flag', () => {
+    const flow = makeFlow({ a: makeStep('a') });
+    const dirtyNode = makeNode('a');
+    dirtyNode.data.isDirty = true;
+    get().setFlow(flow, [dirtyNode], []);
+    store.setState({ isDirty: true });
+
+    get().clearDirtyState();
+
+    expect(get().isDirty).toBe(false);
+    expect(get().nodes[0].data.isDirty).toBe(false);
+  });
+});
+
+describe('onNodesChange', () => {
+  it('persists a node position change into the canonical flow definition', () => {
+    const flow = makeFlow({ a: makeStep('a', { position: { x: 0, y: 0 } }) });
+    get().setFlow(flow, [makeNode('a')], []);
+
+    get().onNodesChange([{ type: 'position', id: 'a', position: { x: 99, y: 88 } }]);
+
+    expect(get().flowDefinition!.steps.a.position).toEqual({ x: 99, y: 88 });
+    expect(get().isDirty).toBe(true);
+  });
+
+  it('treats a selection-only change as non-dirtying visual state', () => {
+    const flow = makeFlow({ a: makeStep('a') });
+    get().setFlow(flow, [makeNode('a')], []);
+
+    get().onNodesChange([{ type: 'select', id: 'a', selected: true }]);
+
+    expect(get().nodes[0].selected).toBe(true);
+    expect(get().isDirty).toBe(false);
+  });
+});
+
+describe('onEdgesChange', () => {
+  it('cleans up the source step when an edge is removed', () => {
+    const flow = makeFlow({
+      a: makeStep('a', { defaultNextStepInstanceId: 'b' }),
+      b: makeStep('b'),
+    });
+    get().setFlow(flow, [makeNode('a'), makeNode('b')], [makeEdge('e1', 'a', 'b')]);
+
+    get().onEdgesChange([{ type: 'remove', id: 'e1' }]);
+
+    expect(get().edges).toHaveLength(0);
+    expect(get().flowDefinition!.steps.a.defaultNextStepInstanceId).toBeUndefined();
+    expect(get().isDirty).toBe(true);
+  });
+});
+
+describe('deselectAll', () => {
+  it('deselects any selected nodes and edges', () => {
+    const flow = makeFlow({ a: makeStep('a'), b: makeStep('b') });
+    const selectedNode = makeNode('a');
+    selectedNode.selected = true;
+    get().setFlow(flow, [selectedNode, makeNode('b')], [makeEdge('e1', 'a', 'b', { selected: true })]);
+
+    get().deselectAll();
+
+    expect(get().nodes.find((n) => n.id === 'a')!.selected).toBe(false);
+    expect(get().edges[0].selected).toBe(false);
+  });
+});

--- a/packages/admin-shell/tests/unit/features/flows/editor/zod-schema-mappers.test.ts
+++ b/packages/admin-shell/tests/unit/features/flows/editor/zod-schema-mappers.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { StepType } from '@allma/core-types';
+import { z } from 'zod';
+import {
+  ALL_STEP_SCHEMA_KEYS,
+  STEP_SCHEMA_EXCLUDED_FIELDS,
+  getStepSchema,
+  parseDescription,
+} from '../../../../../src/features/flows/editor/zod-schema-mappers.js';
+
+const DEFINITION_ONLY_FIELDS = ['id', 'name', 'version', 'createdAt', 'updatedAt'];
+
+describe('ALL_STEP_SCHEMA_KEYS', () => {
+  it('is a non-empty set of string keys', () => {
+    expect(ALL_STEP_SCHEMA_KEYS).toBeInstanceOf(Set);
+    expect(ALL_STEP_SCHEMA_KEYS.size).toBeGreaterThan(0);
+    for (const key of ALL_STEP_SCHEMA_KEYS) expect(typeof key).toBe('string');
+  });
+
+  it('collects keys from the intersected instance/definition schemas (recurses unions)', () => {
+    // These live on different arms of the .and()/superRefine intersections, so their
+    // presence proves the recursive walker descended through the wrappers.
+    expect(ALL_STEP_SCHEMA_KEYS.has('stepInstanceId')).toBe(true);
+    expect(ALL_STEP_SCHEMA_KEYS.has('displayName')).toBe(true);
+    expect(ALL_STEP_SCHEMA_KEYS.has('transitions')).toBe(true);
+    expect(ALL_STEP_SCHEMA_KEYS.has('id')).toBe(true);
+    expect(ALL_STEP_SCHEMA_KEYS.has('name')).toBe(true);
+  });
+});
+
+describe('getStepSchema', () => {
+  it('returns the mapped schema for a known step type', () => {
+    const schema = getStepSchema(StepType.LLM_INVOCATION);
+    expect(schema).toBeInstanceOf(z.ZodObject);
+    expect(Object.keys(schema.shape).length).toBeGreaterThan(0);
+  });
+
+  it('strips definition-only metadata fields from the validation schema', () => {
+    const schema = getStepSchema(StepType.API_CALL);
+    for (const field of DEFINITION_ONLY_FIELDS) {
+      expect(schema.shape).not.toHaveProperty(field);
+    }
+  });
+
+  it('falls back to an empty object schema for an unmapped step type', () => {
+    const schema = getStepSchema('TOTALLY_UNKNOWN_TYPE' as StepType);
+    expect(schema).toBeInstanceOf(z.ZodObject);
+    expect(Object.keys(schema.shape)).toHaveLength(0);
+  });
+});
+
+describe('parseDescription', () => {
+  it('returns sensible defaults for an undefined description', () => {
+    expect(parseDescription(undefined)).toEqual({
+      label: 'Unknown Field',
+      componentType: 'text',
+      placeholder: '',
+    });
+  });
+
+  it('parses a label-only description, defaulting the rest', () => {
+    expect(parseDescription('My Label')).toEqual({
+      label: 'My Label',
+      componentType: 'text',
+      placeholder: '',
+    });
+  });
+
+  it('parses the full Label|Component|Placeholder triple', () => {
+    expect(parseDescription('Max Retries|number|How many times')).toEqual({
+      label: 'Max Retries',
+      componentType: 'number',
+      placeholder: 'How many times',
+    });
+  });
+});
+
+describe('STEP_SCHEMA_EXCLUDED_FIELDS', () => {
+  it('excludes the editor-special-cased and base fields', () => {
+    for (const field of ['stepType', 'inputMappings', 'outputMappings', 'onError', 'displayName']) {
+      expect(STEP_SCHEMA_EXCLUDED_FIELDS.has(field)).toBe(true);
+    }
+  });
+});

--- a/packages/admin-shell/tests/unit/features/shared/step-form/form-utils.test.ts
+++ b/packages/admin-shell/tests/unit/features/shared/step-form/form-utils.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { getDefaultsFromShape } from '../../../../../src/features/shared/step-form/form-utils.js';
+
+describe('getDefaultsFromShape', () => {
+  it('uses the schema default when one is declared', () => {
+    const shape = { withDefault: z.string().default('hello') };
+    expect(getDefaultsFromShape(shape)).toEqual({ withDefault: 'hello' });
+  });
+
+  it('defaults strings and effects (transform/refine) to an empty string', () => {
+    const shape = {
+      plain: z.string(),
+      email: z.string().email(),
+      transformed: z.string().transform((s) => s.trim()),
+    };
+    expect(getDefaultsFromShape(shape)).toEqual({ plain: '', email: '', transformed: '' });
+  });
+
+  it('defaults objects and records to an empty object', () => {
+    const shape = {
+      obj: z.object({ a: z.string() }),
+      rec: z.record(z.string()),
+    };
+    expect(getDefaultsFromShape(shape)).toEqual({ obj: {}, rec: {} });
+  });
+
+  it('defaults arrays to an empty array', () => {
+    const shape = { list: z.array(z.string()) };
+    expect(getDefaultsFromShape(shape)).toEqual({ list: [] });
+  });
+
+  it('defaults enums, numbers and booleans to null (safe for controlled inputs)', () => {
+    const shape = {
+      count: z.number(),
+      enabled: z.boolean(),
+      choice: z.enum(['a', 'b']),
+    };
+    expect(getDefaultsFromShape(shape)).toEqual({ count: null, enabled: null, choice: null });
+  });
+
+  it('returns an empty object for an empty shape', () => {
+    expect(getDefaultsFromShape({})).toEqual({});
+  });
+});

--- a/packages/admin-shell/tests/unit/utils/formatters.test.ts
+++ b/packages/admin-shell/tests/unit/utils/formatters.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatPreciseDuration,
+  formatFuzzyDurationWithDetail,
+} from '../../../src/utils/formatters.js';
+
+describe('formatPreciseDuration', () => {
+  it.each([
+    [undefined, 'duration n/a'],
+    [null, 'duration n/a'],
+    [-1, 'duration n/a'],
+  ])('returns the n/a sentinel for %s', (input, expected) => {
+    expect(formatPreciseDuration(input)).toBe(expected);
+  });
+
+  it.each([
+    [0, '0 ms'],
+    [123, '123 ms'],
+    [999, '999 ms'],
+  ])('renders sub-second values as raw milliseconds (%i)', (input, expected) => {
+    expect(formatPreciseDuration(input)).toBe(expected);
+  });
+
+  it.each([
+    [1000, '1s'],
+    [1234, '1.234s'],
+    [1500, '1.5s'],
+    [2000, '2s'],
+    [60000, '1m'],
+    [61234, '1m 1.234s'],
+    [3600000, '1h'],
+    [3661234, '1h 1m 1.234s'],
+    [90061000, '1d 1h 1m 1s'],
+  ])('formats %i ms as "%s"', (input, expected) => {
+    expect(formatPreciseDuration(input)).toBe(expected);
+  });
+
+  it('strips trailing zeros from the fractional second', () => {
+    // 1.250s, not 1.250s with padding
+    expect(formatPreciseDuration(1250)).toBe('1.25s');
+  });
+});
+
+describe('formatFuzzyDurationWithDetail', () => {
+  it('reports invalid dates', () => {
+    expect(formatFuzzyDurationWithDetail('not-a-date', '2020-01-01')).toBe('Invalid date');
+  });
+
+  it('appends a seconds detail for sub-minute spans', () => {
+    const start = new Date('2020-01-01T00:00:00.000Z');
+    const end = new Date('2020-01-01T00:00:23.000Z');
+    expect(formatFuzzyDurationWithDetail(start, end)).toBe('less than a minute (23 seconds)');
+  });
+
+  it('appends a minutes+seconds detail for sub-hour spans', () => {
+    const start = new Date('2020-01-01T00:00:00.000Z');
+    const end = new Date('2020-01-01T00:05:30.000Z');
+    // date-fns formatDistance rounds the fuzzy part (5m30s → "6 minutes"); the precise
+    // detail in parentheses is the exact value.
+    expect(formatFuzzyDurationWithDetail(start, end)).toBe('6 minutes (5m, 30s)');
+  });
+
+  it('appends an hour/minute detail for multi-hour spans', () => {
+    const start = new Date('2020-01-01T00:00:00.000Z');
+    const end = new Date('2020-01-01T02:30:00.000Z');
+    expect(formatFuzzyDurationWithDetail(start, end)).toBe('about 3 hours (2h 30m)');
+  });
+});

--- a/packages/admin-shell/vitest.config.ts
+++ b/packages/admin-shell/vitest.config.ts
@@ -30,10 +30,10 @@ export default defineConfig({
       // (TEST_PLAN Phase 6). Whole-src denominator, so absolutes are low while individual
       // covered modules sit at ~96-100%.
       thresholds: {
-        lines: 27,
-        functions: 62,
-        statements: 27,
-        branches: 69,
+        lines: 35,
+        functions: 63,
+        statements: 35,
+        branches: 73,
       },
     },
   },

--- a/packages/admin-shell/vitest.config.ts
+++ b/packages/admin-shell/vitest.config.ts
@@ -26,11 +26,14 @@ export default defineConfig({
       // Measure the whole src tree (not just imported files) so coverage reflects real
       // progress across the codebase. Thresholds start low and ratchet up (TEST_PLAN Phase 6).
       all: true,
+      // Floors sit just under the current actuals — raise them as each phase lands
+      // (TEST_PLAN Phase 6). Whole-src denominator, so absolutes are low while individual
+      // covered modules sit at ~96-100%.
       thresholds: {
-        lines: 2,
-        functions: 2,
-        statements: 2,
-        branches: 30,
+        lines: 7,
+        functions: 18,
+        statements: 7,
+        branches: 55,
       },
     },
   },

--- a/packages/admin-shell/vitest.config.ts
+++ b/packages/admin-shell/vitest.config.ts
@@ -30,10 +30,10 @@ export default defineConfig({
       // (TEST_PLAN Phase 6). Whole-src denominator, so absolutes are low while individual
       // covered modules sit at ~96-100%.
       thresholds: {
-        lines: 23,
-        functions: 60,
-        statements: 23,
-        branches: 68,
+        lines: 27,
+        functions: 62,
+        statements: 27,
+        branches: 69,
       },
     },
   },

--- a/packages/admin-shell/vitest.config.ts
+++ b/packages/admin-shell/vitest.config.ts
@@ -30,10 +30,10 @@ export default defineConfig({
       // (TEST_PLAN Phase 6). Whole-src denominator, so absolutes are low while individual
       // covered modules sit at ~96-100%.
       thresholds: {
-        lines: 7,
-        functions: 18,
-        statements: 7,
-        branches: 55,
+        lines: 11,
+        functions: 28,
+        statements: 11,
+        branches: 60,
       },
     },
   },

--- a/packages/admin-shell/vitest.config.ts
+++ b/packages/admin-shell/vitest.config.ts
@@ -30,10 +30,10 @@ export default defineConfig({
       // (TEST_PLAN Phase 6). Whole-src denominator, so absolutes are low while individual
       // covered modules sit at ~96-100%.
       thresholds: {
-        lines: 19,
-        functions: 57,
-        statements: 19,
-        branches: 66,
+        lines: 23,
+        functions: 60,
+        statements: 23,
+        branches: 68,
       },
     },
   },

--- a/packages/admin-shell/vitest.config.ts
+++ b/packages/admin-shell/vitest.config.ts
@@ -30,10 +30,10 @@ export default defineConfig({
       // (TEST_PLAN Phase 6). Whole-src denominator, so absolutes are low while individual
       // covered modules sit at ~96-100%.
       thresholds: {
-        lines: 12,
-        functions: 30,
-        statements: 12,
-        branches: 62,
+        lines: 19,
+        functions: 57,
+        statements: 19,
+        branches: 66,
       },
     },
   },

--- a/packages/admin-shell/vitest.config.ts
+++ b/packages/admin-shell/vitest.config.ts
@@ -30,10 +30,10 @@ export default defineConfig({
       // (TEST_PLAN Phase 6). Whole-src denominator, so absolutes are low while individual
       // covered modules sit at ~96-100%.
       thresholds: {
-        lines: 11,
-        functions: 28,
-        statements: 11,
-        branches: 60,
+        lines: 12,
+        functions: 30,
+        statements: 12,
+        branches: 62,
       },
     },
   },

--- a/packages/admin-shell/vitest.config.ts
+++ b/packages/admin-shell/vitest.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+/**
+ * Root config for `@allma/admin-shell`. Holds shared options and the (root-level) coverage
+ * config; the project split (unit/node vs dom/jsdom) lives in vitest.workspace.ts.
+ *
+ * Coverage is configured here because Vitest does not honour per-project coverage options.
+ * Thresholds start deliberately low and are ratcheted up as modules gain tests
+ * (see TEST_PLAN.md, Phase 6).
+ */
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    clearMocks: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'text-summary', 'html', 'lcov'],
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: [
+        'src/**/*.d.ts',
+        'src/**/index.ts',
+        'src/types/**',
+        'src/harness/**',
+      ],
+      // Measure the whole src tree (not just imported files) so coverage reflects real
+      // progress across the codebase. Thresholds start low and ratchet up (TEST_PLAN Phase 6).
+      all: true,
+      thresholds: {
+        lines: 2,
+        functions: 2,
+        statements: 2,
+        branches: 30,
+      },
+    },
+  },
+});

--- a/packages/admin-shell/vitest.workspace.ts
+++ b/packages/admin-shell/vitest.workspace.ts
@@ -1,0 +1,33 @@
+import { defineWorkspace } from 'vitest/config';
+
+/**
+ * Two-project layout (see TEST_PLAN.md):
+ *  - `unit` — pure logic, `node` environment. No DOM, no React render. The bulk of the
+ *             suite (store actions, graph utils, mappers, formatters). Fast; the CI gate.
+ *  - `dom`  — anything touching React/DOM: API hooks and component tests. `jsdom`
+ *             environment with a shared setup file.
+ *
+ * Coverage is configured at the root (vitest.config.ts) because Vitest does not honour
+ * per-project coverage options.
+ */
+export default defineWorkspace([
+  {
+    extends: './vitest.config.ts',
+    test: {
+      name: 'unit',
+      environment: 'node',
+      include: ['tests/unit/**/*.test.{ts,tsx}'],
+      clearMocks: true,
+    },
+  },
+  {
+    extends: './vitest.config.ts',
+    test: {
+      name: 'dom',
+      environment: 'jsdom',
+      include: ['tests/dom/**/*.test.{ts,tsx}'],
+      setupFiles: ['./tests/_setup/jsdom.setup.ts'],
+      clearMocks: true,
+    },
+  },
+]);


### PR DESCRIPTION
## Summary

Stands up a hermetic Vitest test suite for `@allma/admin-shell` (the React Admin Panel shell), which previously had **zero tests and no test runner**. The package is a published library, so its public surface (`createAllmaAdminApp`, the `AllmaPlugin` contract, the service/hook layer) is a real contract worth protecting. Plan and conventions live in `packages/admin-shell/TEST_PLAN.md` and `packages/admin-shell/tests/README.md`.

**Result:** 185 tests green across two projects; coverage ratcheted to **35% lines/stmts, 73% branches, 63% funcs** (whole-`src` denominator). Lint stays at 0 errors. No source was changed to make a test pass.

## What's covered

- **Pure logic (`unit`, node env):** formatters, executions status utils, form-utils, zod↔form mappers, the full `useFlowEditorStore` Zustand store (via `getState()`), and `flow-utils` graph construction.
- **API layer (`dom`, jsdom):** every service hook — flow, flowControl, execution, prompt, agent, mcp, stepDefinition, systemTools, dashboard, importExport. Each asserts method, the versioned route built from `ALLMA_ADMIN_API_ROUTES` (never hardcoded), query/body shape, `AdminApiResponse` envelope unwrapping, disabled-query gating, and notification side effects.
- **Components (`dom`):** forms (Agent, Prompt, McpConnection, FlowSettings, StepConfigurationForm) with real `@mantine/form` + zod validation and submit-payload shape; modals/tables (ContextDiffModal, StatefulRedriveModal, Import/ExportModal, ExecutionsTable); and `createAllmaAdminApp` asserting the plugin contract (plugins forwarded, AppWrappers composed, missing-root throws).

## Approach / conventions

- Two Vitest projects: `unit` (node, pure logic) and `dom` (jsdom, React). Coverage configured once at the root with a ratchet raised per batch.
- The single `axiosInstance` module is mocked via a `vi.mock` factory (it throws at import time without `VITE_API_BASE_URL` and pulls in Amplify); `@mantine/notifications` is mocked to assert `notifications.show`.
- Testing-Library `cleanup()` is registered in the shared jsdom setup (the `dom` project runs without `globals: true`).
- Deliberately deferred (lowest ROI): reactflow visual-layout rendering and the optional MSW page-level integration layer.

## Test plan

- `npm test -w @allma/admin-shell` → 185 passing (both projects)
- `npm run test:coverage -w @allma/admin-shell` → gate passes (exit 0)
- `npm run lint -w @allma/admin-shell` → 0 errors (8 pre-existing warnings, untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)