### PR TITLE
feat(llm): optional Vertex AI backend for Gemini invocations

### DIFF
--- a/.changeset/gemini-vertex-ai-support.md
+++ b/.changeset/gemini-vertex-ai-support.md
@@ -1,0 +1,19 @@
+---
+"@allma/core-types": minor
+"@allma/core-cdk": minor
+---
+
+Add optional support for calling Gemini through **Vertex AI** instead of the
+key-based Gemini Developer API, to escape the low rate limits of API-key access.
+
+The `LLM_INVOCATION` Gemini adapter now constructs a Vertex AI client when
+`gemini.useVertex` is set in the stage config (new `gemini` block:
+`useVertex`, `gcpProjectId`, `gcpLocation`, optional `serviceAccountKeySecretArn`).
+Authentication uses a GCP service-account key from Secrets Manager when provided,
+otherwise Application Default Credentials / Workload Identity Federation. The CDK
+construct injects the new env vars (`GEMINI_USE_VERTEX`, `GCP_PROJECT_ID`,
+`GCP_LOCATION`, `GCP_SA_KEY_SECRET_ARN`) onto the iterative step processor and
+grants read access to the service-account key secret when configured.
+
+Fully backward-compatible and feature-flagged: with `useVertex` unset (the
+default), Gemini keeps using the existing API key from `aiApiKeySecretArn`.

--- a/documents/wip/gemini-vertex-migration.md
+++ b/documents/wip/gemini-vertex-migration.md
@@ -1,0 +1,119 @@
+# Migrating Gemini from API Key → Vertex AI
+
+**Status:** In progress
+**Author:** Platform / AI agent
+**Scope:** Platform only (`packages/*`, `core-cdk`). Backward-compatible, feature-flagged.
+
+---
+
+## 1. Motivation
+
+The Gemini Developer API (AI Studio **API key**) has low per-project rate limits
+(RPM / TPM / RPD) that throttle production flows. **Vertex AI** ("Vertex" /
+"enterprise" mode) offers dramatically higher quota (dynamic shared quota +
+optional Provisioned Throughput), SLAs, data-residency control, no
+prompt-data-for-training clause, and unified GCP IAM governance.
+
+We want `LLM_INVOCATION` steps with `provider: GEMINI` to be able to call Gemini
+**through Vertex AI** instead of the key-based Developer API.
+
+## 2. Key enabler — we are already 90% there
+
+The codebase uses the **unified `@google/genai` SDK** (`^1.47.0` in `app-logic`,
+`^1.28.0` in `core-cdk`), which speaks **both** backends from the same surface:
+
+| Backend | Constructor |
+| --- | --- |
+| Gemini Developer API (today) | `new GoogleGenAI({ apiKey })` |
+| Vertex AI (target) | `new GoogleGenAI({ vertexai: true, project, location })` |
+
+Everything downstream of the constructor — `client.models.generateContent(...)`,
+JSON mode (`responseMimeType`), safety settings, `inlineData` media, token usage,
+retries — is **backend-agnostic and unchanged**.
+
+The whole Gemini surface is one file:
+`packages/app-logic/src/allma-core/llm-adapters/gemini-adapter.ts`. The only
+backend-specific code is `getClient()` (lines ~70-75).
+
+## 3. The one real challenge — authentication from AWS Lambda
+
+Vertex does **not** accept the AI Studio API key. It authenticates via Google IAM
+(short-lived OAuth tokens via Application Default Credentials). From AWS Lambda
+there are two ways to bridge:
+
+| | **Option A — Service Account key (JSON)** | **Option B — Workload Identity Federation (WIF)** ✅ prod |
+| --- | --- | --- |
+| Stored secret | SA private-key JSON in Secrets Manager | Credential-config file (no private key) |
+| How | SDK signs JWT → OAuth token | AWS creds → GCP STS → impersonate SA → OAuth token |
+| Security | ⚠️ long-lived key, must rotate | ✅ no static key, short-lived tokens |
+| Setup | Lower | Higher (one-time WIF pool/provider + IAM binding) |
+| Google's stance | Discouraged | Preferred for external clouds |
+
+**Decision:** support both in code. Option A unblocks an immediate proof of
+concept; Option B (WIF) is the production target. If no SA-key secret is
+configured, the adapter falls back to ADC (works with WIF via
+`GOOGLE_APPLICATION_CREDENTIALS` pointing at a bundled credential-config file).
+
+## 4. Model-ID caveat
+
+Vertex and the Developer API do **not** share every model alias. Developer-API
+`-latest` aliases (e.g. `gemini-1.5-pro-latest`) are generally **invalid on
+Vertex**, which wants pinned IDs / its own aliases (e.g. `gemini-2.0-flash`,
+`gemini-1.5-pro-002`). Because `modelId` is now templated from config
+(`{{config.llmModels.*}}`, via the templated-model-selection feature), this is
+mostly fixed by **updating config values**, not code. Audit hardcoded `-latest`
+IDs (incl. admin step docs).
+
+## 5. Implementation
+
+### 5.1 Code — `core-types`
+- `ENV_VAR_NAMES` (`src/common/shared.ts`): add
+  `GEMINI_USE_VERTEX`, `GCP_PROJECT_ID`, `GCP_LOCATION`, `GCP_SA_KEY_SECRET_ARN`.
+
+### 5.2 Code — `app-logic` (`gemini-adapter.ts`)
+- Make `getClient()` config-driven:
+  - `GEMINI_USE_VERTEX === 'true'` → `new GoogleGenAI({ vertexai: true, project, location, googleAuthOptions? })`.
+    - If `GCP_SA_KEY_SECRET_ARN` set → fetch JSON from Secrets Manager, pass
+      `googleAuthOptions: { credentials: { client_email, private_key }, projectId }`.
+    - Else → omit `googleAuthOptions`, rely on ADC / WIF.
+  - else → existing `new GoogleGenAI({ apiKey })` path (unchanged default).
+- Keep the singleton cache; the API-key path and secret JSON shape
+  `{ GeminiApiKey }` stay intact.
+
+### 5.3 Infra — `core-cdk`
+- `StageConfig` (`lib/config/stack-config.ts`): add optional `gemini` block:
+  `{ useVertex?, gcpProjectId?, gcpLocation?, serviceAccountKeySecretArn? }`.
+- `compute.ts`: inject the four env vars onto the **iterative step processor**
+  Lambda (mirroring the existing `AI_API_KEY_SECRET_ARN` injection); grant
+  `secretsmanager:GetSecretValue` on the SA-key secret when present.
+- `allma-stack.ts`: light validation — if `gemini.useVertex`, require
+  `gcpProjectId` and `gcpLocation`.
+- **No VPC/networking change** — Vertex is a public HTTPS Google API.
+
+### 5.4 GCP-side setup (one-time, per environment; manage in Terraform)
+1. Project + enable Vertex AI API (`aiplatform.googleapis.com`) + billing.
+2. Service account with `roles/aiplatform.user` (least privilege).
+3. **Option A:** create + download JSON key → put in AWS Secrets Manager →
+   set `serviceAccountKeySecretArn`.
+   **Option B:** create Workload Identity Pool + AWS provider, bind the Lambda
+   execution-role ARN to impersonate the SA, generate the credential-config file,
+   bundle it and set `GOOGLE_APPLICATION_CREDENTIALS`.
+
+## 6. Rollout
+1. Land code (flag default **off** → no behavior change).
+2. GCP setup; stand up Option A for a dev stage.
+3. Update `config.llmModels.*` to Vertex-valid model IDs.
+4. Deploy dev, run real `LLM_INVOCATION` flows (JSON mode + media).
+5. Stand up WIF (Option B) for prod; flip `gemini.useVertex=true` per stage.
+6. Instant rollback = flip the flag back.
+
+## 7. Versioning
+New backward-compatible config + env constants + SDK capability → **minor**
+changeset bumping `@allma/core-cdk` (it bundles `app-logic`) and
+`@allma/core-types`. Not a major (no breaking change; default path unchanged).
+
+## 8. Complexity
+**Low–Medium**, ~1–3 days. Code blast radius is tiny (one constructor behind a
+flag). The real work is the GCP IAM/WIF setup and model-ID normalization. The
+single gating risk to validate early: **one real `generateContent` from a
+deployed Lambda via WIF** (the token exchange).

--- a/packages/app-logic/src/allma-core/llm-adapters/gemini-adapter.ts
+++ b/packages/app-logic/src/allma-core/llm-adapters/gemini-adapter.ts
@@ -11,7 +11,18 @@ import { log_info, log_debug, log_warn, log_error } from '@allma/core-sdk';
 
 const secretsManagerClient = new SecretsManagerClient({});
 const geminiApiKeySecretArn = process.env[ENV_VAR_NAMES.AI_API_KEY_SECRET_ARN];
+
+// --- Vertex AI configuration ---
+// When GEMINI_USE_VERTEX is 'true', the adapter talks to Vertex AI (Google IAM /
+// OAuth) instead of the key-based Developer API. The same @google/genai SDK
+// serves both backends, so only client construction differs.
+const useVertex = process.env[ENV_VAR_NAMES.GEMINI_USE_VERTEX] === 'true';
+const gcpProjectId = process.env[ENV_VAR_NAMES.GCP_PROJECT_ID];
+const gcpLocation = process.env[ENV_VAR_NAMES.GCP_LOCATION];
+const gcpSaKeySecretArn = process.env[ENV_VAR_NAMES.GCP_SA_KEY_SECRET_ARN];
+
 let cachedApiKey: string | null = null;
+let cachedSaCredentials: { client_email: string; private_key: string } | null = null;
 let genAI: GoogleGenAI | null = null;
 
 const DEFAULT_SAFETY_SETTINGS: SafetySetting[] = [
@@ -63,12 +74,66 @@ export class GeminiAdapter implements LlmProviderAdapter {
   }
 
   /**
+   * Retrieves a GCP service-account key (`{ client_email, private_key }`) from
+   * AWS Secrets Manager for authenticating to Vertex AI. Cached per execution
+   * context. Only used when `GCP_SA_KEY_SECRET_ARN` is configured; otherwise the
+   * SDK authenticates via Application Default Credentials / Workload Identity
+   * Federation.
+   * @param correlationId - Optional ID for logging.
+   */
+  private async getServiceAccountCredentials(correlationId?: string): Promise<{ client_email: string; private_key: string }> {
+    if (cachedSaCredentials) return cachedSaCredentials;
+    log_info('Fetching GCP service-account key from Secrets Manager', { secretArn: gcpSaKeySecretArn }, correlationId);
+    const command = new GetSecretValueCommand({ SecretId: gcpSaKeySecretArn });
+    try {
+      const data = await secretsManagerClient.send(command);
+      if (data.SecretString) {
+        const key = JSON.parse(data.SecretString);
+        if (key.client_email && key.private_key) {
+          cachedSaCredentials = { client_email: key.client_email, private_key: key.private_key };
+          log_info('Successfully fetched and cached GCP service-account key.', {}, correlationId);
+          return cachedSaCredentials;
+        }
+      }
+      throw new Error('client_email/private_key not found in the GCP service-account key secret.');
+    } catch (error: any) {
+      log_error('Failed to retrieve GCP service-account key from Secrets Manager', { error: error.message }, correlationId);
+      throw error;
+    }
+  }
+
+  /**
    * Initializes and returns a singleton instance of the GoogleGenAI client.
+   * Constructs a Vertex AI client when `GEMINI_USE_VERTEX` is enabled, otherwise
+   * the key-based Gemini Developer API client. All downstream generation logic is
+   * identical across both backends.
    * @param correlationId - Optional ID for logging.
    * @returns An instance of the GoogleGenAI client.
    */
   private async getClient(correlationId?: string): Promise<GoogleGenAI> {
     if (genAI) return genAI;
+
+    if (useVertex) {
+      if (!gcpProjectId || !gcpLocation) {
+        throw new Error('Vertex AI mode (GEMINI_USE_VERTEX=true) requires GCP_PROJECT_ID and GCP_LOCATION to be set.');
+      }
+      const googleAuthOptions = gcpSaKeySecretArn
+        ? { credentials: await this.getServiceAccountCredentials(correlationId), projectId: gcpProjectId }
+        : undefined;
+      log_info('GeminiAdapter: initializing Vertex AI client', {
+        project: gcpProjectId,
+        location: gcpLocation,
+        auth: gcpSaKeySecretArn ? 'service-account-key' : 'application-default-credentials',
+      }, correlationId);
+      genAI = new GoogleGenAI({
+        vertexai: true,
+        project: gcpProjectId,
+        location: gcpLocation,
+        ...(googleAuthOptions && { googleAuthOptions }),
+      });
+      return genAI;
+    }
+
     const apiKey = await this.getApiKey(correlationId);
     genAI = new GoogleGenAI({ apiKey });
     return genAI;

--- a/packages/app-logic/tests/unit/allma-core/llm-adapters/gemini-adapter.vertex.test.ts
+++ b/packages/app-logic/tests/unit/allma-core/llm-adapters/gemini-adapter.vertex.test.ts
@@ -1,0 +1,81 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
+import { LLMProviderType, type LlmGenerationRequest } from '@allma/core-types';
+import { mockClient, resetAwsClientMocks } from '../../_helpers/aws-mock.js';
+
+// Vertex AI mode is selected via env vars that the adapter reads at import time,
+// so they must be set before the module is imported. This lives in its own file
+// (separate module registry) to avoid colliding with the API-key-mode suite.
+const generateContentMock = vi.hoisted(() => vi.fn());
+const googleGenAiCtor = vi.hoisted(() => vi.fn());
+
+vi.hoisted(() => {
+  process.env.GEMINI_USE_VERTEX = 'true';
+  process.env.GCP_PROJECT_ID = 'my-gcp-project';
+  process.env.GCP_LOCATION = 'us-central1';
+  process.env.GCP_SA_KEY_SECRET_ARN = 'arn:aws:secretsmanager:us-east-1:123:secret:gcp-sa-key';
+});
+
+vi.mock('@google/genai', () => ({
+  GoogleGenAI: vi.fn().mockImplementation((opts: unknown) => {
+    googleGenAiCtor(opts);
+    return { models: { generateContent: generateContentMock } };
+  }),
+  HarmCategory: {
+    HARM_CATEGORY_HARASSMENT: 'HARM_CATEGORY_HARASSMENT',
+    HARM_CATEGORY_HATE_SPEECH: 'HARM_CATEGORY_HATE_SPEECH',
+    HARM_CATEGORY_SEXUALLY_EXPLICIT: 'HARM_CATEGORY_SEXUALLY_EXPLICIT',
+    HARM_CATEGORY_DANGEROUS_CONTENT: 'HARM_CATEGORY_DANGEROUS_CONTENT',
+  },
+  HarmBlockThreshold: { BLOCK_MEDIUM_AND_ABOVE: 'BLOCK_MEDIUM_AND_ABOVE' },
+}));
+
+import { GeminiAdapter } from '../../../../src/allma-core/llm-adapters/gemini-adapter.js';
+
+const secretsMock = mockClient(SecretsManagerClient);
+
+const makeRequest = (overrides: Partial<LlmGenerationRequest> = {}): LlmGenerationRequest =>
+  ({
+    provider: LLMProviderType.GEMINI,
+    modelId: 'gemini-2.0-flash',
+    prompt: 'Hello',
+    correlationId: 'corr-vertex',
+    ...overrides,
+  }) as LlmGenerationRequest;
+
+describe('GeminiAdapter (Vertex AI mode)', () => {
+  const adapter = new GeminiAdapter();
+
+  beforeEach(() => {
+    resetAwsClientMocks(secretsMock);
+    secretsMock.on(GetSecretValueCommand).resolves({
+      SecretString: JSON.stringify({ client_email: 'sa@my-gcp-project.iam.gserviceaccount.com', private_key: 'PEM' }),
+    });
+    generateContentMock.mockReset();
+    googleGenAiCtor.mockReset();
+  });
+
+  it('constructs a Vertex client with project/location and service-account credentials', async () => {
+    generateContentMock.mockResolvedValue({
+      text: 'hi from vertex',
+      candidates: [{ finishReason: 'STOP' }],
+      usageMetadata: { promptTokenCount: 4, candidatesTokenCount: 2 },
+    });
+
+    const result = await adapter.generateContent(makeRequest());
+
+    expect(result).toMatchObject({ success: true, responseText: 'hi from vertex' });
+    expect(googleGenAiCtor).toHaveBeenCalledTimes(1);
+    expect(googleGenAiCtor.mock.calls[0][0]).toMatchObject({
+      vertexai: true,
+      project: 'my-gcp-project',
+      location: 'us-central1',
+      googleAuthOptions: {
+        projectId: 'my-gcp-project',
+        credentials: { client_email: 'sa@my-gcp-project.iam.gserviceaccount.com', private_key: 'PEM' },
+      },
+    });
+    // The Vertex client must never be constructed with an apiKey.
+    expect(googleGenAiCtor.mock.calls[0][0]).not.toHaveProperty('apiKey');
+  });
+});

--- a/packages/core-cdk/lib/allma-stack.ts
+++ b/packages/core-cdk/lib/allma-stack.ts
@@ -68,6 +68,9 @@ export class AllmaStack extends cdk.Stack {
     if (stageConfig.aiApiKeySecretArn === 'YOUR_AI_API_KEY_SECRET_ARN') {
       throw new Error('The `aiApiKeySecretArn` must be overridden in your stageConfig.');
     }
+    if (stageConfig.gemini?.useVertex && (!stageConfig.gemini.gcpProjectId || !stageConfig.gemini.gcpLocation)) {
+      throw new Error('When `gemini.useVertex` is true, both `gemini.gcpProjectId` and `gemini.gcpLocation` must be set in your stageConfig.');
+    }
 
     let configAssetHash: string | undefined = undefined;
 

--- a/packages/core-cdk/lib/config/stack-config.ts
+++ b/packages/core-cdk/lib/config/stack-config.ts
@@ -263,6 +263,49 @@ export interface StageConfig {
   aiApiKeySecretArn: string;
 
   /**
+   * Optional configuration for calling Gemini through **Vertex AI** instead of
+   * the key-based Gemini Developer API. Vertex offers far higher quota/limits,
+   * SLAs, and enterprise governance. When omitted (or `useVertex` is falsy), the
+   * Gemini adapter keeps using the API key from {@link aiApiKeySecretArn}.
+   *
+   * @see documents/wip/gemini-vertex-migration.md
+   */
+  gemini?: {
+    /**
+     * Route `provider: GEMINI` LLM invocations through Vertex AI.
+     * @default false
+     */
+    useVertex?: boolean;
+
+    /**
+     * The Google Cloud project ID that hosts Vertex AI.
+     * Required when `useVertex` is true.
+     * @example 'my-gcp-project'
+     */
+    gcpProjectId?: string;
+
+    /**
+     * The Vertex AI location/region requests are sent to.
+     * Required when `useVertex` is true.
+     * @example 'us-central1'
+     */
+    gcpLocation?: string;
+
+    /**
+     * Optional ARN of a Secrets Manager secret holding a GCP **service-account
+     * key** JSON (`{ client_email, private_key, ... }`). Provide this for the
+     * quickest path to a working Vertex call.
+     *
+     * Leave undefined to authenticate via Application Default Credentials /
+     * Workload Identity Federation (the recommended, key-less production setup),
+     * in which case the credential-config file must be made available to the
+     * Lambda (e.g. via `GOOGLE_APPLICATION_CREDENTIALS`).
+     * @example 'arn:aws:secretsmanager:us-east-1:123456789012:secret:gcp-sa-key'
+     */
+    serviceAccountKeySecretArn?: string;
+  };
+
+  /**
    * Optional configuration for AWS Simple Email Service (SES).
    * Required for email sending and receiving features.
    */

--- a/packages/core-cdk/lib/constructs/compute.ts
+++ b/packages/core-cdk/lib/constructs/compute.ts
@@ -94,6 +94,16 @@ export class AllmaCompute extends Construct {
       }));
     }
 
+    // Allow reading the GCP service-account key secret when Gemini is routed
+    // through Vertex AI with key-based auth. (WIF auth needs no secret.)
+    if (stageConfig.gemini?.serviceAccountKeySecretArn) {
+      this.orchestrationLambdaRole.addToPolicy(new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['secretsmanager:GetSecretValue'],
+        resources: [stageConfig.gemini.serviceAccountKeySecretArn],
+      }));
+    }
+
     this.orchestrationLambdaRole.addToPolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
       actions: ['secretsmanager:GetSecretValue'],
@@ -169,6 +179,10 @@ export class AllmaCompute extends Construct {
       {
         ...commonEnvVars,
         [ENV_VAR_NAMES.AI_API_KEY_SECRET_ARN!]: stageConfig.aiApiKeySecretArn || '',
+        [ENV_VAR_NAMES.GEMINI_USE_VERTEX]: stageConfig.gemini?.useVertex ? 'true' : 'false',
+        [ENV_VAR_NAMES.GCP_PROJECT_ID]: stageConfig.gemini?.gcpProjectId || '',
+        [ENV_VAR_NAMES.GCP_LOCATION]: stageConfig.gemini?.gcpLocation || '',
+        [ENV_VAR_NAMES.GCP_SA_KEY_SECRET_ARN]: stageConfig.gemini?.serviceAccountKeySecretArn || '',
         [ENV_VAR_NAMES.ALLMA_FLOW_START_REQUEST_QUEUE_URL!]: props.flowStartRequestQueue?.queueUrl || '',
         [ENV_VAR_NAMES.MAX_CONCURRENT_STEP_EXECUTIONS]: stageConfig.orchestratorConcurrency ? String(stageConfig.orchestratorConcurrency) : '',
       },

--- a/packages/core-types/src/common/shared.ts
+++ b/packages/core-types/src/common/shared.ts
@@ -42,6 +42,16 @@ export const ENV_VAR_NAMES = {
     // Secrets and Credentials
     AI_API_KEY_SECRET_ARN: "AI_API_KEY_SECRET_ARN",
     COGNITO_USER_POOL_ID: "COGNITO_USER_POOL_ID",
+
+    // Gemini via Vertex AI
+    // When 'true', the Gemini adapter calls Vertex AI instead of the key-based
+    // Developer API. The remaining vars supply the Vertex project/location and
+    // (optionally) a service-account key secret; omit the key secret to rely on
+    // Application Default Credentials / Workload Identity Federation.
+    GEMINI_USE_VERTEX: "GEMINI_USE_VERTEX",
+    GCP_PROJECT_ID: "GCP_PROJECT_ID",
+    GCP_LOCATION: "GCP_LOCATION",
+    GCP_SA_KEY_SECRET_ARN: "GCP_SA_KEY_SECRET_ARN",
     EVENTBRIDGE_SCHEDULER_ROLE_ARN: "EVENTBRIDGE_SCHEDULER_ROLE_ARN",
 
     // System Limits and Behavior Configs


### PR DESCRIPTION
## Why

The key-based Gemini Developer API (AI Studio API key) has low per-project rate limits (RPM/TPM/RPD) that throttle production flows. **Vertex AI** offers far higher quota (dynamic shared quota + optional Provisioned Throughput), SLAs, data-residency control, and unified GCP IAM governance.

## What

Opt-in path to route `provider: GEMINI` invocations through **Vertex AI**, using the same `@google/genai` SDK already in the codebase — so only client construction differs. **Default off, fully backward-compatible.**

- **`gemini-adapter.ts`** — `getClient()` builds a Vertex client (`vertexai: true`, `project`, `location`) when `GEMINI_USE_VERTEX=true`. Auth uses a GCP service-account key fetched from Secrets Manager when `GCP_SA_KEY_SECRET_ARN` is set, otherwise Application Default Credentials / Workload Identity Federation. The API-key path is untouched and remains the default. All downstream generation logic (JSON mode, safety, `inlineData` media, retries, token usage) is unchanged.
- **`core-types`** — new `ENV_VAR_NAMES`: `GEMINI_USE_VERTEX`, `GCP_PROJECT_ID`, `GCP_LOCATION`, `GCP_SA_KEY_SECRET_ARN`.
- **`core-cdk`** — new optional `gemini` stage-config block (`useVertex`, `gcpProjectId`, `gcpLocation`, `serviceAccountKeySecretArn`); injects the env vars onto the iterative step processor Lambda; grants `secretsmanager:GetSecretValue` on the SA-key secret when configured; validates project/location when `useVertex` is true.

## Migration plan

See `documents/wip/gemini-vertex-migration.md` for the full plan, auth options (SA-key vs. Workload Identity Federation), model-ID caveats, and rollout/rollback.

## Operator notes

- **Model IDs:** Vertex rejects Developer-API `-latest` aliases — use pinned IDs (`gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.0-flash`).
- **Rollback:** flip `gemini.useVertex` back to `false` and redeploy; the API-key path is preserved.
- **Prod hardening (follow-up):** move to Workload Identity Federation and drop `serviceAccountKeySecretArn` (adapter falls back to ADC automatically — no code change).

## Testing

- New `gemini-adapter.vertex.test.ts` verifies the Vertex client is constructed with `vertexai`/project/location + SA credentials and **no** `apiKey`.
- Existing API-key adapter suite unchanged and passing (9/9 total).
- `core-types`, `core-cdk`, `app-logic` build clean; ESLint clean on all changed files.

## Versioning

Minor bump on `@allma/core-types` + `@allma/core-cdk` (new backward-compatible surface). Not a major — default path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)