### PR TITLE
feat(executions): live execution progress with checkpoints (phase 1)

### DIFF
--- a/.changeset/realtime-execution-progress-phase1.md
+++ b/.changeset/realtime-execution-progress-phase1.md
@@ -1,0 +1,26 @@
+---
+"@allma/core-types": minor
+"@allma/core-cdk": patch
+"@allma/admin-shell": patch
+---
+
+feat(executions): live execution progress (current step, checkpoints, % complete)
+
+Phase 1 of real-time execution status. Adds a read-time progress view for a single flow
+execution and an optional per-step **checkpoint** so flows can report meaningful milestones
+instead of every micro-step.
+
+- `core-types`: optional `checkpoint` (`{ id, label, order? }`) on `StepInstance`; new
+  `FLOW_EXECUTION_PROGRESS` admin route; new `ExecutionProgressResponse` / `ExecutionProgressNode`
+  schemas.
+- `core-cdk` (bundles `allma-app-logic`): new `GET /flow-executions/{id}/progress` endpoint that
+  computes current step, stage (checkpoint), completed/total steps, a percentage, and a
+  waiting-state flag from the execution's step records + flow definition. No new IAM/env — the
+  existing execution-monitoring Lambda already reads the config table.
+- `admin-shell`: `useGetExecutionProgress` hook (polls while running, stops on terminal status)
+  and an `ExecutionProgressBar` on the execution detail page.
+
+Backward-compatible: all additions are optional; flows that declare no checkpoints get a
+step-count progress bar. Progress is derived from step records, so it requires execution logging
+to be enabled for the flow. Orchestrator stamping, the sub-flow/branch tree, and client
+notifications follow in later phases.

--- a/docs/design/real-time-execution-status.md
+++ b/docs/design/real-time-execution-status.md
@@ -1,0 +1,502 @@
+# Design: Real-Time Flow Execution Status & Client Notifications
+
+| | |
+|---|---|
+| **Status** | Draft for implementation |
+| **Scope** | Platform (`packages/*`, `allma.cdk/`) — product-agnostic |
+| **Audience** | Allma platform engineers |
+| **Related** | Admin execution monitoring, Step Functions orchestration, `onCompletionActions` |
+
+---
+
+## 1. Summary
+
+This document specifies how the Allma platform exposes **live, easy-to-read execution progress** and **delivers status to the application that triggered a flow** (e.g. a consumer app such as the generic `examples/basic-deployment`).
+
+It delivers three capabilities:
+
+1. **Progress model** — "what is going on now", "which stage", and "how many steps / checkpoints done vs. left → percentage". *No time estimation / ETA.*
+2. **Subflow roll-up** — progress of nested sub-flows and parallel branches is visible from the top-level execution the caller triggered.
+3. **Notifications & subscriptions** — the triggering application is reliably told about progress and, critically, **terminal status including hard crashes**, via a per-trigger callback and/or a pub/sub topic.
+
+The design is **additive and backward-compatible**: all new fields are optional; flows that adopt nothing keep working and still get a zero-config step-count progress bar.
+
+---
+
+## 2. Goals / Non-Goals
+
+### Goals
+- Show, for any running execution: the current step, a human-readable stage, and a percentage based on **completed steps / checkpoints**.
+- Let flow authors mark a small set of steps as **checkpoints** so progress reflects *meaningful milestones*, not millisecond micro-steps.
+- Surface **sub-flow and parallel-branch** progress from the root execution.
+- Notify the triggering application of progress and terminal status, **including crashes where the flow never finalizes gracefully**.
+- Let a consumer application **subscribe** to the status of flows *it* triggered, without Admin (Cognito) credentials.
+- Keep the Admin UI as the rich, authenticated monitoring surface.
+
+### Non-Goals
+- **No ETA / time-to-completion estimation.** Explicitly out of scope.
+- No change to flow execution semantics or the iterative Step Functions loop.
+- No new GraphQL/AppSync stack. We stay REST + SNS/EventBrige, optionally WebSocket later.
+- No historical duration baselines or percentile analytics.
+
+---
+
+## 3. Background — current architecture (as-is)
+
+| Concern | Where | Notes |
+|---|---|---|
+| Execution + step records | DynamoDB `AllmaFlowExecutionLogTable`, `PK=flowExecutionId`, `SK=eventTimestamp_stepInstanceId_attempt` | One `METADATA` record per execution; one `STEP#…` record per step attempt. `core-cdk/lib/constructs/data-stores.ts` |
+| Record schemas | `packages/core-types/src/logging/records.ts` | `AllmaFlowExecutionRecordSchema`, `AllmaStepExecutionRecordSchema` |
+| Status enums | same | flow: `INITIALIZING\|RUNNING\|COMPLETED\|FAILED\|TIMED_OUT\|CANCELLED`; step: `STARTED\|COMPLETED\|FAILED\|RETRYING_SFN\|RETRYING_CONTENT\|SKIPPED` |
+| Record writer | `packages/app-logic/src/allma-core/execution-logger.ts` (+ `execution-logger-client.ts`) | **Async, fire-and-forget** (`Event` invocation). Step records may lag a step boundary by ~seconds. |
+| Metadata create | `packages/app-logic/src/allma-flows/initialize-flow.ts` | writes `status=RUNNING` METADATA record |
+| Metadata finalize | `packages/app-logic/src/allma-flows/finalize-flow.ts` | sets terminal status; runs `onCompletionActions` |
+| Orchestration | `packages/core-cdk/lib/constructs/orchestration.ts` | iterative Lambda-per-step loop on Step Functions; **SFN execution name = `flowExecutionId`** |
+| Step processor | `packages/app-logic/src/allma-flows/iterative-step-processor/` | `index.ts`, `step-executor.ts`, `sync-flow-handler.ts`, `parallel-handler.ts` |
+| Sub-flow (SYNC) | `sync-flow-handler.ts` | nested SFN `.sync` execution; child gets a **new** `flowExecutionId`; link to parent is **only a string** in `triggerSource` |
+| Step definition | `packages/core-types/src/steps/definitions.ts` | `StepInstance` has `displayName`, `transitions[]` (conditional, JSONPath), `defaultNextStepInstanceId`; **no stage/checkpoint concept** |
+| Admin routes | `packages/core-types/src/admin/endpoints.ts` | `ALLMA_ADMIN_API_ROUTES`, version `v1`, base `/allma/flow-executions` |
+| Admin handler/service | `packages/app-logic/src/allma-admin/execution-monitoring.ts` + `services/execution-monitoring.service.ts` | list / detail / step-record / branch-steps |
+| Admin auth | `packages/core-sdk/src/authUtils.ts` `withAdminAuth` | Cognito `Admins` group + `EXECUTIONS_READ` permission |
+| UI | `packages/admin-shell/src/features/executions/*`, `src/api/executionService.ts` | REST + manual refresh; **no polling on execution views**; no WS/SSE |
+| Flow-level egress | `finalize-flow.ts` + `packages/core-types/src/flow/actions.ts` `onCompletionActions` | API_CALL / SNS_SEND / CUSTOM_LAMBDA_INVOKE work; SQS_SEND stubbed |
+| Crash net | `packages/core-cdk/lib/constructs/monitoring.ts` | EventBridge rule on SFN `FAILED\|TIMED_OUT\|ABORTED` → SNS alerts topic |
+| Trigger entry | `flow-start-request-listener.ts` (SQS), `allma-admin/flow-trigger.ts` (API) | `StartFlowExecutionInput` has `triggerSource` string; **no callback/replyTo field** |
+
+### Two architectural facts that drive the design
+
+1. **A SYNC sub-flow suspends its parent.** It runs as a nested SFN `.sync` task, so while the child runs, the parent's orchestrator Lambda is *not executing*. The parent therefore **cannot pull** child status — propagation must be **child-driven (push up)** or **assembled at read time (pull the tree)**.
+2. **Graceful finalize is not guaranteed.** `finalize-flow` (and thus `onCompletionActions` and the terminal DynamoDB write) is skipped on a hard crash (Lambda OOM/timeout, SFN abort). The **EventBridge SFN-status-change event is the only crash-proof terminal signal**, and today it only emails an alerts topic. Reliable client notification and "stuck-at-RUNNING" repair must be built on EventBridge, not on `finalize-flow`.
+
+---
+
+## 4. Design overview
+
+Three pillars:
+
+```
+ ┌────────────────────────────────────────────────────────────────────┐
+ │ A. PROGRESS MODEL (per execution)                                    │
+ │   • checkpoint on the step definition  → derived denominator         │
+ │   • orchestrator stamps METADATA: currentStep, completedSteps,       │
+ │     totalSteps, currentCheckpoint, percent                           │
+ ├────────────────────────────────────────────────────────────────────┤
+ │ B. EXECUTION TREE (across sub-flows / branches)                      │
+ │   • structured linkage on child METADATA: parent/root ids            │
+ │   • GSI by rootFlowExecutionId → one query returns the whole tree    │
+ │   • child bubbles a one-line liveStatus onto the ROOT record         │
+ ├────────────────────────────────────────────────────────────────────┤
+ │ C. DELIVERY                                                          │
+ │   • Admin UI: authenticated REST + polling (tree mode)               │
+ │   • Client: per-trigger notificationConfig + status SNS topic        │
+ │   • EventBridge dispatcher: crash-safe terminal + reconcile RUNNING  │
+ └────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 5. Pillar A — Progress model
+
+### 5.1 Checkpoints live on the step (no separate list)
+
+Add an optional `checkpoint` to `StepInstance` in `packages/core-types/src/steps/definitions.ts`:
+
+```ts
+// StepInstanceSchema additions
+checkpoint: z
+  .object({
+    id: z.string().min(1),       // stable id; UI/clients map id → display/status
+    label: z.string().min(1),    // human-readable milestone ("Extracting documents")
+    order: z.number().int().min(0).optional(), // optional, for monotonic ordering
+  })
+  .optional(),
+```
+
+**Why on the step and not a flow-level list:** the checkpoint travels with the step. Adding/removing/reordering/cloning steps keeps progress correct automatically — there is no second list to keep in sync. The denominator is **derived** from the flow definition at runtime.
+
+**Derived progress (computed by the orchestrator, see 5.3):**
+
+- `totalCheckpoints` = number of steps in the flow definition whose `checkpoint` is set
+  *(or, if `order` is used, `max(order) + 1`).*
+- `reachedCheckpointOrder` = highest `order` among checkpoint steps that have completed
+  *(or count of distinct completed checkpoint steps when `order` is absent).*
+- `percent` = `round(100 * (reachedCheckpointOrder + 1) / totalCheckpoints)`.
+
+**Rules:**
+- **Monotonic:** track the *highest* order reached, so loops re-entering an earlier step never move the bar backward.
+- **Skipped intermediate checkpoints** (conditional branches) simply jump the bar forward — acceptable and author-controlled (place checkpoints on the common path).
+- **Clamp to 100 % on terminal `COMPLETED`** so a path that never hits the highest-ordered checkpoint still completes the bar.
+
+### 5.2 Two-layer progress
+
+| Layer | Denominator | Author effort | When used |
+|---|---|---|---|
+| **L1 step-count** (default) | `totalSteps` = distinct steps executed vs. count of steps in the definition | none | always available |
+| **L2 checkpoint** (opt-in) | `totalCheckpoints` derived from tagged steps | tag a few steps | when the flow declares any `checkpoint` |
+
+Resolution: **if the flow defines ≥1 checkpoint, the UI/clients render L2; otherwise L1.** L1 is honest-but-noisy (a 5 ms step moves it as much as a 5 min step; conditionals/loops make the total approximate). L2 is the readable experience.
+
+### 5.3 Orchestrator stamps the METADATA record
+
+The iterative step processor already carries `FlowRuntimeState` (`currentStepInstanceId`) through the loop. Extend the runtime state with `completedStepCount` and `reachedCheckpoint`, and **stamp the METADATA record at each step boundary** (single `UpdateItem`, one cheap item to poll).
+
+New `AllmaFlowExecutionRecordSchema` fields (in `packages/core-types/src/logging/records.ts`):
+
+```ts
+// progress (Pillar A)
+currentStepInstanceId: z.string().optional(),
+currentStepDisplayName: z.string().optional(),
+currentStepType: z.string().optional(),
+completedStepCount: z.number().int().optional(),
+totalStepCount: z.number().int().optional(),        // count of steps in definition
+currentCheckpoint: z
+  .object({ id: z.string(), label: z.string(), order: z.number().int().optional() })
+  .optional(),
+totalCheckpoints: z.number().int().optional(),
+progressPercent: z.number().int().min(0).max(100).optional(),
+progressUpdatedAt: z.string().datetime({ offset: true }).optional(),
+```
+
+**Write cadence & cost:**
+- `currentStep*` / `completedStepCount` / `progressPercent`: updated **once per step boundary** inside the iterative processor (it is already writing/transitioning there). This is an `UpdateItem` on the same partition key, no extra read.
+- `currentCheckpoint` / `liveStatus` bubble-up (Pillar B): updated **only when a checkpoint step completes** — coarse, low volume.
+
+> **Why stamp the metadata item instead of deriving from STEP records on read?**
+> The step logger is async/fire-and-forget and may lag or arrive out of order. Stamping the metadata item from the orchestrator (which is authoritative and synchronous) gives the UI a **single, lag-free item to GET**, avoids scanning step records on every poll, and is what the client bubble-up (Pillar B) needs anyway.
+
+---
+
+## 6. Pillar B — Execution tree across sub-flows & branches
+
+### 6.1 Structured linkage (replace the `triggerSource` string)
+
+When a sub-flow / branch is launched, write structured linkage onto the **child** METADATA record. Set these in `sync-flow-handler.ts` (and branch fan-out in `parallel-handler.ts` / `orchestration.ts`), and persist them in `initialize-flow.ts`:
+
+```ts
+// AllmaFlowExecutionRecordSchema additions (linkage)
+parentFlowExecutionId: z.string().uuid().optional(),
+parentStepInstanceId: z.string().optional(),
+rootFlowExecutionId: z.string().uuid().optional(),  // = self for a top-level execution
+depth: z.number().int().min(0).optional(),          // 0 = root
+executionKind: z.enum(['ROOT', 'SYNC_SUBFLOW', 'ASYNC_SUBFLOW', 'PARALLEL_BRANCH']).optional(),
+```
+
+- For a top-level execution: `rootFlowExecutionId = flowExecutionId`, `depth = 0`, `executionKind = ROOT`.
+- `triggerSource` remains for backwards compatibility but is no longer the linkage mechanism.
+
+### 6.2 New GSI: query a whole tree in one shot
+
+Add a GSI to `AllmaFlowExecutionLogTable` in `core-cdk/lib/constructs/data-stores.ts`:
+
+```
+GSI_ByRoot
+  PK = rootFlowExecutionId
+  SK = depth#parentStepInstanceId#flowExecutionId   (or startTime)
+  Projection: metadata fields (status, progress*, currentCheckpoint, liveStatus, linkage)
+```
+
+A single `Query(rootFlowExecutionId = R)` returns every execution node in the tree (parent, sync children, async children, branches), each carrying its own progress.
+
+> **Backfill note:** only executions created after deployment have linkage. Pre-existing executions return a single-node tree. Acceptable.
+
+### 6.3 Each node stamps its own record (normalized)
+
+No cross-writes for the per-node progress: child `C` stamps `C`'s metadata, parent `P` stamps `P`'s. One writer per record, zero contention.
+
+### 6.4 Bubble-up: child pushes a one-line summary to the root
+
+Because the parent is **suspended** during a SYNC sub-flow, the child writes a compact roll-up onto the **root** record so a single GET of the root reflects "what's happening at the deepest active level". This fires **only on checkpoint change** (coarse → low write volume, negligible contention):
+
+```ts
+// AllmaFlowExecutionRecordSchema addition (root only)
+liveStatus: z
+  .object({
+    activeExecutionId: z.string().uuid(),
+    depth: z.number().int(),
+    stepDisplayName: z.string().optional(),
+    checkpointId: z.string().optional(),
+    checkpointLabel: z.string().optional(),
+    percent: z.number().int().min(0).max(100).optional(),
+    updatedAt: z.string().datetime({ offset: true }),
+  })
+  .optional(),
+```
+
+Mechanics: the child orchestrator knows `rootFlowExecutionId`; on a checkpoint change it issues a conditional `UpdateItem` on the root METADATA item (`PK=rootFlowExecutionId, SK=METADATA`) setting `liveStatus`. Use a `updatedAt`/`depth`-guarded condition so a shallower execution resuming later overwrites the deeper one cleanly. When the parent resumes after the sub-flow returns, it overwrites `liveStatus` with its own.
+
+### 6.5 End-to-end propagation
+
+```
+App triggers flow ──► R returned (rootFlowExecutionId = R)
+   │
+   R runs … step_4 = START_SUB_FLOW (SYNC) ──► launches child C
+   │ (R SUSPENDED in SFN .sync — cannot self-update)
+   ▼
+   C runs; on each checkpoint:
+     ├─ UpdateItem C.METADATA   (own progress — for the tree)
+     └─ UpdateItem R.METADATA.liveStatus = {deepest summary}  (bubble-up — one-read)
+   │
+   C COMPLETED ──► R resumes ──► overwrites R.liveStatus with its own checkpoints
+```
+
+- **Admin UI** → read-time **tree** via `GSI_ByRoot` (full nested detail).
+- **Client** → single GET of `R` (`liveStatus`) or the SNS event stream; never needs to know `C` exists.
+
+**ASYNC sub-flows:** parent does not wait and may complete while the child runs. Linkage + tree still apply, but async children are **not** bubbled into the root's headline `liveStatus` (the root may already be terminal). The UI shows them as independent linked nodes.
+
+---
+
+## 7. Pillar C — Delivery
+
+### 7.1 Admin UI monitoring (authenticated, REST + polling)
+
+**New endpoint — progress roll-up** (add to `ALLMA_ADMIN_API_ROUTES` in `core-types/src/admin/endpoints.ts`, handler in `allma-admin/execution-monitoring.ts`, logic in `execution-monitoring.service.ts`; guarded by `withAdminAuth` + `EXECUTIONS_READ`):
+
+```
+GET /v1/allma/flow-executions/{flowExecutionId}/progress?mode=tree|single
+```
+
+- `mode=single` (default): `GetItem` on the METADATA record → returns the node's progress + `liveStatus`. Cheap; for compact status widgets.
+- `mode=tree`: `Query(GSI_ByRoot = rootFlowExecutionId)` → assembles the nested tree (Pillar B) → returns root + descendants, each with progress.
+
+**Response schema** (`core-types/src/admin/executionMonitoring.ts`):
+
+```ts
+export const ExecutionProgressNodeSchema = z.object({
+  flowExecutionId: z.string().uuid(),
+  flowDefinitionId: z.string(),
+  flowDefinitionVersion: z.number().int().optional(),
+  executionKind: z.enum(['ROOT','SYNC_SUBFLOW','ASYNC_SUBFLOW','PARALLEL_BRANCH']),
+  parentStepInstanceId: z.string().optional(),
+  depth: z.number().int(),
+  status: z.enum(['INITIALIZING','RUNNING','COMPLETED','FAILED','TIMED_OUT','CANCELLED']),
+  isWaiting: z.boolean(),                 // current step is WAIT_FOR_EXTERNAL_EVENT / POLL_EXTERNAL_API
+  currentStep: z.object({
+    stepInstanceId: z.string().optional(),
+    displayName: z.string().optional(),
+    stepType: z.string().optional(),
+  }).optional(),
+  currentCheckpoint: z.object({ id: z.string(), label: z.string(), order: z.number().int().optional() }).optional(),
+  completedStepCount: z.number().int().optional(),
+  totalStepCount: z.number().int().optional(),
+  progressPercent: z.number().int().min(0).max(100).optional(),
+  startTime: z.string().datetime({ offset: true }),
+  endTime: z.string().datetime({ offset: true }).optional(),
+  children: z.array(z.lazy(() => ExecutionProgressNodeSchema)).default([]),
+});
+
+export const ExecutionProgressResponseSchema = z.object({
+  root: ExecutionProgressNodeSchema,
+  // convenience: deepest active leaf, for a one-line headline
+  headline: z.object({
+    executionId: z.string().uuid(),
+    label: z.string(),                    // checkpoint label or step displayName
+    percent: z.number().int().min(0).max(100).optional(),
+    status: z.string(),
+  }).optional(),
+});
+```
+
+**React Query hook** (`packages/admin-shell/src/api/executionService.ts`):
+
+```ts
+export function useGetExecutionProgress(flowExecutionId?: string, mode: 'tree'|'single' = 'tree') {
+  return useQuery({
+    queryKey: [EXECUTION_PROGRESS_QUERY_KEY, flowExecutionId, mode],
+    queryFn: () => api.get(ROUTES.FLOW_EXECUTION_PROGRESS(flowExecutionId!), { params: { mode } }),
+    enabled: !!flowExecutionId,
+    // poll ONLY while running; stop on terminal
+    refetchInterval: (q) => {
+      const s = q.state.data?.root?.status;
+      return s && ['COMPLETED','FAILED','TIMED_OUT','CANCELLED'].includes(s) ? false : 3000;
+    },
+  });
+}
+```
+
+**UI rendering** (`features/executions/`):
+- **Execution list** (`ExecutionListPage`/`FlowExecutionsPreview`): add a compact progress cell (`progressPercent` + `currentCheckpoint.label`), polling in `single` mode while `RUNNING`.
+- **Execution detail** (`ExecutionDetailPage`): a header progress bar + a **nested tree** of sub-flow/branch nodes, each with its own bar and current-step line. The existing step accordion stays for full per-step detail.
+- **Waiting state:** when `isWaiting` is true, render "Waiting for external input / polling…" instead of an active spinner (these steps can pause for a long time).
+
+**Cost control:** poll the `single`/`progress` item (not the full step list); 3 s while running; stop immediately on terminal status.
+
+### 7.2 Client subscription (e.g. Optiroq) — get status of flows it triggered
+
+A consumer application triggered the flow and holds the **root `flowExecutionId`** (returned by the trigger API/SQS). It must receive status **without** Cognito Admin credentials, and must be told about **crashes**.
+
+Two complementary mechanisms:
+
+#### (a) Per-trigger callback — point-to-point
+
+Extend `StartFlowExecutionInputSchema` (consumed by `flow-start-request-listener.ts` and `allma-admin/flow-trigger.ts`) with an **optional** `notificationConfig`:
+
+```ts
+export const NotificationConfigSchema = z.object({
+  // at least one sink
+  webhookUrl: z.string().url().optional(),
+  snsTopicArn: z.string().startsWith('arn:aws:sns:').optional(),
+  sqsUrl: z.string().url().optional(),
+  // what to send
+  events: z.array(z.enum(['STARTED','CHECKPOINT','TERMINAL'])).default(['TERMINAL']),
+  // echoed back so the caller can correlate
+  correlationKey: z.string().optional(),
+  // webhook signing (HMAC-SHA256 over the raw body)
+  signingSecretArn: z.string().optional(), // Secrets Manager ARN; platform never stores raw secrets
+}).optional();
+```
+
+This is persisted onto the root METADATA record at `initialize-flow`. The caller decides **where** to be notified, **per execution** — exactly what a consumer app needs, instead of baking sinks into every flow definition.
+
+#### (b) Status SNS topic — pub/sub broadcast
+
+Provision a dedicated **execution status topic** (`AllmaExecutionStatusTopic-${stage}`) in `core-cdk`, exported as a stack output (alongside the existing `ALLMA_FLOW_OUTPUT_SNS_TOPIC_ARN`). Every lifecycle event is published with **message attributes** so subscribers filter server-side:
+
+```
+MessageAttributes:
+  flowDefinitionId : <id>
+  rootFlowExecutionId : <R>
+  eventType : STARTED | CHECKPOINT | TERMINAL
+  status : RUNNING | COMPLETED | FAILED | TIMED_OUT | CANCELLED
+```
+
+A consumer subscribes its own SQS queue/HTTPS endpoint with a **subscription filter policy** (e.g. by `flowDefinitionId`, or by a set of `rootFlowExecutionId`s) and reconstructs live status from the stream. Cross-account subscribe is granted via topic policy.
+
+#### Event payload (shared by webhook + SNS)
+
+```jsonc
+{
+  "schemaVersion": "1.0",
+  "eventType": "CHECKPOINT",             // STARTED | CHECKPOINT | TERMINAL
+  "rootFlowExecutionId": "R-uuid",
+  "flowExecutionId": "C-uuid",           // node that produced the event (may == root)
+  "flowDefinitionId": "invoice-flow",
+  "flowDefinitionVersion": 7,
+  "status": "RUNNING",                   // node status
+  "depth": 1,
+  "checkpoint": { "id": "extract", "label": "Extracting documents", "order": 2 },
+  "progressPercent": 66,
+  "headline": { "label": "Extracting documents", "percent": 66 },
+  "correlationKey": "optiroq:job:1234",
+  "errorInfo": null,                     // populated on TERMINAL FAILED/TIMED_OUT
+  "occurredAt": "2026-06-26T10:15:30.123Z"
+}
+```
+
+> **Idempotency & ordering:** delivery is at-least-once and **not ordered**. Every event is self-describing (carries `status` + `occurredAt` + `progressPercent`). Consumers must **dedupe** on (`flowExecutionId`,`eventType`,`occurredAt`) and treat a higher `occurredAt` as newer. Do not assume `STARTED` arrives before `CHECKPOINT`.
+
+#### Where events are emitted
+
+- `STARTED` / `CHECKPOINT`: from the orchestrator at the same point it stamps progress (publish to the status topic; if `notificationConfig` is present, also dispatch to its sinks). Keep this on the **checkpoint** cadence to bound volume.
+- `TERMINAL`: see §7.3 — emitted by the **EventBridge dispatcher**, not by `finalize-flow`, so it survives crashes.
+
+### 7.3 Crash-safe terminal status + reconciler (EventBridge dispatcher)
+
+Promote the existing EventBridge rule (`core-cdk/lib/constructs/monitoring.ts`) from "email an alert" to the **authoritative terminal pipeline**. Add a new Lambda `execution-lifecycle-dispatcher` subscribed to **SFN Execution Status Change** events for the orchestrator + polling state machines, on `SUCCEEDED | FAILED | TIMED_OUT | ABORTED`.
+
+Because **SFN execution name = `flowExecutionId`**, the event's `executionArn` yields the id directly. The dispatcher:
+
+1. **Reconcile** — `GetItem` the METADATA record. If still `RUNNING`/`INITIALIZING`, write the real terminal status + `errorInfo`. *This fixes "zombie RUNNING" executions left by hard crashes.*
+2. **Notify the caller** — read `notificationConfig` from the (root) record; dispatch a `TERMINAL` event to its sinks (signed webhook / SNS / SQS), with retry + DLQ.
+3. **Broadcast** — publish the `TERMINAL` event to `AllmaExecutionStatusTopic`.
+4. (Future) push to the Admin WebSocket.
+
+```
+SFN status change (SUCCEEDED|FAILED|TIMED_OUT|ABORTED)
+        │  detail.executionArn → flowExecutionId
+        ▼
+ execution-lifecycle-dispatcher (Lambda)
+        ├─ reconcile DynamoDB METADATA if not already terminal   (crash repair)
+        ├─ read notificationConfig → deliver TERMINAL to caller   (webhook/SNS/SQS + DLQ)
+        └─ publish TERMINAL to AllmaExecutionStatusTopic          (pub/sub)
+```
+
+> **Why not `onCompletionActions`/`finalize-flow` alone:** they are skipped on a hard crash. `onCompletionActions` remains supported for **in-flow declarative actions**, but it is **not** the crash-safe path. The dispatcher is.
+
+**Dedup vs. finalize:** on a graceful finish, both `finalize-flow` (writes terminal status) and the dispatcher (reconcile) run. The reconciler's "only if not already terminal" condition makes it a no-op write in that case; terminal **notifications** are emitted **only** by the dispatcher to guarantee exactly the crash path is covered and to avoid double-send.
+
+---
+
+## 8. Data model changes (summary)
+
+### `packages/core-types`
+- `steps/definitions.ts`: `StepInstance.checkpoint?: { id, label, order? }`.
+- `logging/records.ts` `AllmaFlowExecutionRecordSchema`: progress fields (§5.3), linkage fields (§6.1), `liveStatus` (§6.4), `notificationConfig` (§7.2a).
+- `runtime/core.ts` `FlowRuntimeStateSchema`: `completedStepCount`, `reachedCheckpoint`, `rootFlowExecutionId`, `parentFlowExecutionId`, `parentStepInstanceId`, `depth`.
+- inputs: `StartFlowExecutionInputSchema.notificationConfig?` (§7.2a).
+- `admin/endpoints.ts`: `FLOW_EXECUTION_PROGRESS(id)` route.
+- `admin/executionMonitoring.ts`: `ExecutionProgressNode/Response` schemas.
+- New shared event schema: `notifications/execution-events.ts` (the §7.2 payload).
+
+### `packages/core-cdk`
+- `data-stores.ts`: add `GSI_ByRoot` to `AllmaFlowExecutionLogTable`.
+- new construct `notifications.ts`: `AllmaExecutionStatusTopic-${stage}` (+ stack output), `execution-lifecycle-dispatcher` Lambda, DLQ.
+- `monitoring.ts`: point the SFN-status EventBridge rule at the dispatcher (keep the alerts target).
+- IAM: dispatcher gets `dynamodb:GetItem/UpdateItem` on the log table, `sns:Publish` on the status topic, `sqs:SendMessage`/HTTPS egress for webhooks, `secretsmanager:GetSecretValue` for signing secrets.
+
+### `packages/app-logic`
+- `initialize-flow.ts`: persist linkage + `notificationConfig`; init progress fields.
+- `iterative-step-processor/index.ts` + `step-executor.ts`: maintain `completedStepCount`/`reachedCheckpoint`; stamp METADATA progress each step boundary; on checkpoint change emit `STARTED`/`CHECKPOINT` events + bubble `liveStatus` to root.
+- `sync-flow-handler.ts` + `parallel-handler.ts`: pass `parent*`/`root*`/`depth`/`executionKind` into child start input.
+- new `execution-lifecycle-dispatcher.ts` (§7.3).
+- `allma-admin/execution-monitoring.ts` + `services/execution-monitoring.service.ts`: `/progress` endpoint (single + tree).
+
+### `packages/admin-shell`
+- `api/executionService.ts`: `useGetExecutionProgress` (polling while running).
+- `features/executions/`: progress cell in lists; header bar + nested sub-flow tree in detail; waiting-state rendering.
+
+### `packages/core-sdk` (optional)
+- helper for HMAC webhook signing + a small client-side `verifySignature` example for consumers.
+
+---
+
+## 9. Implementation plan (phased)
+
+**Phase 1 — Single-execution progress (UI).** *No new infra.*
+1. `StepInstance.checkpoint` schema.
+2. Runtime-state + METADATA progress fields; orchestrator stamping (L1 + L2).
+3. `/progress?mode=single` endpoint + `useGetExecutionProgress` + UI progress cell/bar.
+4. Waiting-state detection (`WAIT_FOR_EXTERNAL_EVENT` / `POLL_EXTERNAL_API`).
+
+**Phase 2 — Execution tree (sub-flows).**
+5. Linkage fields + `GSI_ByRoot`.
+6. Stamp linkage in `sync-flow-handler`/branch fan-out + `initialize-flow`.
+7. Child bubble-up of `liveStatus` to root.
+8. `/progress?mode=tree` + nested UI tree.
+
+**Phase 3 — Client notifications (crash-safe).** *Highest correctness value.*
+9. `AllmaExecutionStatusTopic` + `execution-lifecycle-dispatcher` + DLQ.
+10. EventBridge rule → dispatcher; **reconcile** zombie RUNNING.
+11. `notificationConfig` on trigger input; signed webhook / SNS / SQS delivery.
+12. `STARTED`/`CHECKPOINT` event emission from the orchestrator.
+13. Consumer docs (subscribe + verify signature) under `docs.allma.dev/docs/reference/`.
+
+**Phase 4 (optional) — WebSocket push** reusing the §7.1 payload, if 3 s polling proves insufficient.
+
+> Phase 3's reconciler + terminal notification is independently valuable: it closes a real correctness gap (silent crashes never notify; executions stuck at RUNNING). Consider shipping it even before Phase 2.
+
+---
+
+## 10. Backward compatibility, versioning, security
+
+- **All new fields optional.** Flows adopting nothing keep working (L1 progress, single-node tree, no notifications). New exported schema fields/endpoints/topic = **minor** changeset bumps per affected `@allma/*` package; no breaking changes → **not** major. (Follow `AGENTS.md` Changesets rules; never select major.)
+- **Auth:** the Admin `/progress` endpoint stays behind `withAdminAuth` + `EXECUTIONS_READ`. Consumers never use Admin auth — they receive events via their own SNS/SQS/HTTPS sink or a topic subscription. No public unauthenticated read endpoint is introduced.
+- **Webhook security:** HMAC-SHA256 signature header over the raw body; secret stored in the **consumer's** Secrets Manager and referenced by ARN — the platform reads it at send time, never persists raw secrets. Include `occurredAt` to bound replay.
+- **Least privilege:** dispatcher IAM scoped to the specific table/topic/queues; cross-account topic subscribe via explicit topic policy.
+- **Docs:** product-agnostic only (generic `examples/basic-deployment`); update `docs.allma.dev/docs/reference/` for the new endpoint, the trigger `notificationConfig`, and the status topic. Validate with `npm run build --prefix docs.allma.dev`.
+
+---
+
+## 11. Open questions
+
+1. **Checkpoint authoring UX** in the Flow Editor — mark a step as a checkpoint + set `label`/`order`. (Drives whether `order` is required or auto-assigned by graph order.)
+2. **Async sub-flow headline semantics** — show the most-recently-active async child as the root headline, or only sync descendants? (Default: sync only.)
+3. **Event volume** for very chatty flows — is checkpoint-cadence enough, or do we also want a coalescing window in the dispatcher?
+4. **Retention** — `liveStatus`/progress fields share the record TTL; confirm that matches the desired post-mortem window.
+5. **Polling interval** — 3 s default; expose as Admin setting?
+
+---
+
+## 12. Mental model (one paragraph)
+
+Each execution stamps its **own** metadata item with current step + checkpoint percentage. A flow author marks a few steps as **checkpoints** (`{id,label,order}` on the step) so the bar tracks meaningful milestones, and the denominator is derived from the definition — no list to maintain. Because a sync sub-flow **suspends** its parent, the child both records its own progress and **pushes a one-line `liveStatus` up to the root**; the full nested picture is assembled **on read** from a single `GSI_ByRoot` query. The Admin UI polls a `/progress` endpoint (tree mode) while a flow runs. The triggering client gets status **without Admin auth** through a per-trigger `notificationConfig` and/or an execution-status SNS topic, and terminal status — **including crashes** — is guaranteed by an **EventBridge dispatcher** that reconciles the record and notifies, independent of graceful finalize.

--- a/packages/admin-shell/src/api/executionService.ts
+++ b/packages/admin-shell/src/api/executionService.ts
@@ -5,9 +5,15 @@ import {
     ALLMA_ADMIN_API_ROUTES,
     ALLMA_ADMIN_API_VERSION,
     BranchStepsResponse,
-    AllmaStepExecutionRecord
+    AllmaStepExecutionRecord,
+    ExecutionProgressResponse
 } from '@allma/core-types';
-import { EXECUTION_DETAIL_QUERY_KEY, EXECUTIONS_LIST_QUERY_KEY, BRANCH_STEPS_QUERY_KEY } from '../features/executions/constants';
+import {
+    EXECUTION_DETAIL_QUERY_KEY, EXECUTIONS_LIST_QUERY_KEY, BRANCH_STEPS_QUERY_KEY,
+    EXECUTION_PROGRESS_QUERY_KEY, EXECUTION_PROGRESS_POLL_INTERVAL_MS
+} from '../features/executions/constants';
+
+const TERMINAL_EXECUTION_STATUSES = ['COMPLETED', 'FAILED', 'TIMED_OUT', 'CANCELLED'];
 
 // ---- Fetch a list of flow executions ----
 
@@ -67,6 +73,33 @@ export const useGetExecutionDetail = (executionId: string | undefined): UseQuery
       throw new Error(response.data.error?.message || 'Failed to fetch execution details');
     },
     enabled: !!executionId, // Only run if executionId is provided
+  });
+};
+
+// ---- Fetch live progress for a single execution ----
+// Polls while the execution is still running and automatically stops once it reaches a
+// terminal status, so completed executions incur no further requests.
+
+export const useGetExecutionProgress = (executionId: string | undefined): UseQueryResult<ExecutionProgressResponse, Error> => {
+  return useQuery({
+    queryKey: [EXECUTION_PROGRESS_QUERY_KEY, executionId],
+    queryFn: async () => {
+      if (!executionId) throw new Error('Execution ID is undefined.');
+
+      const response = await axiosInstance.get<AdminApiResponse<ExecutionProgressResponse>>(
+        `/${ALLMA_ADMIN_API_VERSION}${ALLMA_ADMIN_API_ROUTES.FLOW_EXECUTION_PROGRESS(executionId)}`
+      );
+
+      if (response.data.success) {
+        return response.data.data;
+      }
+      throw new Error(response.data.error?.message || 'Failed to fetch execution progress');
+    },
+    enabled: !!executionId,
+    refetchInterval: (query) => {
+      const status = query.state.data?.root?.status;
+      return status && TERMINAL_EXECUTION_STATUSES.includes(status) ? false : EXECUTION_PROGRESS_POLL_INTERVAL_MS;
+    },
   });
 };
 

--- a/packages/admin-shell/src/features/executions/ExecutionDetailPage.tsx
+++ b/packages/admin-shell/src/features/executions/ExecutionDetailPage.tsx
@@ -7,6 +7,7 @@ import { useState, useEffect } from 'react';
 import { ExecutionsBreadcrumbs } from './ExecutionsBreadcrumbs';
 import { useDisclosure } from '@mantine/hooks';
 import { ExecutionSummary } from './components/ExecutionSummary';
+import { ExecutionProgressBar } from './components/ExecutionProgressBar';
 import { ContextDiffModal } from './components/ContextDiffModal';
 import { AllmaStepExecutionRecord, StepType, StepInstance } from '@allma/core-types';
 import { ParallelStepAccordionItem } from './components/ParallelStepAccordionItem';
@@ -192,9 +193,11 @@ export function ExecutionDetailPage() {
                         </Group>
                     </Alert>
                 )}
+                {flowExecutionId && <ExecutionProgressBar flowExecutionId={flowExecutionId} />}
+
                 <ExecutionSummary metadata={metadata} />
 
-                <Accordion 
+                <Accordion
                     variant="separated"
                     multiple
                     value={openItems}

--- a/packages/admin-shell/src/features/executions/components/ExecutionProgressBar.tsx
+++ b/packages/admin-shell/src/features/executions/components/ExecutionProgressBar.tsx
@@ -1,0 +1,79 @@
+import { Badge, Group, Paper, Progress, Text, Tooltip } from '@mantine/core';
+import { IconClockPause } from '@tabler/icons-react';
+import { useGetExecutionProgress } from '../../../api/executionService';
+
+const TERMINAL_STATUSES = ['COMPLETED', 'FAILED', 'TIMED_OUT', 'CANCELLED'];
+
+interface ExecutionProgressBarProps {
+    flowExecutionId: string;
+}
+
+/**
+ * Compact, self-refreshing progress indicator for a running execution. Shows the current
+ * step / checkpoint stage, a percentage, and a "waiting" badge when the flow is paused on an
+ * external event or long poll. Polling is handled by the underlying query and stops on terminal
+ * status, so this renders a static final state once the execution finishes.
+ */
+export function ExecutionProgressBar({ flowExecutionId }: ExecutionProgressBarProps) {
+    const { data, isLoading } = useGetExecutionProgress(flowExecutionId);
+
+    // Nothing to show until the first response arrives (avoids a layout flash).
+    if (isLoading || !data) return null;
+
+    const { root, headline } = data;
+    const isTerminal = TERMINAL_STATUSES.includes(root.status);
+    const isFailed = root.status === 'FAILED' || root.status === 'TIMED_OUT' || root.status === 'CANCELLED';
+
+    const stepsLabel =
+        root.totalCheckpoints && root.totalCheckpoints > 0
+            ? `Stage ${root.currentCheckpoint?.ordinal ?? 0} of ${root.totalCheckpoints}`
+            : root.totalStepCount && root.totalStepCount > 0
+                ? `${root.completedStepCount} of ${root.totalStepCount} steps`
+                : `${root.completedStepCount} steps done`;
+
+    const color = isFailed ? 'red' : root.status === 'COMPLETED' ? 'green' : 'blue';
+
+    return (
+        <Paper withBorder p="sm" radius="md" mb="md">
+            <Group justify="space-between" mb={6} wrap="nowrap">
+                <Group gap="xs" wrap="nowrap" style={{ minWidth: 0 }}>
+                    <Text fw={600} size="sm" truncate>
+                        {headline.label}
+                    </Text>
+                    {root.isWaiting && (
+                        <Tooltip label="Paused waiting for an external event or long-running poll">
+                            <Badge color="yellow" variant="light" leftSection={<IconClockPause size={12} />}>
+                                Waiting
+                            </Badge>
+                        </Tooltip>
+                    )}
+                    {!isTerminal && !root.isWaiting && (
+                        <Badge color="blue" variant="light">
+                            Running
+                        </Badge>
+                    )}
+                </Group>
+                <Text fw={700} size="sm" c={color} style={{ flexShrink: 0 }}>
+                    {root.progressPercent}%
+                </Text>
+            </Group>
+            <Progress
+                value={root.progressPercent}
+                color={color}
+                striped={!isTerminal}
+                animated={!isTerminal && !root.isWaiting}
+                radius="xl"
+            />
+            <Group justify="space-between" mt={6}>
+                <Text size="xs" c="dimmed">
+                    {stepsLabel}
+                </Text>
+                {root.currentStep && !isTerminal && (
+                    <Text size="xs" c="dimmed" truncate>
+                        Current: {root.currentStep.displayName ?? root.currentStep.stepInstanceId}
+                    </Text>
+                )}
+            </Group>
+        </Paper>
+    );
+}

--- a/packages/admin-shell/src/features/executions/constants.ts
+++ b/packages/admin-shell/src/features/executions/constants.ts
@@ -2,4 +2,8 @@
 
 export const EXECUTIONS_LIST_QUERY_KEY = 'flowExecutions';
 export const EXECUTION_DETAIL_QUERY_KEY = 'flowExecutionDetail';
+export const EXECUTION_PROGRESS_QUERY_KEY = 'flowExecutionProgress';
 export const BRANCH_STEPS_QUERY_KEY = 'flowExecutionBranchSteps';
+
+// How often (ms) to poll live execution progress while an execution is still running.
+export const EXECUTION_PROGRESS_POLL_INTERVAL_MS = 3000;

--- a/packages/app-logic/src/allma-admin/execution-monitoring.ts
+++ b/packages/app-logic/src/allma-admin/execution-monitoring.ts
@@ -49,6 +49,19 @@ router.get('/flow-executions/{flowExecutionId}', async (event, authContext, { fl
     return createApiGatewayResponse(200, buildSuccessResponse(details), correlationId);
 });
 
+// Route for getting live progress of a single execution (current step, stage, % complete).
+// GET /flow-executions/{flowExecutionId}/progress
+router.get('/flow-executions/{flowExecutionId}/progress', async (event, authContext, { flowExecutionId }) => {
+    const correlationId = event.requestContext.requestId;
+    const progress = await ExecutionMonitoringService.getExecutionProgress(flowExecutionId, correlationId);
+
+    if (!progress) {
+        return createApiGatewayResponse(404, buildErrorResponse(`Execution with ID ${flowExecutionId} not found.`, 'NOT_FOUND'), correlationId);
+    }
+
+    return createApiGatewayResponse(200, buildSuccessResponse(progress), correlationId);
+});
+
 // Route for getting the detailed view of a single step.
 // GET /flow-executions/{flowExecutionId}/step-record
 router.get('/flow-executions/{flowExecutionId}/step-record', async (event, authContext, { flowExecutionId }) => {

--- a/packages/app-logic/src/allma-admin/services/execution-monitoring.service.ts
+++ b/packages/app-logic/src/allma-admin/services/execution-monitoring.service.ts
@@ -1,11 +1,121 @@
 import { AttributeValue, DynamoDBClient, QueryCommandOutput } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, QueryCommand, QueryCommandInput } from '@aws-sdk/lib-dynamodb';
 import {
-    ENV_VAR_NAMES, FlowExecutionDetails, PaginatedResponse, FlowExecutionSummary, AllmaFlowExecutionRecord, 
-    AllmaStepExecutionRecord, ITEM_TYPE_ALLMA_FLOW_EXECUTION_RECORD, ITEM_TYPE_ALLMA_STEP_EXECUTION_RECORD, 
-    StepType, BranchStepsResponse, BranchExecutionGroup
+    ENV_VAR_NAMES, FlowExecutionDetails, PaginatedResponse, FlowExecutionSummary, AllmaFlowExecutionRecord,
+    AllmaStepExecutionRecord, ITEM_TYPE_ALLMA_FLOW_EXECUTION_RECORD, ITEM_TYPE_ALLMA_STEP_EXECUTION_RECORD,
+    StepType, BranchStepsResponse, BranchExecutionGroup,
+    FlowDefinition, ExecutionProgressNode, ExecutionProgressResponse
 } from '@allma/core-types';
-import { log_error, resolveS3Pointer } from '@allma/core-sdk';
+import { log_error, log_warn, resolveS3Pointer } from '@allma/core-sdk';
+import { loadFlowDefinition } from '../../allma-core/config-loader.js';
+
+const TERMINAL_FLOW_STATUSES = ['COMPLETED', 'FAILED', 'TIMED_OUT', 'CANCELLED'] as const;
+const STEP_REACHED_STATUSES = ['STARTED', 'COMPLETED', 'RETRYING_SFN', 'RETRYING_CONTENT'];
+const STEP_TERMINAL_STATUSES = ['COMPLETED', 'FAILED', 'SKIPPED'];
+const STEP_ACTIVE_STATUSES = ['STARTED', 'RETRYING_SFN', 'RETRYING_CONTENT'];
+
+/**
+ * Computes a live progress node for one flow execution from its metadata + step records and
+ * (when available) its flow definition. Derived at read time: requires no orchestrator changes.
+ *
+ * Current step = the most recent active (STARTED/RETRYING) step event that has no terminal event
+ * after it. Checkpoint progress = the highest-ordered declared checkpoint whose step has been
+ * reached. Falls back to step-count progress when the flow declares no checkpoints.
+ */
+export function _computeExecutionProgress(
+    metadata: AllmaFlowExecutionRecord,
+    stepEvents: AllmaStepExecutionRecord[],
+    flowDef: FlowDefinition | undefined,
+): ExecutionProgressNode {
+    const status = metadata.status;
+    const isTerminal = (TERMINAL_FLOW_STATUSES as readonly string[]).includes(status);
+
+    const sorted = [...stepEvents].sort((a, b) => a.eventTimestamp.localeCompare(b.eventTimestamp));
+
+    // Latest terminal event timestamp per step, to decide whether an active step is still running.
+    const latestTerminalByStep = new Map<string, string>();
+    for (const e of sorted) {
+        if (STEP_TERMINAL_STATUSES.includes(e.status)) latestTerminalByStep.set(e.stepInstanceId, e.eventTimestamp);
+    }
+
+    const completedStepIds = new Set(sorted.filter(e => e.status === 'COMPLETED').map(e => e.stepInstanceId));
+    const reachedStepIds = new Set(sorted.filter(e => STEP_REACHED_STATUSES.includes(e.status)).map(e => e.stepInstanceId));
+    const completedStepCount = completedStepIds.size;
+
+    // Current step: walk newest-first for an active event with no later terminal event for that step.
+    let currentStepEvent: AllmaStepExecutionRecord | undefined;
+    if (!isTerminal) {
+        for (let i = sorted.length - 1; i >= 0; i--) {
+            const e = sorted[i];
+            if (!STEP_ACTIVE_STATUSES.includes(e.status)) continue;
+            const term = latestTerminalByStep.get(e.stepInstanceId);
+            if (!term || term < e.eventTimestamp) { currentStepEvent = e; break; }
+        }
+    }
+
+    const totalStepCount = flowDef ? Object.keys(flowDef.steps).length : undefined;
+
+    // Declared checkpoints, ordered. `order` is optional; undefined sorts last but keeps definition order.
+    const checkpointSteps = flowDef
+        ? Object.entries(flowDef.steps)
+            .filter(([, s]) => (s as any).checkpoint)
+            .map(([stepInstanceId, s]) => ({ stepInstanceId, ...((s as any).checkpoint) }))
+            .sort((a, b) => (a.order ?? Number.MAX_SAFE_INTEGER) - (b.order ?? Number.MAX_SAFE_INTEGER))
+        : [];
+    const totalCheckpoints = checkpointSteps.length;
+
+    // Most advanced reached checkpoint (monotonic: take the last in sorted order that was reached).
+    let currentCheckpoint: ExecutionProgressNode['currentCheckpoint'];
+    let checkpointOrdinal = 0;
+    for (let i = 0; i < checkpointSteps.length; i++) {
+        if (reachedStepIds.has(checkpointSteps[i].stepInstanceId)) {
+            const { id, label, order } = checkpointSteps[i];
+            currentCheckpoint = { id, label, order, ordinal: i + 1 };
+            checkpointOrdinal = i + 1;
+        }
+    }
+
+    let progressPercent: number;
+    if (status === 'COMPLETED') {
+        progressPercent = 100; // clamp to 100% on success even if a late checkpoint was skipped
+    } else if (totalCheckpoints > 0) {
+        progressPercent = Math.round((100 * checkpointOrdinal) / totalCheckpoints);
+    } else if (totalStepCount && totalStepCount > 0) {
+        progressPercent = Math.round((100 * completedStepCount) / totalStepCount);
+    } else {
+        progressPercent = 0;
+    }
+    progressPercent = Math.max(0, Math.min(100, progressPercent));
+
+    const currentStepDef = currentStepEvent && flowDef ? (flowDef.steps[currentStepEvent.stepInstanceId] as any) : undefined;
+    const currentStepType = currentStepDef?.stepType ?? currentStepEvent?.stepType;
+    const isWaiting = currentStepType === StepType.WAIT_FOR_EXTERNAL_EVENT || currentStepType === StepType.POLL_EXTERNAL_API;
+
+    const currentStep = currentStepEvent
+        ? {
+            stepInstanceId: currentStepEvent.stepInstanceId,
+            displayName: currentStepDef?.displayName,
+            stepType: currentStepType,
+        }
+        : undefined;
+
+    return {
+        flowExecutionId: metadata.flowExecutionId,
+        flowDefinitionId: metadata.flowDefinitionId,
+        flowDefinitionVersion: metadata.flowDefinitionVersion,
+        status,
+        isWaiting,
+        currentStep,
+        currentCheckpoint,
+        completedStepCount,
+        totalStepCount,
+        totalCheckpoints: flowDef ? totalCheckpoints : undefined,
+        progressPercent,
+        startTime: metadata.startTime,
+        endTime: metadata.endTime,
+        children: [],
+    };
+}
 
 const EXECUTION_LOG_TABLE_NAME = process.env[ENV_VAR_NAMES.ALLMA_FLOW_EXECUTION_LOG_TABLE_NAME]!;
 const ddbDocClient = DynamoDBDocumentClient.from(new DynamoDBClient({}));
@@ -196,7 +306,55 @@ export const ExecutionMonitoringService = {
         }
         return { metadata, steps: consolidatedSteps, resolvedFinalContextData };
     },
-    
+
+    /**
+     * Returns live progress for a single execution: current step, stage (checkpoint),
+     * completed/total steps and a percentage. Computed from the minimal step records (no S3
+     * fetch) plus the flow definition. Progress derived from step records requires execution
+     * logging to be enabled for the flow; without it, only metadata-level status is reflected.
+     */
+    async getExecutionProgress(flowExecutionId: string, correlationId: string): Promise<ExecutionProgressResponse | null> {
+        const allItems = await _getExecutionRecords(flowExecutionId);
+        if (allItems.length === 0) return null;
+
+        const metadata = allItems.find(item => item.itemType === ITEM_TYPE_ALLMA_FLOW_EXECUTION_RECORD) as AllmaFlowExecutionRecord;
+        if (!metadata) return null;
+
+        // Minimal step records are sufficient for progress (status + stepInstanceId + timing);
+        // we deliberately avoid resolving the full S3 records here to keep this endpoint cheap to poll.
+        const mainLevelStepEvents = allItems.filter(
+            item => item.itemType === ITEM_TYPE_ALLMA_STEP_EXECUTION_RECORD && !item.branchId,
+        ) as AllmaStepExecutionRecord[];
+
+        let flowDef: FlowDefinition | undefined;
+        try {
+            flowDef = await loadFlowDefinition(metadata.flowDefinitionId, metadata.flowDefinitionVersion, correlationId);
+        } catch (e: any) {
+            // A missing/unparseable definition (e.g. deleted version) degrades gracefully to
+            // status-only progress rather than failing the request.
+            log_warn('Could not load flow definition for progress computation; returning partial progress.', { flowExecutionId, error: e.message }, correlationId);
+        }
+
+        const root = _computeExecutionProgress(metadata, mainLevelStepEvents, flowDef);
+
+        const headlineLabel =
+            root.currentCheckpoint?.label ??
+            root.currentStep?.displayName ??
+            root.currentStep?.stepInstanceId ??
+            (root.status === 'COMPLETED' ? 'Completed' : root.status);
+
+        return {
+            root,
+            headline: {
+                executionId: root.flowExecutionId,
+                label: headlineLabel,
+                percent: root.progressPercent,
+                status: root.status,
+                isWaiting: root.isWaiting,
+            },
+        };
+    },
+
     async getStepRecordDetails(flowExecutionId: string, stepInstanceId: string, attemptNumber?: number, branchExecutionId?: string, correlationId?: string): Promise<AllmaStepExecutionRecord | null> {
         const queryParams: QueryCommandInput = {
             TableName: EXECUTION_LOG_TABLE_NAME,

--- a/packages/app-logic/tests/unit/allma-admin/execution-progress.test.ts
+++ b/packages/app-logic/tests/unit/allma-admin/execution-progress.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import { _computeExecutionProgress } from '../../../src/allma-admin/services/execution-monitoring.service.js';
+import type { AllmaFlowExecutionRecord, AllmaStepExecutionRecord, FlowDefinition } from '@allma/core-types';
+
+/**
+ * `_computeExecutionProgress` derives the live progress node (current step, stage/checkpoint,
+ * completed/total, percentage, waiting-state) from an execution's metadata + step records and
+ * its flow definition. These tests pin the read-time progress contract that the Admin UI and
+ * consumer status views depend on.
+ */
+
+const baseMetadata = (overrides: Partial<AllmaFlowExecutionRecord> = {}): AllmaFlowExecutionRecord =>
+  ({
+    flowExecutionId: '11111111-1111-1111-1111-111111111111',
+    eventTimestamp_stepInstanceId_attempt: 'METADATA',
+    itemType: 'ALLMA_FLOW_EXECUTION_RECORD',
+    flowDefinitionId: 'flow-a',
+    flowDefinitionVersion: 1,
+    status: 'RUNNING',
+    startTime: '2026-01-01T00:00:00.000Z',
+    initialInputPayload: { flowDefinitionId: 'flow-a' },
+    enableExecutionLogs: true,
+    ...overrides,
+  }) as AllmaFlowExecutionRecord;
+
+// Minimal step event; only the fields the progress computation reads are required.
+const stepEvent = (
+  stepInstanceId: string,
+  status: AllmaStepExecutionRecord['status'],
+  eventTimestamp: string,
+  stepType = 'NO_OP',
+): AllmaStepExecutionRecord =>
+  ({
+    flowExecutionId: '11111111-1111-1111-1111-111111111111',
+    eventTimestamp_stepInstanceId_attempt: `STEP#${eventTimestamp}#${stepInstanceId}#1#${status}`,
+    itemType: 'ALLMA_STEP_EXECUTION_RECORD',
+    eventTimestamp,
+    stepInstanceId,
+    stepType,
+    status,
+    startTime: eventTimestamp,
+    fullRecordS3Pointer: { bucket: 'b', key: 'k' },
+  }) as AllmaStepExecutionRecord;
+
+const flowDef = (steps: Record<string, any>): FlowDefinition =>
+  ({ id: 'flow-a', version: 1, startStepInstanceId: 's1', steps } as unknown as FlowDefinition);
+
+describe('_computeExecutionProgress', () => {
+  it('uses step-count progress when the flow declares no checkpoints', () => {
+    const def = flowDef({
+      s1: { stepInstanceId: 's1', stepType: 'NO_OP', displayName: 'First' },
+      s2: { stepInstanceId: 's2', stepType: 'NO_OP', displayName: 'Second' },
+      s3: { stepInstanceId: 's3', stepType: 'NO_OP', displayName: 'Third' },
+      s4: { stepInstanceId: 's4', stepType: 'NO_OP', displayName: 'Fourth' },
+    });
+    const events = [
+      stepEvent('s1', 'STARTED', '2026-01-01T00:00:01.000Z'),
+      stepEvent('s1', 'COMPLETED', '2026-01-01T00:00:02.000Z'),
+      stepEvent('s2', 'STARTED', '2026-01-01T00:00:03.000Z'),
+      stepEvent('s2', 'COMPLETED', '2026-01-01T00:00:04.000Z'),
+      stepEvent('s3', 'STARTED', '2026-01-01T00:00:05.000Z'),
+    ];
+
+    const node = _computeExecutionProgress(baseMetadata(), events, def);
+
+    expect(node.completedStepCount).toBe(2);
+    expect(node.totalStepCount).toBe(4);
+    expect(node.progressPercent).toBe(50); // 2 of 4 completed
+    expect(node.currentStep?.stepInstanceId).toBe('s3');
+    expect(node.currentStep?.displayName).toBe('Third');
+    expect(node.currentCheckpoint).toBeUndefined();
+    expect(node.isWaiting).toBe(false);
+  });
+
+  it('measures progress against checkpoints when declared, using the highest reached', () => {
+    const def = flowDef({
+      s1: { stepInstanceId: 's1', stepType: 'NO_OP', checkpoint: { id: 'a', label: 'Upload', order: 0 } },
+      s2: { stepInstanceId: 's2', stepType: 'NO_OP' },
+      s3: { stepInstanceId: 's3', stepType: 'NO_OP', checkpoint: { id: 'b', label: 'Extract', order: 1 } },
+      s4: { stepInstanceId: 's4', stepType: 'NO_OP', checkpoint: { id: 'c', label: 'Save', order: 2 } },
+    });
+    const events = [
+      stepEvent('s1', 'STARTED', '2026-01-01T00:00:01.000Z'),
+      stepEvent('s1', 'COMPLETED', '2026-01-01T00:00:02.000Z'),
+      stepEvent('s2', 'COMPLETED', '2026-01-01T00:00:03.000Z'),
+      stepEvent('s3', 'STARTED', '2026-01-01T00:00:04.000Z'),
+    ];
+
+    const node = _computeExecutionProgress(baseMetadata(), events, def);
+
+    expect(node.totalCheckpoints).toBe(3);
+    expect(node.currentCheckpoint).toMatchObject({ id: 'b', label: 'Extract', ordinal: 2 });
+    expect(node.progressPercent).toBe(67); // round(100 * 2/3)
+  });
+
+  it('flags the waiting state for long-pausing step types', () => {
+    const def = flowDef({
+      s1: { stepInstanceId: 's1', stepType: 'WAIT_FOR_EXTERNAL_EVENT', displayName: 'Await approval' },
+    });
+    const events = [stepEvent('s1', 'STARTED', '2026-01-01T00:00:01.000Z', 'WAIT_FOR_EXTERNAL_EVENT')];
+
+    const node = _computeExecutionProgress(baseMetadata(), events, def);
+
+    expect(node.isWaiting).toBe(true);
+    expect(node.currentStep?.stepInstanceId).toBe('s1');
+  });
+
+  it('clamps to 100% and drops the current step on terminal COMPLETED', () => {
+    const def = flowDef({
+      s1: { stepInstanceId: 's1', stepType: 'NO_OP', checkpoint: { id: 'a', label: 'Start', order: 0 } },
+      s2: { stepInstanceId: 's2', stepType: 'NO_OP', checkpoint: { id: 'b', label: 'End', order: 1 } },
+    });
+    // Only the first checkpoint was reached, but the flow completed → bar must still read 100%.
+    const events = [
+      stepEvent('s1', 'STARTED', '2026-01-01T00:00:01.000Z'),
+      stepEvent('s1', 'COMPLETED', '2026-01-01T00:00:02.000Z'),
+    ];
+
+    const node = _computeExecutionProgress(
+      baseMetadata({ status: 'COMPLETED', endTime: '2026-01-01T00:00:03.000Z' }),
+      events,
+      def,
+    );
+
+    expect(node.progressPercent).toBe(100);
+    expect(node.currentStep).toBeUndefined();
+  });
+
+  it('degrades gracefully when the flow definition is unavailable', () => {
+    const events = [
+      stepEvent('s1', 'COMPLETED', '2026-01-01T00:00:02.000Z'),
+      stepEvent('s2', 'STARTED', '2026-01-01T00:00:03.000Z'),
+    ];
+
+    const node = _computeExecutionProgress(baseMetadata(), events, undefined);
+
+    expect(node.totalStepCount).toBeUndefined();
+    expect(node.totalCheckpoints).toBeUndefined();
+    expect(node.completedStepCount).toBe(1);
+    // No definition → cannot resolve a percentage from a denominator, stays at 0 while running.
+    expect(node.progressPercent).toBe(0);
+    // Current step still identified from the records, with stepType falling back to the event.
+    expect(node.currentStep?.stepInstanceId).toBe('s2');
+  });
+});

--- a/packages/core-cdk/lib/constructs/admin-api.ts
+++ b/packages/core-cdk/lib/constructs/admin-api.ts
@@ -250,6 +250,13 @@ export class AllmaAdminApi extends Construct {
     });
 
     this.httpApi.addRoutes({
+      path: `${ALLMA_ADMIN_API_ROUTES.FLOW_EXECUTIONS}/{flowExecutionId}/progress`,
+      methods: [apigwv2.HttpMethod.GET],
+      integration: executionMonitoringIntegration,
+      authorizer: adminAuthorizer,
+    });
+
+    this.httpApi.addRoutes({
       path: `${ALLMA_ADMIN_API_ROUTES.FLOW_EXECUTIONS}/{flowExecutionId}/branch-steps`,
       methods: [apigwv2.HttpMethod.GET],
       integration: executionMonitoringIntegration,

--- a/packages/core-types/src/admin/endpoints.ts
+++ b/packages/core-types/src/admin/endpoints.ts
@@ -53,7 +53,8 @@ export const ALLMA_ADMIN_API_ROUTES = {
 
   // Flow Executions
   FLOW_EXECUTIONS: `/allma/${ARS.FLOW_EXECUTIONS}`,
-  FLOW_EXECUTION_DETAIL: (executionId: string) => `/allma/${ARS.FLOW_EXECUTIONS}/${executionId}`, 
+  FLOW_EXECUTION_DETAIL: (executionId: string) => `/allma/${ARS.FLOW_EXECUTIONS}/${executionId}`,
+  FLOW_EXECUTION_PROGRESS: (executionId: string) => `/allma/${ARS.FLOW_EXECUTIONS}/${executionId}/progress`,
   FLOW_EXECUTION_BRANCH_STEPS: (executionId: string) => `/allma/${ARS.FLOW_EXECUTIONS}/${executionId}/branch-steps`,
   FLOW_EXECUTION_STEP_RECORD: (executionId: string) => `/allma/${ARS.FLOW_EXECUTIONS}/${executionId}/step-record`,
   FLOW_EXECUTION_REDRIVE: (executionId: string) => `/allma/${ARS.FLOW_EXECUTIONS}/${executionId}/redrive`,

--- a/packages/core-types/src/admin/executionMonitoring.ts
+++ b/packages/core-types/src/admin/executionMonitoring.ts
@@ -37,6 +37,64 @@ export const ListFlowExecutionsResponseSchema = z.object({
 export type ListFlowExecutionsResponse = z.infer<typeof ListFlowExecutionsResponseSchema>;
 
 /**
+ * Live progress of a single flow execution, computed for the Admin UI and consumer status views.
+ *
+ * Progress uses two layers:
+ *  - L2 (checkpoints): if the flow tags any step with a `checkpoint`, progress is measured against
+ *    those milestones — `progressPercent` and `currentCheckpoint` reflect the milestone reached.
+ *  - L1 (step count): otherwise, progress is `completedStepCount / totalStepCount`.
+ *
+ * `children` is reserved for the Phase 2 sub-flow/branch tree and is empty in the single-execution view.
+ */
+export const ExecutionProgressNodeSchema = z.object({
+  flowExecutionId: z.string().uuid(),
+  flowDefinitionId: z.string(),
+  flowDefinitionVersion: z.number().int().optional(),
+  status: z.enum(['INITIALIZING', 'RUNNING', 'COMPLETED', 'FAILED', 'TIMED_OUT', 'CANCELLED']),
+  /** True when the current step can pause for a long time (WAIT_FOR_EXTERNAL_EVENT / POLL_EXTERNAL_API). */
+  isWaiting: z.boolean(),
+  /** The step currently executing (omitted once the execution reaches a terminal status). */
+  currentStep: z.object({
+    stepInstanceId: z.string(),
+    displayName: z.string().optional(),
+    stepType: z.string().optional(),
+  }).optional(),
+  /** The most advanced checkpoint reached so far (only when the flow declares checkpoints). */
+  currentCheckpoint: z.object({
+    id: z.string(),
+    label: z.string(),
+    order: z.number().int().optional(),
+    /** 1-based position of this checkpoint among all declared checkpoints. */
+    ordinal: z.number().int().optional(),
+  }).optional(),
+  completedStepCount: z.number().int(),
+  totalStepCount: z.number().int().optional(),
+  totalCheckpoints: z.number().int().optional(),
+  progressPercent: z.number().int().min(0).max(100),
+  startTime: z.string(),
+  endTime: z.string().optional(),
+  /** Reserved for the Phase 2 nested sub-flow / parallel-branch tree. Empty today. */
+  children: z.array(z.any()).default([]),
+});
+export type ExecutionProgressNode = z.infer<typeof ExecutionProgressNodeSchema>;
+
+/**
+ * API response for the execution-progress endpoint. `headline` is a one-line summary of the
+ * deepest active work, suitable for compact status widgets.
+ */
+export const ExecutionProgressResponseSchema = z.object({
+  root: ExecutionProgressNodeSchema,
+  headline: z.object({
+    executionId: z.string().uuid(),
+    label: z.string(),
+    percent: z.number().int().min(0).max(100),
+    status: z.string(),
+    isWaiting: z.boolean(),
+  }),
+});
+export type ExecutionProgressResponse = z.infer<typeof ExecutionProgressResponseSchema>;
+
+/**
  * A group of steps belonging to a single parallel branch execution.
  */
 export const BranchExecutionGroupSchema = z.object({

--- a/packages/core-types/src/steps/definitions.ts
+++ b/packages/core-types/src/steps/definitions.ts
@@ -135,6 +135,19 @@ export const StepInstanceSchema = BaseStepDefinitionSchema.and(z.object({
   stepInstanceId: z.string().min(1),
   stepDefinitionId: StepDefinitionIdSchema.optional().nullable(),
   displayName: z.string().optional(),
+  /**
+   * Optional progress milestone for this step. When a flow tags one or more steps as
+   * checkpoints, execution-progress views measure progress against these meaningful
+   * milestones (e.g. "Extracting documents") instead of every micro-step. The checkpoint
+   * travels with the step, so the set of checkpoints — and therefore the progress
+   * denominator — is derived from the flow definition and needs no separate list to maintain.
+   * `order` (optional) keeps progress monotonic and provides a stable "stage N of M" label.
+   */
+  checkpoint: z.object({
+    id: z.string().min(1).describe("Checkpoint ID|text|Stable identifier for this progress milestone; clients can map it to their own status text."),
+    label: z.string().min(1).describe("Checkpoint Label|text|Human-readable milestone shown in progress views."),
+    order: z.number().int().min(0).optional().describe("Checkpoint Order|number|Optional ordering used for monotonic progress and the 'stage N of M' label."),
+  }).optional(),
   position: z.object({ x: z.number(), y: z.number() }).optional(),
   fill: z.string().optional(), // UI-specific property
   transitions: z.array(z.object({


### PR DESCRIPTION
## Summary

**Phase 1** of real-time execution status (design: `docs/design/real-time-execution-status.md`). Gives the Admin UI a live, easy-to-read answer to *"where is this execution right now and how far along is it?"* — **without** time estimation, exactly as scoped.

It adds two things:
- An optional **checkpoint** on a step, so a flow author can tag a few meaningful milestones (e.g. *Upload → Extract → Save*) and progress is measured against those instead of every millisecond-scale micro-step.
- A read-time **progress endpoint** + a self-refreshing **progress bar** on the execution detail page.

## What you get in the UI
- **Current step / stage** — the step running now (its `displayName`), or the current checkpoint label.
- **% complete** — checkpoint-based when the flow declares checkpoints (`stage N of M`), otherwise step-count based (`completed / total steps`).
- **Waiting state** — when the current step is `WAIT_FOR_EXTERNAL_EVENT` / `POLL_EXTERNAL_API` (which can pause for a long time), the bar shows *Waiting* instead of a misleading active spinner.
- **Live updates** — the hook polls every 3s while `RUNNING` and **stops automatically** on a terminal status, so finished executions incur no further requests.

## Design choice: read-time derivation (not orchestrator stamping)
Progress is **computed at read time** in `GET /flow-executions/{id}/progress` from the execution's existing step records + flow definition. This keeps Phase 1 off the hot orchestration path (zero risk to flow execution) while delivering the full UX. Orchestrator stamping + the child→root `liveStatus` bubble-up are deliberately deferred to Phase 2, where they also enable the sub-flow tree and lag-free single-item reads.

**Implication:** progress requires execution logging enabled for the flow (it reads step records). When the flow definition can't be loaded (e.g. a deleted version), it degrades gracefully to status-only progress rather than failing.

## Changes by package
- **`@allma/core-types`** *(minor)* — `StepInstance.checkpoint` `{ id, label, order? }`; `FLOW_EXECUTION_PROGRESS` route; `ExecutionProgressResponse` / `ExecutionProgressNode` schemas (with a reserved empty `children[]` for the Phase 2 tree).
- **`allma-app-logic`** (bundled by `@allma/core-cdk`, *patch*) — `getExecutionProgress` service + `_computeExecutionProgress` pure helper + the `/progress` handler route.
- **`@allma/core-cdk`** *(patch)* — register the new HTTP route. No new IAM/env: the execution-monitoring Lambda already reads the config table.
- **`@allma/admin-shell`** *(patch)* — `useGetExecutionProgress` hook + `ExecutionProgressBar` on the detail page.

## Tests
- New `execution-progress.test.ts` (5 cases): step-count %, checkpoint % (highest reached / monotonic), waiting-state detection, terminal-COMPLETED clamps to 100% and drops current step, and graceful degradation when the flow definition is missing.
- `core-types`, `app-logic`, `core-cdk`, `admin-shell` all build; ESLint clean.

## Not in this PR (later phases)
Orchestrator stamping + `liveStatus` bubble-up · sub-flow / parallel-branch **tree** (`mode=tree`, `GSI_ByRoot`) · client notifications (`notificationConfig`, status SNS topic, crash-safe EventBridge dispatcher + reconciler). All specced in the design doc.

## Versioning
One changeset: `core-types` minor (new optional field + exported schemas/route), `core-cdk` + `admin-shell` patch. No breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdBdzjjoMHmhv8N8amEw4C