### PR TITLE
feat(executions): execution tree across sub-flows & lag-free progress stamping (phase 2)

### DIFF
--- a/.changeset/realtime-execution-tree-phase2.md
+++ b/.changeset/realtime-execution-tree-phase2.md
@@ -1,0 +1,32 @@
+---
+"@allma/core-types": minor
+"@allma/core-cdk": patch
+"@allma/admin-shell": patch
+---
+
+feat(executions): execution tree across sub-flows & lag-free progress stamping (phase 2)
+
+Builds on the Phase 1 single-execution progress view (Pillars B and the authoritative half of A
+from the real-time execution status design).
+
+- **Orchestrator stamping (Pillar A).** The iterative step processor now stamps the execution's
+  `METADATA` record at each step boundary with the current step, completed/total step counts, the
+  reached checkpoint, and a percentage — giving the UI/clients a single, lag-free item to poll. A
+  new `UPDATE_PROGRESS` logger action performs a guarded, monotonic `UpdateItem`. The Phase 1
+  read-time derivation remains as a fallback for executions stamped before this change.
+- **Structured execution-tree linkage (Pillar B).** Sub-flows now record `parentFlowExecutionId`,
+  `parentStepInstanceId`, `rootFlowExecutionId`, `depth`, and `executionKind` on their own metadata
+  record (sync and async sub-flows; a top-level execution is `ROOT`/depth 0). A new
+  `GSI_ByRoot` index returns a whole tree in one query.
+- **Bubble-up roll-up.** On a checkpoint change a sync sub-flow writes a one-line `liveStatus` onto
+  the root record so a single GET of the root reflects the deepest active work even while the parent
+  is suspended. Async sub-flows are linked but not bubbled into the root headline.
+- **Tree read API.** `GET /flow-executions/{id}/progress?mode=tree|single` — `single` (stamped
+  preferred) returns one node; `tree` assembles the nested sub-flow tree with a headline pointing
+  at the deepest active leaf.
+- **Admin UI.** The execution progress bar renders the nested sub-flow tree, each node with its own
+  bar, current-step line, and waiting state.
+
+All new fields are optional and backward-compatible: flows adopting nothing keep working, and
+pre-existing executions return a single-node tree. In-memory parallel branches share the parent's
+`flowExecutionId` and remain surfaced via the existing branch-steps view rather than as tree nodes.

--- a/packages/admin-shell/src/api/executionService.ts
+++ b/packages/admin-shell/src/api/executionService.ts
@@ -80,14 +80,18 @@ export const useGetExecutionDetail = (executionId: string | undefined): UseQuery
 // Polls while the execution is still running and automatically stops once it reaches a
 // terminal status, so completed executions incur no further requests.
 
-export const useGetExecutionProgress = (executionId: string | undefined): UseQueryResult<ExecutionProgressResponse, Error> => {
+export const useGetExecutionProgress = (
+  executionId: string | undefined,
+  mode: 'single' | 'tree' = 'tree',
+): UseQueryResult<ExecutionProgressResponse, Error> => {
   return useQuery({
-    queryKey: [EXECUTION_PROGRESS_QUERY_KEY, executionId],
+    queryKey: [EXECUTION_PROGRESS_QUERY_KEY, executionId, mode],
     queryFn: async () => {
       if (!executionId) throw new Error('Execution ID is undefined.');
 
       const response = await axiosInstance.get<AdminApiResponse<ExecutionProgressResponse>>(
-        `/${ALLMA_ADMIN_API_VERSION}${ALLMA_ADMIN_API_ROUTES.FLOW_EXECUTION_PROGRESS(executionId)}`
+        `/${ALLMA_ADMIN_API_VERSION}${ALLMA_ADMIN_API_ROUTES.FLOW_EXECUTION_PROGRESS(executionId)}`,
+        { params: { mode } }
       );
 
       if (response.data.success) {

--- a/packages/admin-shell/src/features/executions/components/ExecutionProgressBar.tsx
+++ b/packages/admin-shell/src/features/executions/components/ExecutionProgressBar.tsx
@@ -1,79 +1,131 @@
-import { Badge, Group, Paper, Progress, Text, Tooltip } from '@mantine/core';
-import { IconClockPause } from '@tabler/icons-react';
+import { Badge, Box, Group, Paper, Progress, Stack, Text, Tooltip } from '@mantine/core';
+import { IconClockPause, IconSubtask } from '@tabler/icons-react';
+import { ExecutionProgressNode } from '@allma/core-types';
 import { useGetExecutionProgress } from '../../../api/executionService';
 
 const TERMINAL_STATUSES = ['COMPLETED', 'FAILED', 'TIMED_OUT', 'CANCELLED'];
+
+const KIND_LABELS: Record<string, string> = {
+    SYNC_SUBFLOW: 'Sync sub-flow',
+    ASYNC_SUBFLOW: 'Async sub-flow',
+    PARALLEL_BRANCH: 'Parallel branch',
+};
 
 interface ExecutionProgressBarProps {
     flowExecutionId: string;
 }
 
+function nodeTitle(node: ExecutionProgressNode): string {
+    return (
+        node.currentCheckpoint?.label ??
+        node.currentStep?.displayName ??
+        node.currentStep?.stepInstanceId ??
+        (node.status === 'COMPLETED' ? 'Completed' : node.status)
+    );
+}
+
 /**
- * Compact, self-refreshing progress indicator for a running execution. Shows the current
- * step / checkpoint stage, a percentage, and a "waiting" badge when the flow is paused on an
- * external event or long poll. Polling is handled by the underlying query and stops on terminal
- * status, so this renders a static final state once the execution finishes.
+ * Renders one execution node (its current stage, percentage and waiting state) and recursively
+ * renders any nested sub-flow / branch nodes beneath it, each with its own bar. Child nodes are
+ * indented with a left border so the tree structure is visible at a glance.
+ */
+function ProgressNodeView({ node, depth }: { node: ExecutionProgressNode; depth: number }) {
+    const isTerminal = TERMINAL_STATUSES.includes(node.status);
+    const isFailed = node.status === 'FAILED' || node.status === 'TIMED_OUT' || node.status === 'CANCELLED';
+    const color = isFailed ? 'red' : node.status === 'COMPLETED' ? 'green' : 'blue';
+
+    const stepsLabel =
+        node.totalCheckpoints && node.totalCheckpoints > 0
+            ? `Stage ${node.currentCheckpoint?.ordinal ?? 0} of ${node.totalCheckpoints}`
+            : node.totalStepCount && node.totalStepCount > 0
+                ? `${node.completedStepCount} of ${node.totalStepCount} steps`
+                : `${node.completedStepCount} steps done`;
+
+    const kindLabel = depth > 0 && node.executionKind ? KIND_LABELS[node.executionKind] : undefined;
+
+    return (
+        <Box
+            style={
+                depth > 0
+                    ? { borderLeft: '2px solid var(--mantine-color-default-border)', paddingLeft: 'var(--mantine-spacing-md)' }
+                    : undefined
+            }
+        >
+            <Paper withBorder p="sm" radius="md" mb="sm">
+                <Group justify="space-between" mb={6} wrap="nowrap">
+                    <Group gap="xs" wrap="nowrap" style={{ minWidth: 0 }}>
+                        {kindLabel && (
+                            <Tooltip label={kindLabel}>
+                                <Badge color="grape" variant="light" leftSection={<IconSubtask size={12} />}>
+                                    {kindLabel}
+                                </Badge>
+                            </Tooltip>
+                        )}
+                        <Text fw={600} size="sm" truncate>
+                            {nodeTitle(node)}
+                        </Text>
+                        {node.isWaiting && (
+                            <Tooltip label="Paused waiting for an external event or long-running poll">
+                                <Badge color="yellow" variant="light" leftSection={<IconClockPause size={12} />}>
+                                    Waiting
+                                </Badge>
+                            </Tooltip>
+                        )}
+                        {!isTerminal && !node.isWaiting && (
+                            <Badge color="blue" variant="light">
+                                Running
+                            </Badge>
+                        )}
+                    </Group>
+                    <Text fw={700} size="sm" c={color} style={{ flexShrink: 0 }}>
+                        {node.progressPercent}%
+                    </Text>
+                </Group>
+                <Progress
+                    value={node.progressPercent}
+                    color={color}
+                    striped={!isTerminal}
+                    animated={!isTerminal && !node.isWaiting}
+                    radius="xl"
+                />
+                <Group justify="space-between" mt={6}>
+                    <Text size="xs" c="dimmed">
+                        {stepsLabel}
+                    </Text>
+                    {node.currentStep && !isTerminal && (
+                        <Text size="xs" c="dimmed" truncate>
+                            Current: {node.currentStep.displayName ?? node.currentStep.stepInstanceId}
+                        </Text>
+                    )}
+                </Group>
+            </Paper>
+
+            {node.children.length > 0 && (
+                <Stack gap={0}>
+                    {node.children.map((child) => (
+                        <ProgressNodeView key={child.flowExecutionId} node={child} depth={depth + 1} />
+                    ))}
+                </Stack>
+            )}
+        </Box>
+    );
+}
+
+/**
+ * Self-refreshing progress indicator for an execution and its sub-flow tree. Fetches in `tree`
+ * mode so nested sync/async sub-flow nodes are shown beneath the root, each with its own bar and
+ * current-step line. Polling stops on terminal status, so this renders a static final state once
+ * the execution finishes.
  */
 export function ExecutionProgressBar({ flowExecutionId }: ExecutionProgressBarProps) {
-    const { data, isLoading } = useGetExecutionProgress(flowExecutionId);
+    const { data, isLoading } = useGetExecutionProgress(flowExecutionId, 'tree');
 
     // Nothing to show until the first response arrives (avoids a layout flash).
     if (isLoading || !data) return null;
 
-    const { root, headline } = data;
-    const isTerminal = TERMINAL_STATUSES.includes(root.status);
-    const isFailed = root.status === 'FAILED' || root.status === 'TIMED_OUT' || root.status === 'CANCELLED';
-
-    const stepsLabel =
-        root.totalCheckpoints && root.totalCheckpoints > 0
-            ? `Stage ${root.currentCheckpoint?.ordinal ?? 0} of ${root.totalCheckpoints}`
-            : root.totalStepCount && root.totalStepCount > 0
-                ? `${root.completedStepCount} of ${root.totalStepCount} steps`
-                : `${root.completedStepCount} steps done`;
-
-    const color = isFailed ? 'red' : root.status === 'COMPLETED' ? 'green' : 'blue';
-
     return (
-        <Paper withBorder p="sm" radius="md" mb="md">
-            <Group justify="space-between" mb={6} wrap="nowrap">
-                <Group gap="xs" wrap="nowrap" style={{ minWidth: 0 }}>
-                    <Text fw={600} size="sm" truncate>
-                        {headline.label}
-                    </Text>
-                    {root.isWaiting && (
-                        <Tooltip label="Paused waiting for an external event or long-running poll">
-                            <Badge color="yellow" variant="light" leftSection={<IconClockPause size={12} />}>
-                                Waiting
-                            </Badge>
-                        </Tooltip>
-                    )}
-                    {!isTerminal && !root.isWaiting && (
-                        <Badge color="blue" variant="light">
-                            Running
-                        </Badge>
-                    )}
-                </Group>
-                <Text fw={700} size="sm" c={color} style={{ flexShrink: 0 }}>
-                    {root.progressPercent}%
-                </Text>
-            </Group>
-            <Progress
-                value={root.progressPercent}
-                color={color}
-                striped={!isTerminal}
-                animated={!isTerminal && !root.isWaiting}
-                radius="xl"
-            />
-            <Group justify="space-between" mt={6}>
-                <Text size="xs" c="dimmed">
-                    {stepsLabel}
-                </Text>
-                {root.currentStep && !isTerminal && (
-                    <Text size="xs" c="dimmed" truncate>
-                        Current: {root.currentStep.displayName ?? root.currentStep.stepInstanceId}
-                    </Text>
-                )}
-            </Group>
-        </Paper>
+        <Box mb="md">
+            <ProgressNodeView node={data.root} depth={0} />
+        </Box>
     );
 }

--- a/packages/app-logic/src/allma-admin/execution-monitoring.ts
+++ b/packages/app-logic/src/allma-admin/execution-monitoring.ts
@@ -49,11 +49,14 @@ router.get('/flow-executions/{flowExecutionId}', async (event, authContext, { fl
     return createApiGatewayResponse(200, buildSuccessResponse(details), correlationId);
 });
 
-// Route for getting live progress of a single execution (current step, stage, % complete).
-// GET /flow-executions/{flowExecutionId}/progress
+// Route for getting live progress of an execution (current step, stage, % complete).
+// GET /flow-executions/{flowExecutionId}/progress?mode=single|tree
+//   single (default) → just this execution's node (stamped metadata preferred).
+//   tree             → this execution's whole sub-flow tree, assembled from GSI_ByRoot.
 router.get('/flow-executions/{flowExecutionId}/progress', async (event, authContext, { flowExecutionId }) => {
     const correlationId = event.requestContext.requestId;
-    const progress = await ExecutionMonitoringService.getExecutionProgress(flowExecutionId, correlationId);
+    const mode = event.queryStringParameters?.mode === 'tree' ? 'tree' : 'single';
+    const progress = await ExecutionMonitoringService.getExecutionProgress(flowExecutionId, correlationId, mode);
 
     if (!progress) {
         return createApiGatewayResponse(404, buildErrorResponse(`Execution with ID ${flowExecutionId} not found.`, 'NOT_FOUND'), correlationId);

--- a/packages/app-logic/src/allma-admin/services/execution-monitoring.service.ts
+++ b/packages/app-logic/src/allma-admin/services/execution-monitoring.service.ts
@@ -1,10 +1,10 @@
 import { AttributeValue, DynamoDBClient, QueryCommandOutput } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient, QueryCommand, QueryCommandInput } from '@aws-sdk/lib-dynamodb';
+import { DynamoDBDocumentClient, QueryCommand, QueryCommandInput, GetCommand } from '@aws-sdk/lib-dynamodb';
 import {
     ENV_VAR_NAMES, FlowExecutionDetails, PaginatedResponse, FlowExecutionSummary, AllmaFlowExecutionRecord,
     AllmaStepExecutionRecord, ITEM_TYPE_ALLMA_FLOW_EXECUTION_RECORD, ITEM_TYPE_ALLMA_STEP_EXECUTION_RECORD,
     StepType, BranchStepsResponse, BranchExecutionGroup,
-    FlowDefinition, ExecutionProgressNode, ExecutionProgressResponse
+    FlowDefinition, ExecutionProgressNode, ExecutionProgressResponse, METADATA_SK_VALUE
 } from '@allma/core-types';
 import { log_error, log_warn, resolveS3Pointer } from '@allma/core-sdk';
 import { loadFlowDefinition } from '../../allma-core/config-loader.js';
@@ -117,8 +117,93 @@ export function _computeExecutionProgress(
     };
 }
 
+/**
+ * True when the orchestrator has stamped live progress onto the metadata record (Pillar A). When
+ * present, the metadata item is authoritative and lag-free, so the read API serves it directly
+ * instead of deriving progress from (async, possibly-lagging) step records.
+ */
+function _isStamped(metadata: Partial<AllmaFlowExecutionRecord>): boolean {
+    return metadata.progressUpdatedAt !== undefined;
+}
+
+/**
+ * Builds a progress node directly from a stamped metadata record (or a GSI_ByRoot-projected item).
+ * No step records or flow definition required.
+ */
+function _nodeFromStampedMetadata(m: Partial<AllmaFlowExecutionRecord> & { flowExecutionId: string; flowDefinitionId: string; status: AllmaFlowExecutionRecord['status']; startTime: string; }): ExecutionProgressNode {
+    const status = m.status;
+    const isTerminal = (TERMINAL_FLOW_STATUSES as readonly string[]).includes(status);
+    const stepType = m.currentStepType;
+    const isWaiting = !isTerminal && (stepType === StepType.WAIT_FOR_EXTERNAL_EVENT || stepType === StepType.POLL_EXTERNAL_API);
+
+    let progressPercent = typeof m.progressPercent === 'number' ? m.progressPercent : 0;
+    if (status === 'COMPLETED') progressPercent = 100;
+    progressPercent = Math.max(0, Math.min(100, progressPercent));
+
+    const currentStep = !isTerminal && m.currentStepInstanceId
+        ? { stepInstanceId: m.currentStepInstanceId, displayName: m.currentStepDisplayName, stepType: m.currentStepType }
+        : undefined;
+
+    return {
+        flowExecutionId: m.flowExecutionId,
+        flowDefinitionId: m.flowDefinitionId,
+        flowDefinitionVersion: m.flowDefinitionVersion,
+        executionKind: m.executionKind ?? 'ROOT',
+        parentStepInstanceId: m.parentStepInstanceId,
+        depth: m.depth ?? 0,
+        status,
+        isWaiting,
+        currentStep,
+        currentCheckpoint: m.currentCheckpoint,
+        completedStepCount: m.completedStepCount ?? 0,
+        totalStepCount: m.totalStepCount,
+        totalCheckpoints: m.totalCheckpoints,
+        progressPercent,
+        startTime: m.startTime,
+        endTime: m.endTime,
+        children: [],
+    };
+}
+
+/** A one-line headline summarising a single node's current work, for compact status widgets. */
+function _headlineFromNode(node: ExecutionProgressNode): ExecutionProgressResponse['headline'] {
+    const label =
+        node.currentCheckpoint?.label ??
+        node.currentStep?.displayName ??
+        node.currentStep?.stepInstanceId ??
+        (node.status === 'COMPLETED' ? 'Completed' : node.status);
+    return { executionId: node.flowExecutionId, label, percent: node.progressPercent, status: node.status, isWaiting: node.isWaiting };
+}
+
 const EXECUTION_LOG_TABLE_NAME = process.env[ENV_VAR_NAMES.ALLMA_FLOW_EXECUTION_LOG_TABLE_NAME]!;
 const ddbDocClient = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+/** Fetches a single execution's METADATA item directly (cheap, for the progress endpoint). */
+async function _getMetadataItem(flowExecutionId: string): Promise<AllmaFlowExecutionRecord | null> {
+    const { Item } = await ddbDocClient.send(new GetCommand({
+        TableName: EXECUTION_LOG_TABLE_NAME,
+        Key: { flowExecutionId, eventTimestamp_stepInstanceId_attempt: METADATA_SK_VALUE },
+    }));
+    return (Item as AllmaFlowExecutionRecord) ?? null;
+}
+
+/** Queries every execution node in a tree (root + descendants) via GSI_ByRoot in one pass. */
+async function _queryTreeNodes(rootFlowExecutionId: string): Promise<any[]> {
+    let items: any[] = [];
+    let lastEvaluatedKey: Record<string, AttributeValue> | undefined;
+    do {
+        const result: QueryCommandOutput = await ddbDocClient.send(new QueryCommand({
+            TableName: EXECUTION_LOG_TABLE_NAME,
+            IndexName: 'GSI_ByRoot',
+            KeyConditionExpression: 'rootFlowExecutionId = :r',
+            ExpressionAttributeValues: { ':r': rootFlowExecutionId },
+            ExclusiveStartKey: lastEvaluatedKey,
+        }));
+        if (result.Items) items = items.concat(result.Items);
+        lastEvaluatedKey = result.LastEvaluatedKey;
+    } while (lastEvaluatedKey);
+    return items;
+}
 
 /**
  * Fetches all raw DynamoDB records for a single flow execution.
@@ -308,20 +393,42 @@ export const ExecutionMonitoringService = {
     },
 
     /**
-     * Returns live progress for a single execution: current step, stage (checkpoint),
-     * completed/total steps and a percentage. Computed from the minimal step records (no S3
-     * fetch) plus the flow definition. Progress derived from step records requires execution
-     * logging to be enabled for the flow; without it, only metadata-level status is reflected.
+     * Returns live progress for an execution: current step, stage (checkpoint), completed/total
+     * steps and a percentage.
+     *
+     * `mode='single'` (default) returns just the requested execution's node. It prefers the
+     * orchestrator-stamped metadata (Pillar A) — a single, lag-free GetItem — and falls back to
+     * deriving progress from step records for executions predating the stamping (or before the
+     * first stamp lands).
+     *
+     * `mode='tree'` assembles the whole execution tree (root + sub-flows) from a single
+     * GSI_ByRoot query (Pillar B): each node carries its own progress, nested under the parent
+     * that launched it, with a headline pointing at the deepest active leaf.
      */
-    async getExecutionProgress(flowExecutionId: string, correlationId: string): Promise<ExecutionProgressResponse | null> {
-        const allItems = await _getExecutionRecords(flowExecutionId);
-        if (allItems.length === 0) return null;
-
-        const metadata = allItems.find(item => item.itemType === ITEM_TYPE_ALLMA_FLOW_EXECUTION_RECORD) as AllmaFlowExecutionRecord;
+    async getExecutionProgress(flowExecutionId: string, correlationId: string, mode: 'single' | 'tree' = 'single'): Promise<ExecutionProgressResponse | null> {
+        const metadata = await _getMetadataItem(flowExecutionId);
         if (!metadata) return null;
 
-        // Minimal step records are sufficient for progress (status + stepInstanceId + timing);
-        // we deliberately avoid resolving the full S3 records here to keep this endpoint cheap to poll.
+        if (mode === 'tree') {
+            return this._buildExecutionTree(metadata, correlationId);
+        }
+
+        const root = await this._buildProgressNode(metadata, correlationId);
+        return { root, headline: _headlineFromNode(root) };
+    },
+
+    /**
+     * Builds one progress node, preferring stamped metadata and falling back to read-time
+     * derivation from step records (+ flow definition) for un-stamped/legacy executions.
+     */
+    async _buildProgressNode(metadata: AllmaFlowExecutionRecord, correlationId: string): Promise<ExecutionProgressNode> {
+        if (_isStamped(metadata)) {
+            return _nodeFromStampedMetadata(metadata);
+        }
+
+        // Fallback: derive from the (minimal) step records + flow definition. No S3 fetch, so the
+        // endpoint stays cheap to poll. Requires execution logging to have been enabled.
+        const allItems = await _getExecutionRecords(metadata.flowExecutionId);
         const mainLevelStepEvents = allItems.filter(
             item => item.itemType === ITEM_TYPE_ALLMA_STEP_EXECUTION_RECORD && !item.branchId,
         ) as AllmaStepExecutionRecord[];
@@ -330,29 +437,66 @@ export const ExecutionMonitoringService = {
         try {
             flowDef = await loadFlowDefinition(metadata.flowDefinitionId, metadata.flowDefinitionVersion, correlationId);
         } catch (e: any) {
-            // A missing/unparseable definition (e.g. deleted version) degrades gracefully to
-            // status-only progress rather than failing the request.
-            log_warn('Could not load flow definition for progress computation; returning partial progress.', { flowExecutionId, error: e.message }, correlationId);
+            log_warn('Could not load flow definition for progress computation; returning partial progress.', { flowExecutionId: metadata.flowExecutionId, error: e.message }, correlationId);
         }
 
-        const root = _computeExecutionProgress(metadata, mainLevelStepEvents, flowDef);
+        return _computeExecutionProgress(metadata, mainLevelStepEvents, flowDef);
+    },
 
-        const headlineLabel =
-            root.currentCheckpoint?.label ??
-            root.currentStep?.displayName ??
-            root.currentStep?.stepInstanceId ??
-            (root.status === 'COMPLETED' ? 'Completed' : root.status);
+    /**
+     * Assembles the nested execution tree rooted at the requested execution's root. Falls back to
+     * a single-node tree when the execution predates tree linkage (no GSI rows).
+     */
+    async _buildExecutionTree(requested: AllmaFlowExecutionRecord, correlationId: string): Promise<ExecutionProgressResponse> {
+        const rootId = requested.rootFlowExecutionId ?? requested.flowExecutionId;
+        const items = await _queryTreeNodes(rootId);
 
-        return {
-            root,
-            headline: {
-                executionId: root.flowExecutionId,
-                label: headlineLabel,
-                percent: root.progressPercent,
-                status: root.status,
-                isWaiting: root.isWaiting,
-            },
-        };
+        // No linkage rows (pre-existing execution) → degrade to a single-node tree.
+        if (items.length === 0) {
+            const node = await this._buildProgressNode(requested, correlationId);
+            return { root: node, headline: _headlineFromNode(node) };
+        }
+
+        const byId = new Map<string, ExecutionProgressNode>();
+        for (const item of items) {
+            byId.set(item.flowExecutionId, _nodeFromStampedMetadata(item));
+        }
+
+        // The root may not appear in the index if it predates linkage but a child points at it;
+        // build it from its own metadata so the tree always has a root.
+        let rootNode = byId.get(rootId);
+        if (!rootNode) {
+            const rootMeta = rootId === requested.flowExecutionId ? requested : await _getMetadataItem(rootId);
+            rootNode = rootMeta ? await this._buildProgressNode(rootMeta, correlationId) : undefined;
+            if (rootNode) byId.set(rootId, rootNode);
+        }
+        if (!rootNode) {
+            // Should not happen, but never fail the request: fall back to the requested node.
+            const node = await this._buildProgressNode(requested, correlationId);
+            return { root: node, headline: _headlineFromNode(node) };
+        }
+
+        // Nest each non-root node under the parent that launched it (or the root if the parent is
+        // missing from the tree, e.g. a deeper grandchild whose parent predates linkage).
+        for (const item of items) {
+            if (item.flowExecutionId === rootId) continue;
+            const node = byId.get(item.flowExecutionId)!;
+            const parent = (item.parentFlowExecutionId && byId.get(item.parentFlowExecutionId)) || rootNode;
+            parent.children.push(node);
+        }
+
+        // Stable order: by start time within each parent.
+        for (const node of byId.values()) {
+            node.children.sort((a, b) => a.startTime.localeCompare(b.startTime));
+        }
+
+        // Headline = deepest active (non-terminal) leaf, else the root.
+        const active = Array.from(byId.values()).filter(n => !(TERMINAL_FLOW_STATUSES as readonly string[]).includes(n.status));
+        const headlineNode = active.length
+            ? active.reduce((a, b) => ((b.depth ?? 0) > (a.depth ?? 0) ? b : a))
+            : rootNode;
+
+        return { root: rootNode, headline: _headlineFromNode(headlineNode) };
     },
 
     async getStepRecordDetails(flowExecutionId: string, stepInstanceId: string, attemptNumber?: number, branchExecutionId?: string, correlationId?: string): Promise<AllmaStepExecutionRecord | null> {

--- a/packages/app-logic/src/allma-core/data-savers/start-flow-execution.ts
+++ b/packages/app-logic/src/allma-core/data-savers/start-flow-execution.ts
@@ -92,6 +92,14 @@ export const executeStartFlowExecution: StepHandler = async (
     flowExecutionId: newFlowExecutionId,
     // Enhance trigger source for better traceability
     triggerSource: `ParentFlow:${runtimeState.flowExecutionId}:${runtimeState.currentStepInstanceId} -> ${payload.triggerSource || 'Unknown'}`,
+    // Execution-tree linkage (Pillar B). This is a fire-and-forget async sub-flow: it appears as
+    // a linked node in the tree but is NOT bubbled into the root's headline (the parent does not
+    // wait for it and may already be terminal by the time it advances).
+    parentFlowExecutionId: runtimeState.flowExecutionId,
+    parentStepInstanceId: runtimeState.currentStepInstanceId,
+    rootFlowExecutionId: runtimeState.rootFlowExecutionId ?? runtimeState.flowExecutionId,
+    depth: (runtimeState.depth ?? 0) + 1,
+    executionKind: 'ASYNC_SUBFLOW',
   };
 
   log_info(`Sending request to start new flow execution`, {

--- a/packages/app-logic/src/allma-core/execution-logger-client.ts
+++ b/packages/app-logic/src/allma-core/execution-logger-client.ts
@@ -55,6 +55,7 @@ class ExecutionLoggerClient {
 
     public async createMetadataRecord(
         record: Pick<AllmaFlowExecutionRecord, 'flowExecutionId' | 'flowDefinitionId' | 'flowDefinitionVersion' | 'startTime' | 'initialInputPayload' | 'triggerSource' | 'enableExecutionLogs'>
+            & Partial<Pick<AllmaFlowExecutionRecord, 'parentFlowExecutionId' | 'parentStepInstanceId' | 'rootFlowExecutionId' | 'depth' | 'executionKind'>>
     ): Promise<void> {
         const payload: ExecutionLoggerPayload = {
             action: 'CREATE_METADATA',
@@ -68,6 +69,21 @@ class ExecutionLoggerClient {
     ): Promise<void> {
         const payload: ExecutionLoggerPayload = {
             action: 'UPDATE_FINAL_STATUS',
+            ...updateData,
+        };
+        await this.invokeLogger(payload, updateData.flowExecutionId);
+    }
+
+    /**
+     * Stamps live progress onto the execution's metadata record (and optionally bubbles a roll-up
+     * up to the root). Fire-and-forget like the other logger actions — progress is best-effort and
+     * must never slow down or fail the orchestration loop.
+     */
+    public async updateProgress(
+        updateData: Omit<ExecutionLoggerPayload & { action: 'UPDATE_PROGRESS' }, 'action'>
+    ): Promise<void> {
+        const payload: ExecutionLoggerPayload = {
+            action: 'UPDATE_PROGRESS',
             ...updateData,
         };
         await this.invokeLogger(payload, updateData.flowExecutionId);

--- a/packages/app-logic/src/allma-core/execution-logger.ts
+++ b/packages/app-logic/src/allma-core/execution-logger.ts
@@ -46,7 +46,15 @@ export const handler: Handler<ExecutionLoggerPayload, void> = async (event) => {
             case 'CREATE_METADATA': {
                 const { record } = payload;
                 const status = 'RUNNING';
-                
+
+                // Default execution-tree linkage to a ROOT node when the trigger supplied none
+                // (top-level execution: root === self, depth 0). The GSI_ByRoot sort key orders
+                // nodes by depth then parent step, so the tree assembles deterministically.
+                const rootFlowExecutionId = record.rootFlowExecutionId ?? record.flowExecutionId;
+                const depth = record.depth ?? 0;
+                const executionKind = record.executionKind ?? 'ROOT';
+                const treeSortKey = `${String(depth).padStart(4, '0')}#${record.parentStepInstanceId ?? ''}#${record.flowExecutionId}`;
+
                 const itemToPut = {
                     ...record,
                     eventTimestamp_stepInstanceId_attempt: METADATA_SK_VALUE,
@@ -55,9 +63,13 @@ export const handler: Handler<ExecutionLoggerPayload, void> = async (event) => {
                     overallStatus: status,
                     overallStartTime: record.startTime,
                     flow_sort_key: `v#${record.flowDefinitionVersion}#s#${status}#t#${record.startTime}`,
+                    rootFlowExecutionId,
+                    depth,
+                    executionKind,
+                    tree_sort_key: treeSortKey,
                     ttl: ttl,
                 };
-                
+
                 const validatedItem = AllmaFlowExecutionRecordSchema.parse(itemToPut);
                 await ddbDocClient.send(new PutCommand({ TableName: FLOW_EXECUTION_LOG_TABLE_NAME, Item: validatedItem }));
                 log_info('Successfully created initial flow execution record.', {}, correlationId);
@@ -115,6 +127,72 @@ export const handler: Handler<ExecutionLoggerPayload, void> = async (event) => {
                     ExpressionAttributeValues: expressionAttributeValues,
                 }));
                 log_info('Successfully updated flow execution record with final status.', { status }, correlationId);
+                break;
+            }
+
+            // Stamps live progress onto the execution's own metadata record and, optionally,
+            // bubbles a one-line roll-up up to the ROOT record. Both are guarded so they only
+            // touch an existing metadata item and never move progress backward; a guard miss
+            // (out-of-order delivery or a not-yet-created record) is a benign no-op.
+            case 'UPDATE_PROGRESS': {
+                const { flowExecutionId, progress, rootBubbleUp } = payload;
+
+                const setClauses: string[] = [];
+                const names: Record<string, string> = { '#sk': 'eventTimestamp_stepInstanceId_attempt' };
+                const values: Record<string, any> = { ':progressUpdatedAt': progress.progressUpdatedAt };
+
+                // Build SET clauses only for the fields actually provided, so an absent checkpoint
+                // (flow has not declared/reached one) never overwrites a previously stamped value.
+                for (const [key, value] of Object.entries(progress)) {
+                    if (value === undefined) continue;
+                    names[`#${key}`] = key;
+                    values[`:${key}`] = value;
+                    setClauses.push(`#${key} = :${key}`);
+                }
+
+                try {
+                    await ddbDocClient.send(new UpdateCommand({
+                        TableName: FLOW_EXECUTION_LOG_TABLE_NAME,
+                        Key: { flowExecutionId, eventTimestamp_stepInstanceId_attempt: METADATA_SK_VALUE },
+                        UpdateExpression: `SET ${setClauses.join(', ')}`,
+                        // Only stamp an existing metadata record, and only if this update is at least
+                        // as recent as the last one (monotonic, tolerant of out-of-order delivery).
+                        ConditionExpression:
+                            'attribute_exists(#sk) AND (attribute_not_exists(#progressUpdatedAt) OR #progressUpdatedAt <= :progressUpdatedAt)',
+                        ExpressionAttributeNames: names,
+                        ExpressionAttributeValues: values,
+                    }));
+                } catch (e: any) {
+                    if (e.name === 'ConditionalCheckFailedException') {
+                        log_info('Skipped progress stamp (record missing or newer progress already present).', { flowExecutionId }, correlationId);
+                    } else {
+                        throw e;
+                    }
+                }
+
+                if (rootBubbleUp) {
+                    try {
+                        await ddbDocClient.send(new UpdateCommand({
+                            TableName: FLOW_EXECUTION_LOG_TABLE_NAME,
+                            Key: { flowExecutionId: rootBubbleUp.rootFlowExecutionId, eventTimestamp_stepInstanceId_attempt: METADATA_SK_VALUE },
+                            UpdateExpression: 'SET #liveStatus = :liveStatus',
+                            // Newest writer wins, so a parent resuming after a sub-flow cleanly
+                            // overwrites the child's roll-up (its updatedAt is later).
+                            ConditionExpression:
+                                'attribute_exists(#sk) AND (attribute_not_exists(#liveStatus) OR #liveStatus.#updatedAt <= :liveUpdatedAt)',
+                            ExpressionAttributeNames: { '#sk': 'eventTimestamp_stepInstanceId_attempt', '#liveStatus': 'liveStatus', '#updatedAt': 'updatedAt' },
+                            ExpressionAttributeValues: { ':liveStatus': rootBubbleUp.liveStatus, ':liveUpdatedAt': rootBubbleUp.liveStatus.updatedAt },
+                        }));
+                    } catch (e: any) {
+                        if (e.name === 'ConditionalCheckFailedException') {
+                            log_info('Skipped liveStatus bubble-up (root missing or newer roll-up already present).', { rootFlowExecutionId: rootBubbleUp.rootFlowExecutionId }, correlationId);
+                        } else {
+                            throw e;
+                        }
+                    }
+                }
+
+                log_info('Progress stamp processed.', { flowExecutionId, bubbledUp: !!rootBubbleUp }, correlationId);
                 break;
             }
 

--- a/packages/app-logic/src/allma-flows/initialize-flow.ts
+++ b/packages/app-logic/src/allma-flows/initialize-flow.ts
@@ -64,6 +64,12 @@ export const handler: Handler<StartFlowExecutionInput, ProcessorOutput> = async 
                 initialInputPayload: event, // Log the original StartFlowExecutionInput for traceability
                 triggerSource: event.triggerSource,
                 enableExecutionLogs: startState.enableExecutionLogs,
+                // Carry forward any execution-tree linkage present on the restored state.
+                parentFlowExecutionId: startState.parentFlowExecutionId,
+                parentStepInstanceId: startState.parentStepInstanceId,
+                rootFlowExecutionId: startState.rootFlowExecutionId ?? startState.flowExecutionId,
+                depth: startState.depth ?? 0,
+                executionKind: startState.executionKind ?? 'ROOT',
             });
         }
         
@@ -128,6 +134,12 @@ export const handler: Handler<StartFlowExecutionInput, ProcessorOutput> = async 
         ...(startInput.executionOverrides && { executionOverrides: startInput.executionOverrides })
     };
 
+    // Execution-tree linkage (Pillar B). A top-level trigger has no parent: it is its own root at
+    // depth 0. A sub-flow start passes parent/root/depth/kind through the start input.
+    const rootFlowExecutionId = startInput.rootFlowExecutionId ?? effectiveFlowExecutionId;
+    const depth = startInput.depth ?? 0;
+    const executionKind = startInput.executionKind ?? 'ROOT';
+
     const initialState: FlowRuntimeState = {
       flowDefinitionId: flowDefinition.id,
       flowDefinitionVersion: flowDefinition.version,
@@ -136,6 +148,12 @@ export const handler: Handler<StartFlowExecutionInput, ProcessorOutput> = async 
       currentStepInstanceId: startInput.executionOverrides?.startStepInstanceId || flowDefinition.startStepInstanceId,
       status: 'RUNNING',
       startTime: startTime,
+      completedStepCount: 0,
+      rootFlowExecutionId,
+      parentFlowExecutionId: startInput.parentFlowExecutionId,
+      parentStepInstanceId: startInput.parentStepInstanceId,
+      depth,
+      executionKind,
       currentContextData: initialContextWithSystemValues,
       stepRetryAttempts: {},
       _internal: {
@@ -157,6 +175,11 @@ export const handler: Handler<StartFlowExecutionInput, ProcessorOutput> = async 
             initialInputPayload: startInput,
             triggerSource: startInput.triggerSource,
             enableExecutionLogs: initialState.enableExecutionLogs,
+            parentFlowExecutionId: startInput.parentFlowExecutionId,
+            parentStepInstanceId: startInput.parentStepInstanceId,
+            rootFlowExecutionId,
+            depth,
+            executionKind,
         });
         initialState._internal!.loggingBootstrapped = true; // Mark that the metadata record was created
         log_info('Main flow execution record queued for logging.', { flowExecutionId: effectiveFlowExecutionId }, correlationId);

--- a/packages/app-logic/src/allma-flows/iterative-step-processor/index.ts
+++ b/packages/app-logic/src/allma-flows/iterative-step-processor/index.ts
@@ -28,9 +28,68 @@ import { prepareStepInput } from '../../allma-core/data-mapper.js';
 import { executionLoggerClient } from '../../allma-core/execution-logger-client.js';
 import { handleSyncFlowStart, handleSyncFlowResult } from './sync-flow-handler.js';
 import { enforceTransitionLimits } from './transition-limits.js';
+import { computeProgressStamp } from './progress-stamper.js';
 
 const EXECUTION_TRACES_BUCKET_NAME = process.env[ENV_VAR_NAMES.ALLMA_EXECUTION_TRACES_BUCKET_NAME];
 const SFN_SAFE_PAYLOAD_LIMIT = 100 * 1024; // 100KB safe threshold to ensure total output stays well under 256KB
+
+/**
+ * Stamps live progress (Pillar A) onto the execution's metadata record at a step boundary, and —
+ * on a checkpoint advance — bubbles a one-line roll-up up to the ROOT record (Pillar B, §6.4).
+ *
+ * Runs for the top-level / sub-flow execution only (never for in-memory parallel branches, which
+ * share the parent's flowExecutionId and would otherwise clobber its progress). Best-effort and
+ * fire-and-forget: any failure here must never disrupt the orchestration loop. Mutates the
+ * runtime-state progress counters (`completedStepCount`, `reachedCheckpoint`) carried through the loop.
+ */
+async function stampProgress(
+    runtimeState: FlowRuntimeState,
+    flowDef: FlowDefinition,
+    correlationId: string,
+): Promise<void> {
+    try {
+        // The step about to run; the prior steps are "completed" for the L1 denominator.
+        const completedSoFar = runtimeState.completedStepCount ?? 0;
+        const now = new Date().toISOString();
+
+        const { stamp, reachedCheckpoint, checkpointChanged } = computeProgressStamp({
+            flowDef,
+            currentStepInstanceId: runtimeState.currentStepInstanceId,
+            completedStepCount: completedSoFar,
+            status: runtimeState.status,
+            reachedCheckpoint: runtimeState.reachedCheckpoint,
+            now,
+        });
+
+        runtimeState.reachedCheckpoint = reachedCheckpoint;
+        runtimeState.completedStepCount = completedSoFar + 1;
+
+        const rootFlowExecutionId = runtimeState.rootFlowExecutionId ?? runtimeState.flowExecutionId;
+        // Async sub-flows are not bubbled into the root headline (the root may already be terminal).
+        const shouldBubble = checkpointChanged && runtimeState.executionKind !== 'ASYNC_SUBFLOW';
+
+        await executionLoggerClient.updateProgress({
+            flowExecutionId: runtimeState.flowExecutionId,
+            progress: stamp,
+            ...(shouldBubble && {
+                rootBubbleUp: {
+                    rootFlowExecutionId,
+                    liveStatus: {
+                        activeExecutionId: runtimeState.flowExecutionId,
+                        depth: runtimeState.depth ?? 0,
+                        stepDisplayName: stamp.currentStepDisplayName,
+                        checkpointId: stamp.currentCheckpoint?.id,
+                        checkpointLabel: stamp.currentCheckpoint?.label,
+                        percent: stamp.progressPercent,
+                        updatedAt: now,
+                    },
+                },
+            }),
+        });
+    } catch (e: any) {
+        log_warn('Progress stamping failed (non-fatal).', { error: e.message }, correlationId);
+    }
+}
 
 /**
  * AWS Lambda handler for the "IterativeStepProcessor" state.
@@ -161,6 +220,12 @@ export const handler: Handler<ProcessorInput, ProcessorOutput | void> = async (e
             if (overrides) {
                 log_info(`Applying step overrides for '${currentStepInstanceId}'`, { overrides }, correlationId);
                 stepInstance = deepMerge(stepInstance, overrides) as StepInstance;
+            }
+
+            // Stamp live progress at the step boundary (covers every step type). Skipped for
+            // in-memory parallel branches, which share the parent's flowExecutionId.
+            if (!isBranchExecution) {
+                await stampProgress(runtimeState, flowDef, correlationId);
             }
 
             const { stepType } = stepInstance;

--- a/packages/app-logic/src/allma-flows/iterative-step-processor/progress-stamper.ts
+++ b/packages/app-logic/src/allma-flows/iterative-step-processor/progress-stamper.ts
@@ -1,0 +1,116 @@
+import type { FlowDefinition, StampedCheckpoint } from '@allma/core-types';
+
+const TERMINAL_STATUSES = ['COMPLETED', 'FAILED', 'TIMED_OUT', 'CANCELLED'];
+
+/** A declared checkpoint plus the step it lives on and its 1-based ordinal among all checkpoints. */
+export interface DeclaredCheckpoint extends StampedCheckpoint {
+    stepInstanceId: string;
+    ordinal: number;
+}
+
+/**
+ * Lists the steps in a flow definition that declare a `checkpoint`, ordered by `checkpoint.order`
+ * (undefined orders sort last but keep definition order), each annotated with a 1-based `ordinal`.
+ */
+export function getDeclaredCheckpoints(flowDef: FlowDefinition): DeclaredCheckpoint[] {
+    return Object.entries(flowDef.steps)
+        .filter(([, s]) => (s as any).checkpoint)
+        .map(([stepInstanceId, s]) => ({ stepInstanceId, ...((s as any).checkpoint as StampedCheckpoint) }))
+        .sort((a, b) => (a.order ?? Number.MAX_SAFE_INTEGER) - (b.order ?? Number.MAX_SAFE_INTEGER))
+        .map((c, i) => ({ ...c, ordinal: i + 1 }));
+}
+
+/** The progress fields stamped onto a flow execution's metadata record. */
+export interface ProgressStamp {
+    currentStepInstanceId?: string;
+    currentStepDisplayName?: string;
+    currentStepType?: string;
+    completedStepCount?: number;
+    totalStepCount?: number;
+    currentCheckpoint?: StampedCheckpoint;
+    totalCheckpoints?: number;
+    progressPercent: number;
+    progressUpdatedAt: string;
+}
+
+export interface ProgressComputation {
+    stamp: ProgressStamp;
+    /** The highest checkpoint reached so far, to carry forward in the runtime state (monotonic). */
+    reachedCheckpoint?: StampedCheckpoint;
+    /** The 1-based ordinal of `reachedCheckpoint` among all declared checkpoints (0 if none). */
+    reachedOrdinal: number;
+    /** True when this boundary advanced the reached checkpoint (gates the low-volume bubble-up). */
+    checkpointChanged: boolean;
+}
+
+/**
+ * Computes the progress stamp for a step boundary from the flow definition and the runtime
+ * counters carried through the loop. Pure and synchronous so it is cheap to call per step and
+ * easy to unit test. Progress is measured against checkpoints when the flow declares any (L2),
+ * otherwise against completed-step count (L1); it is monotonic and clamps to 100% on completion.
+ */
+export function computeProgressStamp(params: {
+    flowDef: FlowDefinition;
+    currentStepInstanceId?: string;
+    completedStepCount: number;
+    status: string;
+    reachedCheckpoint?: StampedCheckpoint;
+    now: string;
+}): ProgressComputation {
+    const { flowDef, currentStepInstanceId, completedStepCount, status, reachedCheckpoint, now } = params;
+    const isTerminal = TERMINAL_STATUSES.includes(status);
+
+    const totalStepCount = Object.keys(flowDef.steps).length;
+    const checkpoints = getDeclaredCheckpoints(flowDef);
+    const totalCheckpoints = checkpoints.length;
+
+    const ordinalOf = (cp?: StampedCheckpoint): number =>
+        cp ? (checkpoints.find((c) => c.id === cp.id)?.ordinal ?? 0) : 0;
+
+    // Advance the reached checkpoint if the current step declares one further along than what we
+    // have already reached (monotonic by ordinal, so loops never move the bar backward).
+    let newReached = reachedCheckpoint;
+    let checkpointChanged = false;
+    const currentCp = currentStepInstanceId
+        ? checkpoints.find((c) => c.stepInstanceId === currentStepInstanceId)
+        : undefined;
+    if (currentCp && currentCp.ordinal > ordinalOf(reachedCheckpoint)) {
+        newReached = { id: currentCp.id, label: currentCp.label, order: currentCp.order };
+        checkpointChanged = true;
+    }
+    const reachedOrdinal = ordinalOf(newReached);
+    const reachedWithOrdinal: StampedCheckpoint | undefined = newReached
+        ? { ...newReached, ordinal: reachedOrdinal }
+        : undefined;
+
+    let progressPercent: number;
+    if (status === 'COMPLETED') {
+        progressPercent = 100;
+    } else if (totalCheckpoints > 0) {
+        progressPercent = Math.round((100 * reachedOrdinal) / totalCheckpoints);
+    } else if (totalStepCount > 0) {
+        progressPercent = Math.round((100 * completedStepCount) / totalStepCount);
+    } else {
+        progressPercent = 0;
+    }
+    progressPercent = Math.max(0, Math.min(100, progressPercent));
+
+    const currentStepDef = currentStepInstanceId ? (flowDef.steps[currentStepInstanceId] as any) : undefined;
+
+    const stamp: ProgressStamp = {
+        completedStepCount,
+        totalStepCount,
+        progressPercent,
+        progressUpdatedAt: now,
+        ...(totalCheckpoints > 0 && { totalCheckpoints }),
+        ...(reachedWithOrdinal && { currentCheckpoint: reachedWithOrdinal }),
+        // Once terminal there is no "current" step to point at.
+        ...(!isTerminal && currentStepInstanceId && {
+            currentStepInstanceId,
+            currentStepDisplayName: currentStepDef?.displayName,
+            currentStepType: currentStepDef?.stepType,
+        }),
+    };
+
+    return { stamp, reachedCheckpoint: newReached, reachedOrdinal, checkpointChanged };
+}

--- a/packages/app-logic/src/allma-flows/iterative-step-processor/sync-flow-handler.ts
+++ b/packages/app-logic/src/allma-flows/iterative-step-processor/sync-flow-handler.ts
@@ -93,6 +93,13 @@ export async function handleSyncFlowStart(
         flowExecutionId: uuidv4(), // The sub-flow gets its own unique ID
         triggerSource: `SyncSubFlow from ${runtimeState.flowExecutionId}:${runtimeState.currentStepInstanceId}`,
         enableExecutionLogs: runtimeState.enableExecutionLogs,
+        // Execution-tree linkage (Pillar B): the child records its position so the root can
+        // reconstruct the tree and the child can bubble progress up to the shared root.
+        parentFlowExecutionId: runtimeState.flowExecutionId,
+        parentStepInstanceId: runtimeState.currentStepInstanceId,
+        rootFlowExecutionId: runtimeState.rootFlowExecutionId ?? runtimeState.flowExecutionId,
+        depth: (runtimeState.depth ?? 0) + 1,
+        executionKind: 'SYNC_SUBFLOW',
     };
 
     return {

--- a/packages/app-logic/tests/unit/allma-admin/execution-progress-tree.test.ts
+++ b/packages/app-logic/tests/unit/allma-admin/execution-progress-tree.test.ts
@@ -1,0 +1,152 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { DynamoDBDocumentClient, GetCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { mockClient, resetAwsClientMocks } from '../_helpers/aws-mock.js';
+
+/**
+ * Pins the Pillar B read API: `getExecutionProgress` prefers the orchestrator-stamped metadata in
+ * `single` mode, falls back to read-time derivation for un-stamped/legacy executions, and assembles
+ * the nested sub-flow tree from a single GSI_ByRoot query in `tree` mode.
+ */
+
+vi.hoisted(() => {
+    process.env.ALLMA_FLOW_EXECUTION_LOG_TABLE_NAME = 'exec-log-table';
+});
+
+vi.mock('../../../src/allma-core/config-loader.js', () => ({
+    loadFlowDefinition: vi.fn(),
+}));
+
+const { ExecutionMonitoringService } = await import('../../../src/allma-admin/services/execution-monitoring.service.js');
+const { loadFlowDefinition } = await import('../../../src/allma-core/config-loader.js');
+const mockedLoadDef = vi.mocked(loadFlowDefinition);
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+const ROOT = '11111111-1111-1111-1111-111111111111';
+const CHILD = '22222222-2222-2222-2222-222222222222';
+
+const stampedMeta = (overrides: Record<string, any> = {}) => ({
+    flowExecutionId: ROOT,
+    eventTimestamp_stepInstanceId_attempt: 'METADATA',
+    itemType: 'ALLMA_FLOW_EXECUTION_RECORD',
+    flowDefinitionId: 'flow-a',
+    flowDefinitionVersion: 1,
+    status: 'RUNNING',
+    startTime: '2026-06-27T00:00:00.000Z',
+    executionKind: 'ROOT',
+    rootFlowExecutionId: ROOT,
+    depth: 0,
+    // Stamped fields (Pillar A):
+    progressUpdatedAt: '2026-06-27T00:00:05.000Z',
+    progressPercent: 40,
+    completedStepCount: 2,
+    totalStepCount: 5,
+    currentStepInstanceId: 's3',
+    currentStepDisplayName: 'Third',
+    currentStepType: 'NO_OP',
+    ...overrides,
+});
+
+beforeEach(() => {
+    resetAwsClientMocks(ddbMock);
+    mockedLoadDef.mockReset();
+});
+
+describe('getExecutionProgress — single mode', () => {
+    it('serves the stamped metadata directly (no step-record/flow-def reads)', async () => {
+        ddbMock.on(GetCommand).resolves({ Item: stampedMeta() });
+
+        const res = await ExecutionMonitoringService.getExecutionProgress(ROOT, 'corr', 'single');
+
+        expect(res).not.toBeNull();
+        expect(res!.root.progressPercent).toBe(40);
+        expect(res!.root.completedStepCount).toBe(2);
+        expect(res!.root.currentStep?.displayName).toBe('Third');
+        expect(res!.headline.label).toBe('Third');
+        // Stamped path must not touch the flow definition.
+        expect(mockedLoadDef).not.toHaveBeenCalled();
+    });
+
+    it('falls back to read-time derivation when the record is not stamped', async () => {
+        const unstamped = stampedMeta({ progressUpdatedAt: undefined, progressPercent: undefined });
+        delete (unstamped as any).progressUpdatedAt;
+        delete (unstamped as any).progressPercent;
+
+        ddbMock.on(GetCommand).resolves({ Item: unstamped });
+        // _getExecutionRecords (base-table Query) returns one completed step.
+        ddbMock.on(QueryCommand).resolves({
+            Items: [
+                {
+                    flowExecutionId: ROOT,
+                    itemType: 'ALLMA_STEP_EXECUTION_RECORD',
+                    eventTimestamp: '2026-06-27T00:00:01.000Z',
+                    stepInstanceId: 's1',
+                    stepType: 'NO_OP',
+                    status: 'COMPLETED',
+                    startTime: '2026-06-27T00:00:01.000Z',
+                },
+            ],
+        });
+        mockedLoadDef.mockResolvedValue({
+            id: 'flow-a',
+            version: 1,
+            startStepInstanceId: 's1',
+            steps: { s1: { stepInstanceId: 's1', stepType: 'NO_OP' }, s2: { stepInstanceId: 's2', stepType: 'NO_OP' } },
+        } as any);
+
+        const res = await ExecutionMonitoringService.getExecutionProgress(ROOT, 'corr', 'single');
+
+        expect(mockedLoadDef).toHaveBeenCalledOnce();
+        expect(res!.root.completedStepCount).toBe(1);
+        expect(res!.root.totalStepCount).toBe(2);
+        expect(res!.root.progressPercent).toBe(50);
+    });
+
+    it('returns null when the execution does not exist', async () => {
+        ddbMock.on(GetCommand).resolves({ Item: undefined });
+        const res = await ExecutionMonitoringService.getExecutionProgress(ROOT, 'corr', 'single');
+        expect(res).toBeNull();
+    });
+});
+
+describe('getExecutionProgress — tree mode', () => {
+    it('assembles nested sub-flow nodes and points the headline at the deepest active leaf', async () => {
+        ddbMock.on(GetCommand).resolves({ Item: stampedMeta() });
+        ddbMock.on(QueryCommand).resolves({
+            Items: [
+                stampedMeta(),
+                stampedMeta({
+                    flowExecutionId: CHILD,
+                    executionKind: 'SYNC_SUBFLOW',
+                    depth: 1,
+                    parentFlowExecutionId: ROOT,
+                    parentStepInstanceId: 's3',
+                    progressPercent: 75,
+                    currentStepDisplayName: 'Child step',
+                    startTime: '2026-06-27T00:00:02.000Z',
+                }),
+            ],
+        });
+
+        const res = await ExecutionMonitoringService.getExecutionProgress(ROOT, 'corr', 'tree');
+
+        expect(res!.root.flowExecutionId).toBe(ROOT);
+        expect(res!.root.children).toHaveLength(1);
+        expect(res!.root.children[0].flowExecutionId).toBe(CHILD);
+        expect(res!.root.children[0].executionKind).toBe('SYNC_SUBFLOW');
+        expect(res!.root.children[0].parentStepInstanceId).toBe('s3');
+        // Deepest active leaf is the child.
+        expect(res!.headline.executionId).toBe(CHILD);
+        expect(res!.headline.label).toBe('Child step');
+    });
+
+    it('degrades to a single-node tree when there is no linkage (legacy execution)', async () => {
+        ddbMock.on(GetCommand).resolves({ Item: stampedMeta() });
+        ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+        const res = await ExecutionMonitoringService.getExecutionProgress(ROOT, 'corr', 'tree');
+
+        expect(res!.root.flowExecutionId).toBe(ROOT);
+        expect(res!.root.children).toHaveLength(0);
+    });
+});

--- a/packages/app-logic/tests/unit/allma-core/execution-logger.test.ts
+++ b/packages/app-logic/tests/unit/allma-core/execution-logger.test.ts
@@ -1,0 +1,129 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { DynamoDBDocumentClient, PutCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import type { ExecutionLoggerPayload } from '@allma/core-types';
+import { mockClient, resetAwsClientMocks } from '../_helpers/aws-mock.js';
+
+/**
+ * Covers the logger actions added for live progress / execution trees: CREATE_METADATA now stamps
+ * tree linkage + a GSI sort key, and the new UPDATE_PROGRESS action guards a monotonic self-stamp
+ * and an optional bubble-up to the root, swallowing conditional-check failures as benign no-ops.
+ */
+
+vi.hoisted(() => {
+    process.env.ALLMA_FLOW_EXECUTION_LOG_TABLE_NAME = 'exec-log-table';
+});
+
+const { handler } = await import('../../../src/allma-core/execution-logger.js');
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+const invoke = (payload: ExecutionLoggerPayload) => handler(payload, {} as never, (() => undefined) as never);
+
+beforeEach(() => {
+    resetAwsClientMocks(ddbMock);
+});
+
+describe('CREATE_METADATA', () => {
+    it('defaults to a ROOT node and a depth-0 tree sort key for a top-level execution', async () => {
+        ddbMock.on(PutCommand).resolves({});
+        await invoke({
+            action: 'CREATE_METADATA',
+            record: {
+                flowExecutionId: '11111111-1111-1111-1111-111111111111',
+                flowDefinitionId: 'flow-a',
+                flowDefinitionVersion: 1,
+                startTime: '2026-06-27T00:00:00.000Z',
+                initialInputPayload: { flowDefinitionId: 'flow-a' } as any,
+                enableExecutionLogs: true,
+            },
+        });
+
+        const item = ddbMock.commandCalls(PutCommand)[0].args[0].input.Item as any;
+        expect(item.executionKind).toBe('ROOT');
+        expect(item.rootFlowExecutionId).toBe('11111111-1111-1111-1111-111111111111');
+        expect(item.depth).toBe(0);
+        expect(item.tree_sort_key).toBe('0000##11111111-1111-1111-1111-111111111111');
+    });
+
+    it('persists supplied sub-flow linkage and encodes it into the tree sort key', async () => {
+        ddbMock.on(PutCommand).resolves({});
+        await invoke({
+            action: 'CREATE_METADATA',
+            record: {
+                flowExecutionId: '22222222-2222-2222-2222-222222222222',
+                flowDefinitionId: 'flow-b',
+                flowDefinitionVersion: 1,
+                startTime: '2026-06-27T00:00:00.000Z',
+                initialInputPayload: { flowDefinitionId: 'flow-b' } as any,
+                enableExecutionLogs: true,
+                parentFlowExecutionId: '11111111-1111-1111-1111-111111111111',
+                parentStepInstanceId: 's3',
+                rootFlowExecutionId: '11111111-1111-1111-1111-111111111111',
+                depth: 1,
+                executionKind: 'SYNC_SUBFLOW',
+            },
+        });
+
+        const item = ddbMock.commandCalls(PutCommand)[0].args[0].input.Item as any;
+        expect(item.executionKind).toBe('SYNC_SUBFLOW');
+        expect(item.rootFlowExecutionId).toBe('11111111-1111-1111-1111-111111111111');
+        expect(item.tree_sort_key).toBe('0001#s3#22222222-2222-2222-2222-222222222222');
+    });
+});
+
+describe('UPDATE_PROGRESS', () => {
+    const basePayload = (): ExecutionLoggerPayload => ({
+        action: 'UPDATE_PROGRESS',
+        flowExecutionId: '22222222-2222-2222-2222-222222222222',
+        progress: {
+            progressUpdatedAt: '2026-06-27T00:00:05.000Z',
+            progressPercent: 50,
+            completedStepCount: 2,
+            totalStepCount: 4,
+            currentStepInstanceId: 's2',
+            currentCheckpoint: { id: 'b', label: 'Extract', order: 1, ordinal: 2 },
+            totalCheckpoints: 3,
+        },
+        rootBubbleUp: {
+            rootFlowExecutionId: '11111111-1111-1111-1111-111111111111',
+            liveStatus: {
+                activeExecutionId: '22222222-2222-2222-2222-222222222222',
+                depth: 1,
+                checkpointId: 'b',
+                checkpointLabel: 'Extract',
+                percent: 50,
+                updatedAt: '2026-06-27T00:00:05.000Z',
+            },
+        },
+    });
+
+    it('stamps the own record (guarded, monotonic) and bubbles up to the root', async () => {
+        ddbMock.on(UpdateCommand).resolves({});
+        await invoke(basePayload());
+
+        const calls = ddbMock.commandCalls(UpdateCommand);
+        expect(calls).toHaveLength(2);
+
+        const selfStamp = calls[0].args[0].input;
+        expect(selfStamp.Key).toMatchObject({ flowExecutionId: '22222222-2222-2222-2222-222222222222', eventTimestamp_stepInstanceId_attempt: 'METADATA' });
+        expect(selfStamp.UpdateExpression).toContain('#progressPercent = :progressPercent');
+        expect(selfStamp.ConditionExpression).toContain('attribute_exists(#sk)');
+        expect(selfStamp.ConditionExpression).toContain('#progressUpdatedAt <= :progressUpdatedAt');
+
+        const bubble = calls[1].args[0].input;
+        expect(bubble.Key).toMatchObject({ flowExecutionId: '11111111-1111-1111-1111-111111111111' });
+        expect(bubble.UpdateExpression).toContain('#liveStatus = :liveStatus');
+    });
+
+    it('does not bubble up when no rootBubbleUp is supplied', async () => {
+        ddbMock.on(UpdateCommand).resolves({});
+        const payload = basePayload();
+        delete (payload as any).rootBubbleUp;
+        await invoke(payload);
+        expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(1);
+    });
+
+    it('swallows a conditional-check failure (out-of-order / missing record) without throwing', async () => {
+        ddbMock.on(UpdateCommand).rejects(Object.assign(new Error('conditional'), { name: 'ConditionalCheckFailedException' }));
+        await expect(invoke(basePayload())).resolves.toBeUndefined();
+    });
+});

--- a/packages/app-logic/tests/unit/allma-flows/iterative-step-processor/progress-stamper.test.ts
+++ b/packages/app-logic/tests/unit/allma-flows/iterative-step-processor/progress-stamper.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { computeProgressStamp, getDeclaredCheckpoints } from '../../../../src/allma-flows/iterative-step-processor/progress-stamper.js';
+import type { FlowDefinition } from '@allma/core-types';
+
+/**
+ * `computeProgressStamp` is the pure core of Pillar A stamping: from the flow definition and the
+ * runtime counters carried through the loop it derives the progress fields written onto the
+ * metadata record at each step boundary. These tests pin its checkpoint math, monotonicity, and
+ * the L1/L2 percentage resolution.
+ */
+
+const flowDef = (steps: Record<string, any>): FlowDefinition =>
+    ({ id: 'flow-a', version: 1, startStepInstanceId: 's1', steps } as unknown as FlowDefinition);
+
+const NOW = '2026-06-27T00:00:00.000Z';
+
+describe('getDeclaredCheckpoints', () => {
+    it('orders checkpoints by order and assigns 1-based ordinals', () => {
+        const def = flowDef({
+            s1: { stepInstanceId: 's1', stepType: 'NO_OP', checkpoint: { id: 'b', label: 'B', order: 1 } },
+            s2: { stepInstanceId: 's2', stepType: 'NO_OP' },
+            s3: { stepInstanceId: 's3', stepType: 'NO_OP', checkpoint: { id: 'a', label: 'A', order: 0 } },
+        });
+        const cps = getDeclaredCheckpoints(def);
+        expect(cps.map((c) => c.id)).toEqual(['a', 'b']);
+        expect(cps.map((c) => c.ordinal)).toEqual([1, 2]);
+        expect(cps[0].stepInstanceId).toBe('s3');
+    });
+});
+
+describe('computeProgressStamp', () => {
+    it('uses step-count progress (L1) when no checkpoints are declared', () => {
+        const def = flowDef({
+            s1: { stepInstanceId: 's1', stepType: 'NO_OP', displayName: 'First' },
+            s2: { stepInstanceId: 's2', stepType: 'NO_OP', displayName: 'Second' },
+            s3: { stepInstanceId: 's3', stepType: 'NO_OP' },
+            s4: { stepInstanceId: 's4', stepType: 'NO_OP' },
+        });
+        const { stamp } = computeProgressStamp({
+            flowDef: def,
+            currentStepInstanceId: 's2',
+            completedStepCount: 1,
+            status: 'RUNNING',
+            now: NOW,
+        });
+        expect(stamp.totalStepCount).toBe(4);
+        expect(stamp.completedStepCount).toBe(1);
+        expect(stamp.progressPercent).toBe(25); // 1 of 4
+        expect(stamp.currentStepInstanceId).toBe('s2');
+        expect(stamp.currentStepDisplayName).toBe('Second');
+        expect(stamp.currentCheckpoint).toBeUndefined();
+        expect(stamp.totalCheckpoints).toBeUndefined();
+        expect(stamp.progressUpdatedAt).toBe(NOW);
+    });
+
+    it('measures progress against checkpoints (L2) when the current step declares one', () => {
+        const def = flowDef({
+            s1: { stepInstanceId: 's1', stepType: 'NO_OP', checkpoint: { id: 'a', label: 'Upload', order: 0 } },
+            s2: { stepInstanceId: 's2', stepType: 'NO_OP', checkpoint: { id: 'b', label: 'Extract', order: 1 } },
+            s3: { stepInstanceId: 's3', stepType: 'NO_OP', checkpoint: { id: 'c', label: 'Save', order: 2 } },
+        });
+        const { stamp, reachedCheckpoint, checkpointChanged, reachedOrdinal } = computeProgressStamp({
+            flowDef: def,
+            currentStepInstanceId: 's2',
+            completedStepCount: 1,
+            status: 'RUNNING',
+            now: NOW,
+        });
+        expect(stamp.totalCheckpoints).toBe(3);
+        expect(stamp.currentCheckpoint).toMatchObject({ id: 'b', label: 'Extract', ordinal: 2 });
+        expect(stamp.progressPercent).toBe(67); // round(100 * 2/3)
+        expect(reachedOrdinal).toBe(2);
+        expect(checkpointChanged).toBe(true);
+        expect(reachedCheckpoint).toMatchObject({ id: 'b' });
+    });
+
+    it('is monotonic: a loop re-entering an earlier checkpoint never moves the bar backward', () => {
+        const def = flowDef({
+            s1: { stepInstanceId: 's1', stepType: 'NO_OP', checkpoint: { id: 'a', label: 'A', order: 0 } },
+            s2: { stepInstanceId: 's2', stepType: 'NO_OP', checkpoint: { id: 'b', label: 'B', order: 1 } },
+        });
+        // Already reached checkpoint b, now re-entering step s1 (checkpoint a).
+        const { stamp, checkpointChanged } = computeProgressStamp({
+            flowDef: def,
+            currentStepInstanceId: 's1',
+            completedStepCount: 3,
+            status: 'RUNNING',
+            reachedCheckpoint: { id: 'b', label: 'B', order: 1 },
+            now: NOW,
+        });
+        expect(checkpointChanged).toBe(false);
+        expect(stamp.currentCheckpoint).toMatchObject({ id: 'b', ordinal: 2 });
+        expect(stamp.progressPercent).toBe(100); // still at the highest reached (2 of 2)
+    });
+
+    it('clamps to 100% and drops the current step on terminal COMPLETED', () => {
+        const def = flowDef({
+            s1: { stepInstanceId: 's1', stepType: 'NO_OP', checkpoint: { id: 'a', label: 'Start', order: 0 } },
+            s2: { stepInstanceId: 's2', stepType: 'NO_OP', checkpoint: { id: 'b', label: 'End', order: 1 } },
+        });
+        const { stamp } = computeProgressStamp({
+            flowDef: def,
+            currentStepInstanceId: undefined,
+            completedStepCount: 2,
+            status: 'COMPLETED',
+            reachedCheckpoint: { id: 'a', label: 'Start', order: 0 },
+            now: NOW,
+        });
+        expect(stamp.progressPercent).toBe(100);
+        expect(stamp.currentStepInstanceId).toBeUndefined();
+    });
+});

--- a/packages/core-cdk/lib/constructs/data-stores.ts
+++ b/packages/core-cdk/lib/constructs/data-stores.ts
@@ -133,6 +133,38 @@ export class AllmaDataStores extends Construct {
       ],
     });
 
+    // GSI to assemble a whole execution tree (root + sub-flows) in a single query (Pillar B, §6.2).
+    // Only metadata records created after this change carry `rootFlowExecutionId`/`tree_sort_key`,
+    // so only they appear in this index; pre-existing executions degrade to a single-node tree.
+    this.allmaFlowExecutionLogTable.addGlobalSecondaryIndex({
+      indexName: 'GSI_ByRoot',
+      partitionKey: { name: 'rootFlowExecutionId', type: dynamodb.AttributeType.STRING },
+      // `<zero-padded depth>#<parentStepInstanceId>#<flowExecutionId>` for stable ordering.
+      sortKey: { name: 'tree_sort_key', type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.INCLUDE,
+      nonKeyAttributes: [
+        'flowDefinitionId',
+        'flowDefinitionVersion',
+        'status',
+        'startTime',
+        'endTime',
+        'executionKind',
+        'parentFlowExecutionId',
+        'parentStepInstanceId',
+        'depth',
+        'currentStepInstanceId',
+        'currentStepDisplayName',
+        'currentStepType',
+        'completedStepCount',
+        'totalStepCount',
+        'currentCheckpoint',
+        'totalCheckpoints',
+        'progressPercent',
+        'progressUpdatedAt',
+        'liveStatus',
+      ],
+    });
+
     // GSI for the Admin UI Step Statistics view to aggregate step-execution records by time.
     // Dedicated to step records (itemType = ALLMA_STEP_EXECUTION_RECORD) and projects only the
     // attributes the aggregation needs, so the stats query never falls back to the base table.

--- a/packages/core-types/src/admin/executionMonitoring.ts
+++ b/packages/core-types/src/admin/executionMonitoring.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { AllmaFlowExecutionRecordSchema, AllmaStepExecutionRecordSchema } from '../logging/records.js';
+import { ExecutionKindSchema } from '../common/enums.js';
 
 /**
  * A summary of a flow execution for display in a list view.
@@ -44,39 +45,80 @@ export type ListFlowExecutionsResponse = z.infer<typeof ListFlowExecutionsRespon
  *    those milestones — `progressPercent` and `currentCheckpoint` reflect the milestone reached.
  *  - L1 (step count): otherwise, progress is `completedStepCount / totalStepCount`.
  *
- * `children` is reserved for the Phase 2 sub-flow/branch tree and is empty in the single-execution view.
+ * `children` holds nested sub-flow / branch execution nodes (Pillar B); it is empty in the
+ * single-execution view and populated in `mode=tree`.
  */
-export const ExecutionProgressNodeSchema = z.object({
-  flowExecutionId: z.string().uuid(),
-  flowDefinitionId: z.string(),
-  flowDefinitionVersion: z.number().int().optional(),
-  status: z.enum(['INITIALIZING', 'RUNNING', 'COMPLETED', 'FAILED', 'TIMED_OUT', 'CANCELLED']),
+export interface ExecutionProgressNode {
+  flowExecutionId: string;
+  flowDefinitionId: string;
+  flowDefinitionVersion?: number;
+  /** Position of this node in the execution tree. Defaults to a ROOT node for old executions. */
+  executionKind?: z.infer<typeof ExecutionKindSchema>;
+  /** The step in the PARENT flow that launched this node (sub-flows / branches only). */
+  parentStepInstanceId?: string;
+  /** 0 = root. */
+  depth?: number;
+  status: 'INITIALIZING' | 'RUNNING' | 'COMPLETED' | 'FAILED' | 'TIMED_OUT' | 'CANCELLED';
   /** True when the current step can pause for a long time (WAIT_FOR_EXTERNAL_EVENT / POLL_EXTERNAL_API). */
-  isWaiting: z.boolean(),
+  isWaiting: boolean;
   /** The step currently executing (omitted once the execution reaches a terminal status). */
-  currentStep: z.object({
-    stepInstanceId: z.string(),
-    displayName: z.string().optional(),
-    stepType: z.string().optional(),
-  }).optional(),
+  currentStep?: {
+    stepInstanceId: string;
+    displayName?: string;
+    stepType?: string;
+  };
   /** The most advanced checkpoint reached so far (only when the flow declares checkpoints). */
-  currentCheckpoint: z.object({
-    id: z.string(),
-    label: z.string(),
-    order: z.number().int().optional(),
+  currentCheckpoint?: {
+    id: string;
+    label: string;
+    order?: number;
     /** 1-based position of this checkpoint among all declared checkpoints. */
-    ordinal: z.number().int().optional(),
-  }).optional(),
-  completedStepCount: z.number().int(),
-  totalStepCount: z.number().int().optional(),
-  totalCheckpoints: z.number().int().optional(),
-  progressPercent: z.number().int().min(0).max(100),
-  startTime: z.string(),
-  endTime: z.string().optional(),
-  /** Reserved for the Phase 2 nested sub-flow / parallel-branch tree. Empty today. */
-  children: z.array(z.any()).default([]),
-});
-export type ExecutionProgressNode = z.infer<typeof ExecutionProgressNodeSchema>;
+    ordinal?: number;
+  };
+  completedStepCount: number;
+  totalStepCount?: number;
+  totalCheckpoints?: number;
+  progressPercent: number;
+  startTime: string;
+  endTime?: string;
+  /** Nested sub-flow / parallel-branch nodes. Empty in single mode. */
+  children: ExecutionProgressNode[];
+}
+
+export const ExecutionProgressNodeSchema: z.ZodType<ExecutionProgressNode> = z.lazy(() =>
+  z.object({
+    flowExecutionId: z.string().uuid(),
+    flowDefinitionId: z.string(),
+    flowDefinitionVersion: z.number().int().optional(),
+    executionKind: ExecutionKindSchema.optional(),
+    parentStepInstanceId: z.string().optional(),
+    depth: z.number().int().optional(),
+    status: z.enum(['INITIALIZING', 'RUNNING', 'COMPLETED', 'FAILED', 'TIMED_OUT', 'CANCELLED']),
+    isWaiting: z.boolean(),
+    currentStep: z
+      .object({
+        stepInstanceId: z.string(),
+        displayName: z.string().optional(),
+        stepType: z.string().optional(),
+      })
+      .optional(),
+    currentCheckpoint: z
+      .object({
+        id: z.string(),
+        label: z.string(),
+        order: z.number().int().optional(),
+        ordinal: z.number().int().optional(),
+      })
+      .optional(),
+    completedStepCount: z.number().int(),
+    totalStepCount: z.number().int().optional(),
+    totalCheckpoints: z.number().int().optional(),
+    progressPercent: z.number().int().min(0).max(100),
+    startTime: z.string(),
+    endTime: z.string().optional(),
+    children: z.array(ExecutionProgressNodeSchema),
+  }),
+);
 
 /**
  * API response for the execution-progress endpoint. `headline` is a one-line summary of the

--- a/packages/core-types/src/common/enums.ts
+++ b/packages/core-types/src/common/enums.ts
@@ -30,6 +30,14 @@ export enum SfnActionType {
 export const SfnActionTypeSchema = z.nativeEnum(SfnActionType);
 
 /**
+ * Classifies a flow execution within an execution tree (Pillar B). A top-level execution is a
+ * `ROOT`; sub-flows launched by a step are `SYNC_SUBFLOW`/`ASYNC_SUBFLOW`; `PARALLEL_BRANCH` is
+ * reserved for branch executions materialised as their own execution record.
+ */
+export const ExecutionKindSchema = z.enum(['ROOT', 'SYNC_SUBFLOW', 'ASYNC_SUBFLOW', 'PARALLEL_BRANCH']);
+export type ExecutionKind = z.infer<typeof ExecutionKindSchema>;
+
+/**
  * Defines the strategy for aggregating results from parallel branches.
  */
 export enum AggregationStrategy {

--- a/packages/core-types/src/logging/payloads.ts
+++ b/packages/core-types/src/logging/payloads.ts
@@ -1,6 +1,11 @@
 import { z } from 'zod';
 import { AllmaErrorSchema, S3PointerSchema } from '../index.js';
-import { AllmaFlowExecutionRecordSchema, MinimalLogStepExecutionRecordSchema } from './records.js';
+import {
+  AllmaFlowExecutionRecordSchema,
+  MinimalLogStepExecutionRecordSchema,
+  StampedCheckpointSchema,
+  ExecutionLiveStatusSchema,
+} from './records.js';
 
 // --- Payload Schemas for the asynchronous Logger Lambda ---
 
@@ -14,6 +19,13 @@ const CreateMetadataPayloadSchema = z.object({
       initialInputPayload: true,
       triggerSource: true,
       enableExecutionLogs: true,
+      // Execution-tree linkage (Pillar B) — persisted at creation so a single GSI query can
+      // reconstruct the whole tree. Defaulted to a ROOT node by the logger when absent.
+      parentFlowExecutionId: true,
+      parentStepInstanceId: true,
+      rootFlowExecutionId: true,
+      depth: true,
+      executionKind: true,
   })
 });
 
@@ -32,11 +44,40 @@ const LogStepExecutionPayloadSchema = z.object({
 });
 
 /**
+ * Stamps live progress (Pillar A) onto a flow execution's metadata record, and optionally bubbles
+ * a one-line roll-up up to the ROOT record (Pillar B, §6.4). Both writes are guarded so they only
+ * touch an existing metadata item and never move progress backward (monotonic on `progressUpdatedAt`
+ * / `liveStatus.updatedAt`). Fire-and-forget like the other logger actions.
+ */
+const UpdateProgressPayloadSchema = z.object({
+  action: z.literal('UPDATE_PROGRESS'),
+  flowExecutionId: z.string().uuid(),
+  progress: z.object({
+    currentStepInstanceId: z.string().optional(),
+    currentStepDisplayName: z.string().optional(),
+    currentStepType: z.string().optional(),
+    completedStepCount: z.number().int().optional(),
+    totalStepCount: z.number().int().optional(),
+    currentCheckpoint: StampedCheckpointSchema.optional(),
+    totalCheckpoints: z.number().int().optional(),
+    progressPercent: z.number().int().min(0).max(100).optional(),
+    progressUpdatedAt: z.string().datetime({ offset: true }),
+  }),
+  rootBubbleUp: z
+    .object({
+      rootFlowExecutionId: z.string().uuid(),
+      liveStatus: ExecutionLiveStatusSchema,
+    })
+    .optional(),
+});
+
+/**
  * A discriminated union schema for all possible payloads sent to the ExecutionLogger Lambda.
  */
 export const ExecutionLoggerPayloadSchema = z.discriminatedUnion('action', [
   CreateMetadataPayloadSchema,
   UpdateFinalStatusPayloadSchema,
   LogStepExecutionPayloadSchema,
+  UpdateProgressPayloadSchema,
 ]);
 export type ExecutionLoggerPayload = z.infer<typeof ExecutionLoggerPayloadSchema>;

--- a/packages/core-types/src/logging/records.ts
+++ b/packages/core-types/src/logging/records.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { AllmaErrorSchema, S3PointerSchema } from '../common/core.js';
+import { ExecutionKindSchema } from '../common/enums.js';
 import { StartFlowExecutionInputSchema } from '../runtime/core.js';
 import { StepInstanceSchema } from '../steps/definitions.js';
 import { MappingEventSchema, TransitionEvaluationEventSchema } from './events.js';
@@ -7,6 +8,36 @@ import { MappingEventSchema, TransitionEvaluationEventSchema } from './events.js
 export const ITEM_TYPE_ALLMA_FLOW_EXECUTION_RECORD = 'ALLMA_FLOW_EXECUTION_RECORD' as const;
 export const ITEM_TYPE_ALLMA_STEP_EXECUTION_RECORD = 'ALLMA_STEP_EXECUTION_RECORD' as const;
 export const METADATA_SK_VALUE = 'METADATA';
+
+/**
+ * The most advanced checkpoint a flow execution has reached, as stamped onto its metadata record.
+ * Mirrors `StepInstance.checkpoint` so a single GET of the metadata item carries the milestone.
+ */
+export const StampedCheckpointSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  order: z.number().int().optional(),
+  /** 1-based position among all declared checkpoints, for a "stage N of M" label. */
+  ordinal: z.number().int().optional(),
+});
+export type StampedCheckpoint = z.infer<typeof StampedCheckpointSchema>;
+
+/**
+ * A compact, one-line roll-up of the deepest active work in an execution tree, written onto the
+ * ROOT execution's metadata record so a single GET of the root reflects "what's happening now"
+ * even while the parent is suspended by a synchronous sub-flow (Pillar B, §6.4). Guarded by
+ * `updatedAt` so the most recent writer wins (e.g. a parent overwrites a finished child's roll-up).
+ */
+export const ExecutionLiveStatusSchema = z.object({
+  activeExecutionId: z.string().uuid(),
+  depth: z.number().int(),
+  stepDisplayName: z.string().optional(),
+  checkpointId: z.string().optional(),
+  checkpointLabel: z.string().optional(),
+  percent: z.number().int().min(0).max(100).optional(),
+  updatedAt: z.string().datetime({ offset: true }),
+});
+export type ExecutionLiveStatus = z.infer<typeof ExecutionLiveStatusSchema>;
 
 /**
  * Schema for the main "header" record of a flow execution, stored in DynamoDB.
@@ -29,6 +60,33 @@ export const AllmaFlowExecutionRecordSchema = z.object({
   overallStatus: z.string().optional(),
   overallStartTime: z.string().datetime().optional(),
   flow_sort_key: z.string().optional(),
+
+  // --- Progress (Pillar A, §5.3) — stamped by the orchestrator at each step boundary so the
+  // metadata item is a single, lag-free thing to GET/poll. All optional for backward compat
+  // (pre-existing executions omit them; the read API falls back to deriving from step records).
+  currentStepInstanceId: z.string().optional(),
+  currentStepDisplayName: z.string().optional(),
+  currentStepType: z.string().optional(),
+  completedStepCount: z.number().int().optional(),
+  totalStepCount: z.number().int().optional(),
+  currentCheckpoint: StampedCheckpointSchema.optional(),
+  totalCheckpoints: z.number().int().optional(),
+  progressPercent: z.number().int().min(0).max(100).optional(),
+  progressUpdatedAt: z.string().datetime({ offset: true }).optional(),
+
+  // --- Execution-tree linkage (Pillar B, §6.1) — present on every execution created after this
+  // change. For a top-level execution: rootFlowExecutionId === flowExecutionId, depth === 0,
+  // executionKind === 'ROOT'. `triggerSource` is retained for display but is no longer the link.
+  parentFlowExecutionId: z.string().uuid().optional(),
+  parentStepInstanceId: z.string().optional(),
+  rootFlowExecutionId: z.string().uuid().optional(),
+  depth: z.number().int().min(0).optional(),
+  executionKind: ExecutionKindSchema.optional(),
+  /** GSI_ByRoot sort key: `<zero-padded depth>#<parentStepInstanceId>#<flowExecutionId>`. */
+  tree_sort_key: z.string().optional(),
+
+  // --- Bubble-up roll-up (Pillar B, §6.4) — written onto the ROOT record only.
+  liveStatus: ExecutionLiveStatusSchema.optional(),
 });
 export type AllmaFlowExecutionRecord = z.infer<typeof AllmaFlowExecutionRecordSchema>;
 

--- a/packages/core-types/src/runtime/core.ts
+++ b/packages/core-types/src/runtime/core.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { S3PointerSchema, AllmaErrorSchema } from '../common/core.js';
-import { SfnActionTypeSchema } from '../common/enums.js';
+import { SfnActionTypeSchema, ExecutionKindSchema } from '../common/enums.js';
 import { StepInstanceSchema } from '../steps/definitions.js';
 import { AggregationConfigSchema, BranchResultSchema, BranchExecutionPayloadSchema, BranchDefinitionSchema } from '../flow/branching.js';
 
@@ -24,6 +24,20 @@ export const FlowRuntimeStateSchema: z.ZodType<any> = z.object({
   status: z.enum(['INITIALIZING', 'RUNNING', 'COMPLETED', 'FAILED', 'TIMED_OUT', 'CANCELLED']),
   startTime: z.string().datetime(),
   endTime: z.string().datetime().optional(),
+  // --- Progress tracking (Pillar A) carried through the orchestration loop so the metadata
+  // record can be stamped at each step boundary. Both monotonic / best-effort.
+  completedStepCount: z.number().int().min(0).optional(),
+  reachedCheckpoint: z.object({
+    id: z.string(),
+    label: z.string(),
+    order: z.number().int().optional(),
+  }).optional(),
+  // --- Execution-tree linkage (Pillar B) so a sub-flow knows its root and can bubble up.
+  rootFlowExecutionId: z.string().uuid().optional(),
+  parentFlowExecutionId: z.string().uuid().optional(),
+  parentStepInstanceId: z.string().optional(),
+  depth: z.number().int().min(0).optional(),
+  executionKind: ExecutionKindSchema.optional(),
   currentContextData: z.record(z.any()),
   currentContextDataS3Pointer: S3PointerSchema.optional(),
   errorInfo: AllmaErrorSchema.optional(),
@@ -57,6 +71,14 @@ export const StartFlowExecutionInputSchema = z.object({
   flowExecutionId: z.string().uuid().optional(),
   triggerSource: z.string().optional(),
   enableExecutionLogs: z.boolean().optional(),
+  // --- Execution-tree linkage (Pillar B, §6.1) — set when a step launches a sub-flow so the
+  // child's metadata record can be stamped with its position in the tree. Omitted for top-level
+  // triggers, where initialize-flow defaults to a ROOT node (root === self, depth 0).
+  parentFlowExecutionId: z.string().uuid().optional(),
+  parentStepInstanceId: z.string().optional(),
+  rootFlowExecutionId: z.string().uuid().optional(),
+  depth: z.number().int().min(0).optional(),
+  executionKind: ExecutionKindSchema.optional(),
   executionOverrides: z.object({
     stepOverrides: FlowStepOverridesSchema.optional(),
     startFromState: z.lazy((): typeof FlowRuntimeStateSchema => FlowRuntimeStateSchema).optional(),


### PR DESCRIPTION
## Summary

Phase 2 of the real-time execution status work (design: `docs/design/real-time-execution-status.md`). Builds on Phase 1 (#67) and implements **Pillar B** (execution tree across sub-flows) plus the authoritative half of **Pillar A** (orchestrator-driven progress stamping). All changes are additive and backward-compatible.

Two architectural facts shaped the implementation:
- A **sync sub-flow suspends its parent**, so child progress is **pushed up** (bubble-up) and the full tree is assembled **at read time** from a GSI.
- **In-memory parallel branches share the parent's `flowExecutionId`** (they don't create their own metadata record), so the tree is driven by **sub-flows**; branches remain surfaced via the existing branch-steps view. This is a deliberate, documented scoping of the design's `PARALLEL_BRANCH` kind (kept in the enum for forward-compat).

## Changes by package

**`@allma/core-types`** (minor)
- `logging/records.ts`: progress fields, tree linkage (`parent/root/depth/executionKind`, `tree_sort_key`), and `liveStatus` on `AllmaFlowExecutionRecordSchema`; shared `StampedCheckpointSchema` / `ExecutionLiveStatusSchema`.
- `common/enums.ts`: `ExecutionKindSchema` (placed here to avoid a records↔runtime import cycle).
- `runtime/core.ts`: `completedStepCount`/`reachedCheckpoint`/linkage on `FlowRuntimeState`; linkage on `StartFlowExecutionInput`.
- `logging/payloads.ts`: `UPDATE_PROGRESS` logger action; linkage added to `CREATE_METADATA`.
- `admin/executionMonitoring.ts`: `ExecutionProgressNode` made recursive (`children`) with `executionKind`/`depth`/`parentStepInstanceId`.

**`allma-app-logic`** (private; rides the core-cdk bump)
- `execution-logger.ts`: `UPDATE_PROGRESS` handler (guarded monotonic self-stamp + root bubble-up, swallows conditional-check failures); `CREATE_METADATA` defaults linkage and computes `tree_sort_key`.
- `execution-logger-client.ts`: `updateProgress` (fire-and-forget); linkage on `createMetadataRecord`.
- `iterative-step-processor/`: new pure `progress-stamper.ts`; stamping at each step boundary (skips in-memory branches), bubble-up on checkpoint change.
- `initialize-flow.ts` / `sync-flow-handler.ts` / `data-savers/start-flow-execution.ts`: set ROOT / SYNC_SUBFLOW / ASYNC_SUBFLOW linkage.
- `allma-admin`: `getExecutionProgress(mode)` — `single` prefers stamped metadata (falls back to read-time), `tree` assembles the nested tree from `GSI_ByRoot`.

**`@allma/core-cdk`** (patch) — `GSI_ByRoot` (PK `rootFlowExecutionId`, SK `tree_sort_key`) on the execution log table.

**`@allma/admin-shell`** (patch) — `useGetExecutionProgress(mode)`; `ExecutionProgressBar` renders the nested sub-flow tree.

## Test evidence
- `npm run build` (turbo): **9/9 successful** (incl. example apps).
- `vitest run --project unit`: **472 passed**; coverage above all floors (stmts 59.56% / branches 75.7% / funcs 72.3% / lines 59.56%).
- New tests: `progress-stamper.test.ts`, `execution-progress-tree.test.ts` (single stamped/fallback + tree assembly), `execution-logger.test.ts` (UPDATE_PROGRESS + CREATE_METADATA linkage).
- ESLint clean on all changed files.

## Deferred
- Phase 3 (client notifications / crash-safe terminal dispatcher) — separate PR.
- Checkpoint authoring UX in the Flow Editor (design open question #1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)