### PR TITLE
feat(llm): support Handlebars templating for model selection

### DIFF
--- a/.changeset/llm-templated-model-selection.md
+++ b/.changeset/llm-templated-model-selection.md
@@ -1,0 +1,10 @@
+---
+"@allma/core-types": minor
+---
+
+`LLM_INVOCATION` model selection now supports Handlebars templating. The `llmProvider`, `modelId`,
+and every `fallbacks[]` entry are rendered against the flow context at runtime (the same context as
+`templateContextMappings`), so flows can centralize/parameterize model choice, e.g.
+`"modelId": "{{config.llmModels.bedrockSonnet}}"`. Plain values without `{{ }}` are unchanged, so
+existing flows are unaffected. Resolved values are validated after rendering: an empty `modelId` or
+an `llmProvider` that does not resolve to a valid provider fails the step with a clear error.

--- a/docs.allma.dev/docs/reference/step-types/01-llm-invocation.md
+++ b/docs.allma.dev/docs/reference/step-types/01-llm-invocation.md
@@ -17,8 +17,9 @@ It also supports **multimodal (vision) input**: you can attach images and PDFs t
 
 | Parameter                   | Type                               | Required | Description                                                                                                                                                                                          |
 | --------------------------- | ---------------------------------- | :------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `llmProvider`               | `string`                           |   Yes    | The AI provider to use, such as `AWS_BEDROCK` or `GEMINI`.                                                                                                                                           |
-| `modelId`                   | `string`                           |   Yes    | The specific model identifier from the chosen provider (e.g., `anthropic.claude-3-sonnet-20240229-v1:0` for Bedrock, or `gemini-1.5-pro-latest` for Gemini).                                             |
+| `llmProvider`               | `string`                           |   Yes    | The AI provider to use, such as `AWS_BEDROCK` or `GEMINI`. Supports **Handlebars templating** — see [Templated Model Selection](#templated-model-selection).                                          |
+| `modelId`                   | `string`                           |   Yes    | The specific model identifier from the chosen provider (e.g., `anthropic.claude-3-sonnet-20240229-v1:0` for Bedrock, or `gemini-1.5-pro-latest` for Gemini). Supports **Handlebars templating** — see [Templated Model Selection](#templated-model-selection). |
+| `fallbacks`                 | `{ llmProvider, modelId, inferenceParameters?, customConfig? }[]` |    No    | An ordered list of fallback models to try if the primary model fails. Each entry's `llmProvider` and `modelId` also support **Handlebars templating** — see [Templated Model Selection](#templated-model-selection). |
 | `promptTemplateId`          | `string`                           |   Yes    | The ID of a versioned, reusable Prompt Template to use for this invocation. The flow will automatically load the latest **published** version of this template.                                        |
 | `inferenceParameters`       | `object`                           |    No    | Controls the generation behavior of the LLM. Includes `temperature`, `maxOutputTokens`, `topP`, `topK`, and `seed`.                                                                                    |
 | `templateContextMappings`   | `object`                           |    No    | Builds dynamic variables for your prompt template by collecting and formatting data from the Flow Context. Each key becomes a variable name (e.g., `chat_history`) available in your prompt.            |
@@ -28,6 +29,33 @@ It also supports **multimodal (vision) input**: you can attach images and PDFs t
 | `customConfig.anthropic_version`| `string`                           |    No    | (Bedrock/Anthropic only) Specify a different Anthropic version string, e.g., `bedrock-2023-05-31`.                                                                                                   |
 | `securityValidatorConfig`   | `object`                           |    No    | An integrated check to prevent prompt leaking or harmful content. Can check for `forbiddenStrings`.                                                                                                  |
 | `outputValidation`          | `object`                           |    No    | Validates the structure of the LLM's JSON output. `requiredFields` is an array of JSONPaths that must exist in the output. If any check fails, it can trigger `retryOnContentError`.                   |
+
+---
+
+### Templated Model Selection {#templated-model-selection}
+
+The model-selection fields — `llmProvider`, `modelId`, and every entry inside `fallbacks[]` — are rendered as **Handlebars templates** against the flow context at runtime, just like `inputMappings`, `customConfig`, and the prompt body. This lets a flow centralize and parameterize model choice instead of hardcoding model IDs in every step.
+
+```json
+{
+  "stepType": "LLM_INVOCATION",
+  "llmProvider": "{{config.providers.primary}}",
+  "modelId": "{{config.llmModels.bedrockSonnet}}",
+  "fallbacks": [
+    {
+      "llmProvider": "{{config.providers.fallback}}",
+      "modelId": "{{config.llmModels.bedrockHaiku}}"
+    }
+  ]
+}
+```
+
+The templates are resolved against the same context available to `templateContextMappings`, so `config.*`, `flow_variables.*`, `steps_output.*`, and `initialContextData.*` are all in scope.
+
+**Notes & guarantees:**
+
+- **Backward compatible.** Plain values without `{{ }}` (e.g. `"AWS_BEDROCK"`, `"gemini-1.5-pro-latest"`) pass through unchanged, so existing flows are unaffected.
+- **Validated after rendering.** A `modelId` that resolves to an empty/undefined value, or an `llmProvider` that does not resolve to a valid provider (`GEMINI`, `ANTHROPIC`, `OPENAI`, `AWS_BEDROCK`, `CUSTOM_LAMBDA`), fails the step with a clear error instead of silently calling the provider with a bad selection.
 
 ---
 

--- a/packages/app-logic/src/allma-core/step-handlers/llm-invocation-handler.ts
+++ b/packages/app-logic/src/allma-core/step-handlers/llm-invocation-handler.ts
@@ -8,6 +8,8 @@ import {
   LlmGenerationRequest,
   MappingEvent,
   LlmGenerationResponse,
+  LLMProviderType,
+  LlmInvocationFallback,
 } from '@allma/core-types';
 import {
   log_debug,
@@ -21,6 +23,7 @@ import { getLlmAdapter } from '../llm-adapters/adapter-registry.js';
 import { TemplateService } from '../template-service.js';
 import { loadPromptTemplate } from '../config-loader.js';
 import { getMediaAttachmentsConfig, resolveLlmMedia } from './llm/media-resolver.js';
+import { renderNestedTemplates } from '../utils/template-renderer.js';
 
 const EXECUTION_TRACES_BUCKET_NAME = process.env[ENV_VAR_NAMES.ALLMA_EXECUTION_TRACES_BUCKET_NAME]!;
 
@@ -113,6 +116,33 @@ function recordModelSuccess(provider: string, modelId: string) {
 }
 // --------------------------------------------------------
 
+const VALID_LLM_PROVIDERS = new Set<string>(Object.values(LLMProviderType));
+
+/**
+ * Validate a model selection (primary or fallback) after Handlebars rendering and return the
+ * typed values. Templated model fields (e.g. `{{config.llmModels.bedrockSonnet}}`) are resolved
+ * before this runs, so a typo or a missing context value would otherwise reach the provider as an
+ * empty/garbage model id. We fail loudly here instead of silently invoking the provider with a bad
+ * selection.
+ */
+function validateResolvedModel(
+  provider: unknown,
+  modelId: unknown,
+  label: string,
+): { provider: LLMProviderType; modelId: string } {
+  if (typeof modelId !== 'string' || modelId.trim() === '') {
+    throw new Error(
+      `${label} modelId resolved to an empty or non-string value after template rendering. Check the model selection template against the flow context.`
+    );
+  }
+  if (typeof provider !== 'string' || !VALID_LLM_PROVIDERS.has(provider)) {
+    throw new Error(
+      `${label} llmProvider resolved to '${String(provider)}', which is not a valid LLM provider (expected one of: ${[...VALID_LLM_PROVIDERS].join(', ')}).`
+    );
+  }
+  return { provider: provider as LLMProviderType, modelId };
+}
+
 function getObjectSizes(obj: Record<string, any>): Record<string, number> {
   const sizes: Record<string, number> = {};
   for (const key of Object.keys(obj)) {
@@ -141,7 +171,33 @@ export const handleLlmInvocation: StepHandler = async (
 
   // The `stepDefinition` is now the single source of truth, fully merged by the processor.
   const { data: llmStepDef } = parsedStepDef;
-  const { llmProvider, promptTemplateId, modelId, fallbacks = [] } = llmStepDef;
+  const { promptTemplateId, fallbacks = [] } = llmStepDef;
+
+  // Resolve the model-selection fields through Handlebars against the flow context, the same way
+  // inputMappings, customConfig, literals, and the prompt body are resolved. This lets flows
+  // centralize/parameterize model choice, e.g. `modelId: "{{config.llmModels.bedrockSonnet}}"`.
+  // `renderNestedTemplates` recurses into `fallbacks[]`, so each entry's `modelId`/`llmProvider`
+  // string leaves are rendered too. Plain strings without `{{ }}` pass through unchanged, so
+  // existing flows are unaffected. The Zod schema already validated these as non-empty strings
+  // pre-render; we re-validate the resolved values below.
+  const modelTemplateSourceData = { ...runtimeState.currentContextData, ...runtimeState, ...stepInput };
+  const renderedModelSelection = (await renderNestedTemplates(
+    { llmProvider: llmStepDef.llmProvider, modelId: llmStepDef.modelId, fallbacks },
+    modelTemplateSourceData,
+    correlationId
+  )) as { llmProvider: unknown; modelId: unknown; fallbacks: LlmInvocationFallback[] };
+
+  const renderedFallbacks = renderedModelSelection.fallbacks ?? [];
+
+  const { provider: llmProvider, modelId } = validateResolvedModel(
+    renderedModelSelection.llmProvider,
+    renderedModelSelection.modelId,
+    'Primary model'
+  );
+  const validatedFallbacks = renderedFallbacks.map((f, idx) => {
+    const { provider, modelId: fbModelId } = validateResolvedModel(f.llmProvider, f.modelId, `Fallback[${idx}]`);
+    return { ...f, llmProvider: provider, modelId: fbModelId };
+  });
 
   // Determine final parameters. Use `inferenceParameters` as the single source of truth.
   const baseParams = llmStepDef.inferenceParameters || {};
@@ -154,7 +210,7 @@ export const handleLlmInvocation: StepHandler = async (
       inferenceParameters: baseParams,
       customConfig: baseCustomConfig
     },
-    ...fallbacks.map(f => ({
+    ...validatedFallbacks.map(f => ({
       provider: f.llmProvider,
       modelId: f.modelId,
       inferenceParameters: f.inferenceParameters || baseParams,

--- a/packages/app-logic/tests/unit/allma-core/step-handlers/llm-invocation-handler.test.ts
+++ b/packages/app-logic/tests/unit/allma-core/step-handlers/llm-invocation-handler.test.ts
@@ -247,4 +247,122 @@ describe('handleLlmInvocation', () => {
       handleLlmInvocation(makeLlmStepDef(), {}, makeRuntimeState())
     ).rejects.toThrow('has no content');
   });
+
+  describe('model selection templating', () => {
+    it('resolves templated modelId and llmProvider from the flow context', async () => {
+      const generateContent = stubAdapter({ responseText: 'ok' });
+
+      await handleLlmInvocation(
+        makeLlmStepDef({
+          llmProvider: '{{config.providers.primary}}',
+          modelId: '{{config.llmModels.bedrockSonnet}}',
+        } as unknown as Partial<StepDefinition>),
+        {},
+        makeRuntimeState({
+          currentContextData: {
+            config: {
+              providers: { primary: LLMProviderType.AWS_BEDROCK },
+              llmModels: { bedrockSonnet: 'anthropic.claude-3-sonnet-20240229-v1:0' },
+            },
+          },
+        })
+      );
+
+      expect(mockedGetLlmAdapter).toHaveBeenCalledWith(LLMProviderType.AWS_BEDROCK);
+      expect(generateContent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: LLMProviderType.AWS_BEDROCK,
+          modelId: 'anthropic.claude-3-sonnet-20240229-v1:0',
+        })
+      );
+    });
+
+    it('resolves a templated fallback entry from the flow context', async () => {
+      const generateContent = vi.fn();
+      generateContent
+        .mockResolvedValueOnce({ success: false, errorMessage: 'primary down' })
+        .mockResolvedValueOnce({
+          success: true,
+          provider: LLMProviderType.AWS_BEDROCK,
+          modelUsed: 'fallback',
+          responseText: 'recovered',
+        });
+      mockedGetLlmAdapter.mockReturnValue({ generateContent } as never);
+
+      const result = await handleLlmInvocation(
+        makeLlmStepDef({
+          modelId: 'primary-fail',
+          fallbacks: [
+            {
+              llmProvider: '{{flow_variables.fallbackProvider}}',
+              modelId: '{{flow_variables.fallbackModel}}',
+            },
+          ],
+        } as unknown as Partial<StepDefinition>),
+        {},
+        makeRuntimeState({
+          currentContextData: {
+            flow_variables: {
+              fallbackProvider: LLMProviderType.AWS_BEDROCK,
+              fallbackModel: 'anthropic.claude-3-haiku-20240307-v1:0',
+            },
+          },
+        })
+      );
+
+      expect(result.outputData).toMatchObject({ llm_response: 'recovered' });
+      expect(generateContent).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          provider: LLMProviderType.AWS_BEDROCK,
+          modelId: 'anthropic.claude-3-haiku-20240307-v1:0',
+        })
+      );
+    });
+
+    it('passes literal model IDs through unchanged', async () => {
+      const generateContent = stubAdapter({ responseText: 'ok' });
+
+      await handleLlmInvocation(
+        makeLlmStepDef({
+          llmProvider: LLMProviderType.GEMINI,
+          modelId: 'gemini-1.5-flash',
+        } as Partial<StepDefinition>),
+        {},
+        makeRuntimeState()
+      );
+
+      expect(generateContent).toHaveBeenCalledWith(
+        expect.objectContaining({ provider: LLMProviderType.GEMINI, modelId: 'gemini-1.5-flash' })
+      );
+    });
+
+    it('throws a clear error when a templated modelId resolves to empty', async () => {
+      stubAdapter({ responseText: 'unused' });
+
+      await expect(
+        handleLlmInvocation(
+          makeLlmStepDef({
+            modelId: '{{config.llmModels.missing}}',
+          } as unknown as Partial<StepDefinition>),
+          {},
+          makeRuntimeState({ currentContextData: { config: { llmModels: {} } } })
+        )
+      ).rejects.toThrow('modelId resolved to an empty or non-string value');
+    });
+
+    it('throws a clear error when a templated llmProvider resolves to an invalid value', async () => {
+      stubAdapter({ responseText: 'unused' });
+
+      await expect(
+        handleLlmInvocation(
+          makeLlmStepDef({
+            llmProvider: '{{config.providers.primary}}',
+          } as unknown as Partial<StepDefinition>),
+          {},
+          makeRuntimeState({ currentContextData: { config: { providers: { primary: 'NOT_A_PROVIDER' } } } })
+        )
+      ).rejects.toThrow('is not a valid LLM provider');
+    });
+  });
 });

--- a/packages/core-types/src/steps/system/llm.ts
+++ b/packages/core-types/src/steps/system/llm.ts
@@ -26,8 +26,28 @@ export const LlmMediaAttachmentSchema = z
   );
 export type LlmMediaAttachment = z.infer<typeof LlmMediaAttachmentSchema>;
 
+/**
+ * A string containing a Handlebars template expression (`{{ ... }}`). Model-selection fields
+ * accept these so a flow can centralize/parameterize model choice (e.g.
+ * `"{{config.llmModels.bedrockSonnet}}"`). The template is rendered against the flow context at
+ * runtime in the LLM_INVOCATION handler, and the resolved value is then validated.
+ */
+const HandlebarsTemplateStringSchema = z
+  .string()
+  .regex(/\{\{.*\}\}/, 'Must be a Handlebars template expression containing {{ ... }}.');
+
+/**
+ * The `llmProvider` field accepts either a concrete provider enum value or a Handlebars template
+ * that resolves to one at runtime. Schema validation runs before rendering, so a templated value
+ * cannot be checked against the enum here — it is validated post-render in the handler.
+ */
+export const TemplatableLlmProviderSchema = z.union([
+  LLMProviderTypeSchema,
+  HandlebarsTemplateStringSchema,
+]);
+
 export const LlmInvocationFallbackSchema = z.object({
-  llmProvider: LLMProviderTypeSchema,
+  llmProvider: TemplatableLlmProviderSchema,
   modelId: z.string().min(1),
   inferenceParameters: LlmParametersSchema.optional(),
   customConfig: z.object({
@@ -39,8 +59,8 @@ export type LlmInvocationFallback = z.infer<typeof LlmInvocationFallbackSchema>;
 export const LlmInvocationStepPayloadSchema = z.object({
   stepType: z.literal(StepTypeSchema.enum.LLM_INVOCATION),
   moduleIdentifier: z.undefined().optional(),
-  llmProvider: LLMProviderTypeSchema,
-  modelId: z.string().min(1).describe("Model ID|text|e.g., gemini-1.5-pro-latest or anthropic.claude-3-sonnet-20240229-v1:0"),
+  llmProvider: TemplatableLlmProviderSchema,
+  modelId: z.string().min(1).describe("Model ID|text|e.g., gemini-1.5-pro-latest or anthropic.claude-3-sonnet-20240229-v1:0 (supports {{...}} templates)"),
   fallbacks: z.array(LlmInvocationFallbackSchema).optional().describe("Fallback Models|json|List of fallback models to use if the primary model fails."),
   promptTemplateId: z.string().min(1).optional().describe("Prompt Template|prompt-select|Select a pre-defined prompt template."),
   templateContextMappings: z.record(TemplateContextMappingItemSchema).optional().describe("Template Context Mappings|json|Map flow context data to variables in the prompt."),


### PR DESCRIPTION
## Problem

The `LLM_INVOCATION` handler read `modelId`, `llmProvider`, and `fallbacks[]` raw from the step definition. Unlike `inputMappings`, `customConfig`, literals, ARN templates, and the prompt body, these model fields never passed through the template renderer — so a value like `{{config.llmModels.bedrockSonnet}}` was sent verbatim to the provider. Flows couldn't centralize/parameterize model selection.

## Change

In `llm-invocation-handler.ts`, after the step def is parsed and before `modelsToTry` is built, render `{ llmProvider, modelId, fallbacks }` through `renderNestedTemplates(...)` against `{ ...currentContextData, ...runtimeState, ...stepInput }` — the same context shape the handler already uses for `templateContextMappings`. This exposes `config.*`, `flow_variables.*`, `steps_output.*`, etc. `renderNestedTemplates` recurses into `fallbacks[]`, so each entry's `modelId`/`llmProvider` is covered too.

### Validation
A new `validateResolvedModel(...)` runs after rendering:
- A `modelId` that resolves to empty/non-string fails with a clear error (never call the provider with an empty model id).
- An `llmProvider` that does not resolve to a valid `LLMProviderType` fails with a clear error.

### Schema relaxation (`@allma/core-types`)
`llmProvider` was a strict `z.nativeEnum`, which **rejected** a templated string at parse time (schema validation runs pre-render). It is now `z.union([LLMProviderTypeSchema, HandlebarsTemplateStringSchema])` for both the primary and fallback provider. Concrete enum values validate exactly as before; templated values are validated post-render in the handler. `modelId` was already `z.string().min(1)`, so templated model IDs already passed.

## Backward compatibility
Plain strings without `{{ }}` pass through Handlebars unchanged, so all existing flows are unaffected.

## Tests
Added cases (Vitest, `packages/app-logic`):
- `modelId`/`llmProvider` resolve from `config.*`
- a `fallbacks[]` entry resolves from `flow_variables.*`
- literal model IDs are unchanged
- an unresolved/empty `modelId` surfaces a clear error
- an invalid resolved `llmProvider` surfaces a clear error

## Docs
- `reference/step-types/01-llm-invocation.md`: updated the `llmProvider`/`modelId` rows, added a `fallbacks` row, and a new **Templated Model Selection** section with an example and the backward-compat/validation guarantees.
- Added a changeset (`@allma/core-types: minor`).

## Verification
- `tsc --noEmit` on app-logic + core-types: clean
- app-logic step-handler tests: 105 pass (16 in the LLM suite)
- ESLint on changed files: clean
- `npm run build --prefix docs.allma.dev`: succeeds (broken-link check passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166XdgWdq6KUySXnjiBe5r9