### PR TITLE
fix(executions): page past step records in flow-executions list

### DIFF
--- a/.changeset/fix-list-executions-gsi-pollution.md
+++ b/.changeset/fix-list-executions-gsi-pollution.md
@@ -1,0 +1,15 @@
+---
+---
+
+fix(executions): restore the flow-executions list for busy flows.
+
+`listExecutions` queries `GSI_ByFlow_StartTime` (keyed on `flowDefinitionId` + `startTime`) with a
+`Limit` and a `FilterExpression` on `itemType`. The step-statistics work denormalized
+`flowDefinitionId` onto step-execution records, which — combined with their existing `startTime` —
+pulled every step record into that index. Because DynamoDB applies `Limit` before the filter, busy
+flows returned pages made entirely of (filtered-out) step records, so the API responded with
+`items: []` and those flows' executions disappeared from the admin UI. The service now pages through
+the index, accumulating matching flow-execution records until the requested page is filled or the
+partition is exhausted, and derives the `nextToken` from the last record actually returned.
+
+(`allma-app-logic` is private and unpublished, so this changeset intentionally bumps no package.)

--- a/.changeset/fix-list-executions-gsi-pollution.md
+++ b/.changeset/fix-list-executions-gsi-pollution.md
@@ -1,4 +1,5 @@
 ---
+"@allma/core-cdk": patch
 ---
 
 fix(executions): restore the flow-executions list for busy flows.
@@ -12,4 +13,6 @@ flows returned pages made entirely of (filtered-out) step records, so the API re
 the index, accumulating matching flow-execution records until the requested page is filled or the
 partition is exhausted, and derives the `nextToken` from the last record actually returned.
 
-(`allma-app-logic` is private and unpublished, so this changeset intentionally bumps no package.)
+The fix lives in `allma-app-logic`, which is private/unpublished but is compiled into
+`@allma/core-cdk`'s shipped `dist-logic/` at build time — so the bump is recorded against
+`@allma/core-cdk`.

--- a/packages/app-logic/src/allma-admin/services/execution-monitoring.service.ts
+++ b/packages/app-logic/src/allma-admin/services/execution-monitoring.service.ts
@@ -358,9 +358,7 @@ export const ExecutionMonitoringService = {
         const queryParams: QueryCommandInput = {
             TableName: EXECUTION_LOG_TABLE_NAME,
             IndexName: 'GSI_ByFlow_StartTime',
-            Limit: pagination.limit,
             ScanIndexForward: false,
-            ExclusiveStartKey: exclusiveStartKey,
             KeyConditionExpression: 'flowDefinitionId = :pk',
             FilterExpression: filterExpressions.join(' AND '),
             ExpressionAttributeValues: expressionAttributeValues,
@@ -369,8 +367,52 @@ export const ExecutionMonitoringService = {
             queryParams.ExpressionAttributeNames = expressionAttributeNames;
         }
 
-        const { Items, LastEvaluatedKey } = await ddbDocClient.send(new QueryCommand(queryParams));
-        const items: FlowExecutionSummary[] = (Items || []).map(item => ({
+        // GSI_ByFlow_StartTime is keyed on (flowDefinitionId, startTime). Step-execution records are
+        // denormalized with both of those attributes, so they also land in this index even though
+        // they are filtered out by `itemType`. Because DynamoDB applies `Limit` *before* the
+        // FilterExpression, a single bounded query can return a page made entirely of step records,
+        // yielding an empty result for busy flows. We therefore page through the index, accumulating
+        // matching flow-execution records until the requested page size is filled or the partition is
+        // exhausted, and derive the nextToken from the last record we actually return.
+        const collected: Record<string, any>[] = [];
+        let lastEvaluatedKey = exclusiveStartKey;
+        let nextToken: string | undefined;
+        // Safeguard against unbounded scanning of a partition dominated by step records.
+        const MAX_PAGES = 20;
+
+        for (let page = 0; page < MAX_PAGES; page++) {
+            const { Items, LastEvaluatedKey }: QueryCommandOutput = await ddbDocClient.send(
+                new QueryCommand({ ...queryParams, ExclusiveStartKey: lastEvaluatedKey })
+            );
+
+            for (const item of Items || []) {
+                collected.push(item);
+                if (collected.length === pagination.limit) {
+                    // Resume the next page immediately after this record. ExclusiveStartKey for a GSI
+                    // query must carry both the index keys and the base-table primary keys.
+                    nextToken = Buffer.from(JSON.stringify({
+                        flowDefinitionId,
+                        startTime: item.startTime,
+                        flowExecutionId: item.flowExecutionId,
+                        eventTimestamp_stepInstanceId_attempt: item.eventTimestamp_stepInstanceId_attempt,
+                    })).toString('base64');
+                    break;
+                }
+            }
+
+            if (nextToken) break;
+
+            lastEvaluatedKey = LastEvaluatedKey;
+            if (!lastEvaluatedKey) break;
+
+            // Hit the page cap before filling the page: hand back the raw cursor so the caller can
+            // continue from exactly where we stopped rather than silently dropping executions.
+            if (page === MAX_PAGES - 1) {
+                nextToken = Buffer.from(JSON.stringify(lastEvaluatedKey)).toString('base64');
+            }
+        }
+
+        const items: FlowExecutionSummary[] = collected.map(item => ({
             flowExecutionId: item.flowExecutionId,
             status: item.status,
             startTime: item.startTime,
@@ -383,7 +425,7 @@ export const ExecutionMonitoringService = {
 
         return {
             items,
-            ...(LastEvaluatedKey && { nextToken: Buffer.from(JSON.stringify(LastEvaluatedKey)).toString('base64') })
+            ...(nextToken && { nextToken })
         };
     }
 

--- a/packages/app-logic/tests/unit/allma-admin/execution-monitoring.service.test.ts
+++ b/packages/app-logic/tests/unit/allma-admin/execution-monitoring.service.test.ts
@@ -1,0 +1,74 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { mockClient } from '../_helpers/aws-mock.js';
+
+// The service reads the table name at module load, so set it before importing.
+process.env.ALLMA_FLOW_EXECUTION_LOG_TABLE_NAME = 'test-exec-log-table';
+
+const { ExecutionMonitoringService } = await import(
+  '../../../src/allma-admin/services/execution-monitoring.service.js'
+);
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+const flowRecord = (id: string) => ({
+  itemType: 'ALLMA_FLOW_EXECUTION_RECORD',
+  flowExecutionId: id,
+  flowDefinitionId: 'flow-a',
+  flowDefinitionVersion: 1,
+  status: 'COMPLETED',
+  startTime: '2026-06-22T10:00:00.000Z',
+  endTime: '2026-06-22T10:00:05.000Z',
+  eventTimestamp_stepInstanceId_attempt: '__METADATA__',
+});
+
+beforeEach(() => {
+  ddbMock.reset();
+});
+
+describe('listExecutions', () => {
+  it('keeps paging when a page is fully consumed by the server-side itemType filter', async () => {
+    // GSI_ByFlow_StartTime now also contains step records (denormalized with flowDefinitionId +
+    // startTime). DynamoDB applies Limit before the FilterExpression, so the first page can come
+    // back empty-but-not-exhausted: Items=[] with a LastEvaluatedKey. The service must follow the
+    // cursor instead of returning items:[] — this is the regression we are guarding against.
+    ddbMock
+      .on(QueryCommand)
+      .resolvesOnce({ Items: [], LastEvaluatedKey: { flowExecutionId: 'cursor-1' } as any })
+      .resolvesOnce({ Items: [flowRecord('exec-1')] });
+
+    const result = await ExecutionMonitoringService.listExecutions(
+      'flow-a',
+      {},
+      { limit: 25 }
+    );
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]!.flowExecutionId).toBe('exec-1');
+    expect(result.nextToken).toBeUndefined();
+    expect(ddbMock.commandCalls(QueryCommand)).toHaveLength(2);
+  });
+
+  it('returns an item-derived nextToken when the requested page fills mid-partition', async () => {
+    ddbMock
+      .on(QueryCommand)
+      .resolves({ Items: [flowRecord('exec-1'), flowRecord('exec-2')], LastEvaluatedKey: { x: 1 } as any });
+
+    const result = await ExecutionMonitoringService.listExecutions(
+      'flow-a',
+      {},
+      { limit: 2 }
+    );
+
+    expect(result.items).toHaveLength(2);
+    expect(result.nextToken).toBeDefined();
+    const decoded = JSON.parse(Buffer.from(result.nextToken!, 'base64').toString('utf-8'));
+    // The cursor must carry both GSI keys and base-table keys to be a valid ExclusiveStartKey.
+    expect(decoded).toMatchObject({
+      flowDefinitionId: 'flow-a',
+      flowExecutionId: 'exec-2',
+      startTime: '2026-06-22T10:00:00.000Z',
+      eventTimestamp_stepInstanceId_attempt: '__METADATA__',
+    });
+  });
+});


### PR DESCRIPTION
## Problem

The flow-executions list API returned `items: []` for flows that clearly exist in DynamoDB (e.g. `optiroq-process-project-document`), so those flows' executions disappeared from the admin UI.

## Root cause

`ExecutionMonitoringService.listExecutions` queries `GSI_ByFlow_StartTime`, keyed on `(flowDefinitionId, startTime)`, with `Limit` + `FilterExpression: itemType = ALLMA_FLOW_EXECUTION_RECORD`.

The per-step execution statistics work (#60) **denormalized `flowDefinitionId` onto every step-execution record** so step stats could be queried per flow. Step records already carried `startTime`, so they now satisfy *both* key attributes of `GSI_ByFlow_StartTime` and flood that index (step records vastly outnumber flow records). They still lack `flow_sort_key`, so the sibling `GSI_ByFlow` index stayed clean — only `GSI_ByFlow_StartTime` was polluted.

Because **DynamoDB applies `Limit` before the `FilterExpression`**, the query read the N most-recent items by `startTime` — for a busy flow these are all step records — then filtered them all out, returning an empty page. Quiet flows still showed; busy ones vanished, matching "some flows are not displayed."

## Fix

Read-side, backward-compatible (no GSI recreation/backfill, repairs already-written data):

- Drop the per-query `Limit` and page through `GSI_ByFlow_StartTime`, accumulating matching flow-execution records until the requested page is filled or the partition is exhausted (with a `MAX_PAGES` safeguard that hands back the raw cursor rather than dropping executions).
- Derive `nextToken` from the last record actually returned, carrying both the GSI keys and the base-table primary keys so it remains a valid `ExclusiveStartKey`.

Chose a read-side fix over making the GSI sparse because the latter requires recreating the index (downtime + backfill) and would not repair records already written.

## Tests

Added `execution-monitoring.service.test.ts` covering the empty-but-not-exhausted page case (the regression) and the item-derived `nextToken`.

## Changeset

The fix lives in `allma-app-logic`, which is private/unpublished — but its compiled output is bundled into `@allma/core-cdk`'s shipped `dist-logic/` at build time. So the fix ships in `@allma/core-cdk`, and the changeset records a `patch` bump against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
