### PR TITLE
feat(flows-as-code): Phase 2 — coexistence & ergonomics

### DIFF
--- a/.changeset/flows-as-code-authoring-source.md
+++ b/.changeset/flows-as-code-authoring-source.md
@@ -1,0 +1,12 @@
+---
+"@allma/core-types": minor
+"@allma/flow-builder": minor
+---
+
+Add the `authoringSource` flow-ownership marker (Flows-as-Code Phase 2, RFC §6).
+
+`FlowDefinition`, `FlowAuthoringFormat`, and `FlowDefinitionObjectSchema` gain an optional
+`authoringSource?: 'code' | 'visual'` field that defaults to `'visual'`, so every existing flow is
+unchanged. `@allma/flow-builder`'s `build()` now stamps `'code'` on the flows it emits, marking them
+as managed in code. This is the persisted signal the Visual Editor uses to open code-owned flows
+read-only. The change is additive and backward compatible.

--- a/.changeset/flows-as-code-drift-guard.md
+++ b/.changeset/flows-as-code-drift-guard.md
@@ -1,0 +1,12 @@
+---
+"@allma/flow-builder": minor
+---
+
+Add an out-of-band drift guard for code-owned flows (Flows-as-Code Phase 2, RFC §6).
+
+`detectDrift(localCodeFlows, fetchDeployed)` compares each code-owned flow against its deployed
+copy and reports drift when the live version was taken over by the Visual Editor
+(`authoringSource` no longer `'code'`) or its authored fields no longer match the source. The
+`allma-flows check` command gains an opt-in `--remote <baseUrl>` flag that fetches deployed flow
+versions from the admin API (bearer token from `ALLMA_ADMIN_TOKEN`) and fails CI on drift. Without
+`--remote`, `check` is unchanged and performs no network calls.

--- a/.changeset/flows-as-code-editor-read-only.md
+++ b/.changeset/flows-as-code-editor-read-only.md
@@ -1,0 +1,12 @@
+---
+"@allma/admin-shell": minor
+---
+
+Enforce read-only editing for code-owned flows in the Flow Editor (Flows-as-Code Phase 2, RFC §6).
+
+When a flow's `authoringSource === 'code'`, the editor now opens read-only: structural edits
+(drag, connect, delete, add step, step/edge config) and Save are disabled, and a "Managed in code"
+banner explains that the source must be edited and redeployed. Viewing and the single-step Sandbox
+stay fully available, and the existing Dagre auto-layout positions code-owned flows on open. The
+read-only decision is centralized in a shared `resolveEditorReadOnly` helper used by the page, the
+canvas, and the step/edge panels, so published-version and code-owned gating stay consistent.

--- a/.changeset/flows-as-code-eject.md
+++ b/.changeset/flows-as-code-eject.md
@@ -1,0 +1,14 @@
+---
+"@allma/flow-builder": minor
+---
+
+Add `allma-flows eject` — JSON → TypeScript codegen for adopting a flow into code (Flows-as-Code
+Phase 2, RFC §6).
+
+`ejectFlow(flow)` (and the new `eject` CLI command) turn a committed/deployed flow definition back
+into a `.flow.ts` builder source: typed-payload steps map to their factories, known system modules
+to their registry-typed wrappers and consumer modules to the generic escape hatches, and
+instance/wiring fields are re-emitted as chained `.displayName()`/`.inputs()`/`.next()`/`.when()`/
+`.onError({ fallback })` calls. The output is round-trippable — `build()`-ing the generated source
+reproduces the original artifact (modulo the `authoringSource:'code'` stamp). This is the adoption /
+one-way ownership-transfer path from the Visual Editor into code.

--- a/.changeset/flows-as-code-jp-and-flow-class.md
+++ b/.changeset/flows-as-code-jp-and-flow-class.md
@@ -1,0 +1,14 @@
+---
+"@allma/flow-builder": minor
+---
+
+Add the `jp()` JSONPath helper and the `class Flow` OO facade (Flows-as-Code Phase 2, RFC §5.2/§5.6).
+
+`jp('$.steps_output.x')` validates a JSONPath eagerly (reusing the shared `JsonPathStringSchema`) and
+returns it as a branded string for use in mappings, conditions, and right-hand operands — a malformed
+path throws at author time. Its comparison builders (`jp.eq/ne/gt/gte/lt/lte`) emit transition-condition
+strings in the exact grammar the runtime evaluator understands.
+
+`class Flow` (`new Flow(meta)`, `addStep(id, draft)`, `start(ref)`, `build()`/`toExport()`) is an
+imperative authoring facade over the same internals as `defineFlow`; both share one build + strict
+validation core and produce byte-identical artifacts.

--- a/.changeset/flows-as-code-readme-phase-2.md
+++ b/.changeset/flows-as-code-readme-phase-2.md
@@ -1,0 +1,9 @@
+---
+"@allma/flow-builder": patch
+---
+
+Document Phase 2 in the README: `jp()` / `class Flow` ergonomics, `allma-flows eject` and `check
+--remote`, the Visual-Editor coexistence model (read-only enforcement + one-way ownership transfer),
+and the author-time `customConfig` enforcement decision (the builder enforces strictly at build time
+while the shared wire-contract schema stays advisory, because `customConfig` fields may be supplied
+at runtime via `inputMappings`).

--- a/.changeset/flows-as-code-unlock-visual.md
+++ b/.changeset/flows-as-code-unlock-visual.md
@@ -1,0 +1,10 @@
+---
+"@allma/admin-shell": minor
+---
+
+Add the "Unlock for visual editing" action for code-owned flows (Flows-as-Code Phase 2, RFC §6).
+
+The `useUnlockFlowForVisualEditing` mutation and an editor button (behind a confirmation modal) flip
+a code-owned flow's `authoringSource` from `'code'` back to `'visual'`, handing ownership to the
+Visual Editor. This is the explicit, one-way transfer counterpart to `allma-flows eject`; the marker
+flip is the persisted record of the transfer, and the editor re-renders editable afterward.

--- a/packages/admin-shell/src/api/flowService.ts
+++ b/packages/admin-shell/src/api/flowService.ts
@@ -252,6 +252,37 @@ export const useUpdateFlowVersion = () => {
     });
 };
 
+/**
+ * Flips a code-owned flow's `authoringSource` back to `'visual'`, handing
+ * ownership from code to the Visual Editor (Flows-as-Code RFC §6). This is the
+ * explicit, one-way "unlock for visual editing" action: it PUTs the version with
+ * the marker changed, and the flip is itself the persisted, diffable record of
+ * the transfer. After it succeeds the editor re-renders editable.
+ */
+export const useUnlockFlowForVisualEditing = () => {
+    const queryClient = useQueryClient();
+    return useMutation<FlowDefinition, Error, { flowDef: FlowDefinition }>({
+        mutationFn: async ({ flowDef }) => {
+            const flowDataToSave: FlowDefinition = { ...flowDef, authoringSource: 'visual' };
+            const response = await axiosInstance.put<AdminApiResponse<FlowDefinition>>(
+                `/${ALLMA_ADMIN_API_VERSION}${ALLMA_ADMIN_API_ROUTES.FLOW_VERSION_DETAIL(flowDataToSave.id, flowDataToSave.version)}`,
+                flowDataToSave
+            );
+            if (response.data.success) return response.data.data;
+            throw new Error(response.data.error?.message || 'Failed to unlock flow for visual editing');
+        },
+        onSuccess: (data) => {
+            queryClient.invalidateQueries({ queryKey: ['flowVersions', data.id] });
+            queryClient.invalidateQueries({ queryKey: ['flowConfig', data.id] });
+            queryClient.setQueryData(['flowDetail', data.id, String(data.version)], data);
+            notifications.show({ title: 'Unlocked for visual editing', message: `Version ${data.version} is now editable in the canvas. It is no longer managed in code.`, color: 'blue', icon: checkIcon });
+        },
+        onError: (error: unknown) => {
+            showErrorNotification('Unlock Failed', error);
+        }
+    });
+};
+
 export const usePublishFlowVersion = () => {
   const queryClient = useQueryClient();
   return useMutation({

--- a/packages/admin-shell/src/features/flows/editor/FlowEditorPage.tsx
+++ b/packages/admin-shell/src/features/flows/editor/FlowEditorPage.tsx
@@ -6,7 +6,7 @@ import { IconAlertCircle, IconDeviceFloppy, IconLock, IconLayoutSidebarLeftColla
 import { ReactFlowProvider, useReactFlow } from 'reactflow';
 
 import { PageContainer, CopyableText } from '@allma/ui-components';
-import { useGetFlowByVersion, useUpdateFlowVersion, useUnpublishFlowVersion } from '../../../api/flowService';
+import { useGetFlowByVersion, useUpdateFlowVersion, useUnpublishFlowVersion, useUnlockFlowForVisualEditing } from '../../../api/flowService';
 import useFlowEditorStore from './hooks/useFlowEditorStore';
 import { flowDefinitionToElements } from './flow-utils';
 import { FlowCanvas } from './components/FlowCanvas';
@@ -30,9 +30,11 @@ function FlowEditorPageContent() {
   
   const updateFlowMutation = useUpdateFlowVersion();
   const unpublishMutation = useUnpublishFlowVersion();
+  const unlockMutation = useUnlockFlowForVisualEditing();
 
   const [paletteVisible, { close: closePalette, toggle: togglePalette }] = useDisclosure(false);
   const [unpublishModalOpened, { open: openUnpublishModal, close: closeUnpublishModal }] = useDisclosure(false);
+  const [unlockModalOpened, { open: openUnlockModal, close: closeUnlockModal }] = useDisclosure(false);
   
   // State for the right panel
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
@@ -102,6 +104,15 @@ function FlowEditorPageContent() {
                     // causing this component to re-render with the updated isPublished status.
                 }
             }
+        );
+    }
+  };
+
+  const handleUnlock = () => {
+    if (flowFromStore) {
+        unlockMutation.mutate(
+            { flowDef: flowFromStore },
+            { onSuccess: () => closeUnlockModal() },
         );
     }
   };
@@ -199,9 +210,20 @@ function FlowEditorPageContent() {
                 </Button>
             </>
           ) : readOnlyReason === 'code' ? (
-            <Button variant="default" onClick={handleClose}>
-                Back to Versions
-            </Button>
+            <>
+                <Button
+                    variant="subtle"
+                    color="blue"
+                    leftSection={<IconCode size="1rem" />}
+                    onClick={openUnlockModal}
+                    loading={unlockMutation.isPending}
+                >
+                    Unlock for visual editing
+                </Button>
+                <Button variant="default" onClick={handleClose}>
+                    Back to Versions
+                </Button>
+            </>
           ) : (
             <>
                 <Button
@@ -312,6 +334,16 @@ function FlowEditorPageContent() {
         <Group justify="flex-end" mt="xl">
             <Button variant="default" onClick={closeUnpublishModal}>Cancel</Button>
             <Button color="orange" onClick={handleUnpublish} loading={unpublishMutation.isPending}>Unpublish</Button>
+        </Group>
+      </Modal>
+
+      {/* Unlock-for-visual-editing Confirmation Modal */}
+      <Modal opened={unlockModalOpened} onClose={closeUnlockModal} title="Unlock for visual editing" centered>
+        <Text>This flow is currently managed in code. Unlocking hands ownership to the Visual Editor so you can edit <Text span fw={700}>version {flowFromStore?.version}</Text> in the canvas.</Text>
+        <Text c="dimmed" size="sm" mt="sm">This is a one-way transfer: the next deploy of the code source will report drift until you re-eject the flow or remove it from code. Continue?</Text>
+        <Group justify="flex-end" mt="xl">
+            <Button variant="default" onClick={closeUnlockModal}>Cancel</Button>
+            <Button color="blue" onClick={handleUnlock} loading={unlockMutation.isPending}>Unlock</Button>
         </Group>
       </Modal>
     </PageContainer>

--- a/packages/admin-shell/src/features/flows/editor/FlowEditorPage.tsx
+++ b/packages/admin-shell/src/features/flows/editor/FlowEditorPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Box, Button, Group, Alert, ActionIcon, Tooltip, Paper, Stack, Title, Badge, Text, Modal } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
-import { IconAlertCircle, IconDeviceFloppy, IconLock, IconLayoutSidebarLeftCollapse, IconPlus, IconDownloadOff } from '@tabler/icons-react';
+import { IconAlertCircle, IconDeviceFloppy, IconLock, IconLayoutSidebarLeftCollapse, IconPlus, IconDownloadOff, IconCode } from '@tabler/icons-react';
 import { ReactFlowProvider, useReactFlow } from 'reactflow';
 
 import { PageContainer, CopyableText } from '@allma/ui-components';
@@ -15,6 +15,7 @@ import { StepPalette } from './components/editor-panel/StepPalette';
 import { StepEditorPanel } from './components/editor-panel/StepEditorPanel';
 import { EdgeEditorPanel } from './components/editor-panel/EdgeEditorPanel';
 import { useGetFlowConfig } from '../../../api/flowService';
+import { resolveEditorReadOnly } from './read-only';
 
 function FlowEditorPageContent() {
   const { flowId, version } = useParams<{ flowId: string, version: string }>();
@@ -152,7 +153,7 @@ function FlowEditorPageContent() {
   
   // --- END: Coordinated Panel Handlers ---
   
-  const isReadOnly = flowFromStore?.isPublished;
+  const { readOnly: isReadOnly, reason: readOnlyReason, isCodeOwned } = resolveEditorReadOnly(flowFromStore);
 
   const titleComponent = (
     <Stack gap={0} align="flex-start">
@@ -160,9 +161,14 @@ function FlowEditorPageContent() {
         <Title order={2}>
             {isReadOnly ? `Viewing Flow: ${flowFromStore?.name || '...'}` : `Editing Flow: ${flowFromStore?.name || '...'}`}
         </Title>
-        {isReadOnly && (
+        {readOnlyReason === 'published' && (
             <Tooltip label="This version is published and cannot be edited directly. Unpublish or create a new version to make changes." withArrow>
                 <Badge color="orange" variant="light" leftSection={<IconLock size={12} />} style={{ cursor: 'help' }}>Read-Only</Badge>
+            </Tooltip>
+        )}
+        {isCodeOwned && (
+            <Tooltip label="This flow is managed in code. Edit the source and redeploy, or unlock it for visual editing." withArrow>
+                <Badge color="blue" variant="light" leftSection={<IconCode size={12} />} style={{ cursor: 'help' }}>Managed in code</Badge>
             </Tooltip>
         )}
       </Group>
@@ -177,11 +183,11 @@ function FlowEditorPageContent() {
       breadcrumb={<FlowsBreadcrumbs flowId={flowId} flowName={flowFromStore?.name} isEditing />}
       rightSection={
         <Group>
-          {isReadOnly ? (
+          {readOnlyReason === 'published' ? (
             <>
-                <Button 
-                    variant="subtle" 
-                    color="orange" 
+                <Button
+                    variant="subtle"
+                    color="orange"
                     leftSection={<IconDownloadOff size="1rem" />}
                     onClick={openUnpublishModal}
                     loading={unpublishMutation.isPending}
@@ -192,6 +198,10 @@ function FlowEditorPageContent() {
                     Back to Versions
                 </Button>
             </>
+          ) : readOnlyReason === 'code' ? (
+            <Button variant="default" onClick={handleClose}>
+                Back to Versions
+            </Button>
           ) : (
             <>
                 <Button
@@ -219,7 +229,14 @@ function FlowEditorPageContent() {
       loading={isLoading || !flowFromStore}
     >
       {error && <Alert color="red" title="Failed to load flow" icon={<IconAlertCircle />}>{error.message}</Alert>}
-      
+
+      {isCodeOwned && (
+        <Alert color="blue" title="Managed in code" icon={<IconCode size={16} />} mb="sm">
+          This flow is managed in code. Edit the source and redeploy. You can still view it and run
+          steps in the Sandbox here. To take over editing in the canvas, unlock it for visual editing.
+        </Alert>
+      )}
+
       {flowFromStore && (
         <Box style={{ 
           height: `calc(100vh - ${isReadOnly ? 24 : 24}vh)`, // Adjusted height since Alert is gone

--- a/packages/admin-shell/src/features/flows/editor/components/FlowCanvas.tsx
+++ b/packages/admin-shell/src/features/flows/editor/components/FlowCanvas.tsx
@@ -21,6 +21,7 @@ import { UnifiedStepDefinition } from '../../../../api/stepDefinitionService';
 import { IconPlayerPlay, IconTrash } from '@tabler/icons-react';
 import { calculateSmartEdgeConnection } from './custom-nodes/hooks/useSmartEdge';
 import { StepInstance } from '@allma/core-types';
+import { resolveEditorReadOnly } from '../read-only';
 
 const nodeTypes = { stepNode: BaseStepNode };
 const edgeTypes = { conditionalEdge: ConditionalEdge };
@@ -50,7 +51,7 @@ export function FlowCanvas({ onNodeClick, onEdgeClick, onPaneClick, onNodeDouble
   
   const [menu, setMenu] = useState<{ id: string; x: number; y: number } | null>(null);
 
-  const isReadOnly = flowDefinition?.isPublished ?? false;
+  const isReadOnly = resolveEditorReadOnly(flowDefinition).readOnly;
 
   const memoizedNodeTypes = useMemo(() => nodeTypes, []);
   const memoizedEdgeTypes = useMemo(() => edgeTypes, []);

--- a/packages/admin-shell/src/features/flows/editor/components/editor-panel/EdgeEditorPanel.tsx
+++ b/packages/admin-shell/src/features/flows/editor/components/editor-panel/EdgeEditorPanel.tsx
@@ -5,6 +5,7 @@ import { IconDeviceFloppy, IconTrash, IconX } from '@tabler/icons-react';
 import { useMemo } from 'react';
 import { notifications } from '@mantine/notifications';
 import { modals } from '@mantine/modals';
+import { resolveEditorReadOnly } from '../../read-only';
 
 interface EdgeEditorPanelProps {
     selectedEdgeId: string | null;
@@ -38,7 +39,7 @@ export function EdgeEditorPanel({ selectedEdgeId, onClose }: EdgeEditorPanelProp
     }
 
     const { data: edgeData, source, target } = selectedEdge;
-    const isReadOnly = flowDefinition?.isPublished ?? false;
+    const isReadOnly = resolveEditorReadOnly(flowDefinition).readOnly;
     const isConditional = edgeData?.edgeType === 'conditional';
     
     const sourceNode = nodes.find(n => n.id === source);

--- a/packages/admin-shell/src/features/flows/editor/components/editor-panel/StepEditorPanel.tsx
+++ b/packages/admin-shell/src/features/flows/editor/components/editor-panel/StepEditorPanel.tsx
@@ -15,6 +15,7 @@ import { EditableJsonView } from '@allma/ui-components';
 import { useSandboxStep } from '../../../../../api/flowControlService.js';
 import { SandboxResultModal } from './SandboxResultModal.js';
 import { notifications } from '@mantine/notifications';
+import { resolveEditorReadOnly } from '../../read-only.js';
 
 
 interface StepEditorPanelProps {
@@ -162,7 +163,7 @@ export function StepEditorPanel({ selectedNodeId, onClose, isShaking, onValidati
         return null;
     }
 
-    const isReadOnly = flowDefinition?.isPublished ?? false;
+    const isReadOnly = resolveEditorReadOnly(flowDefinition).readOnly;
 
     const handlePreviewPrompt = (promptId: string) => {
         setPreviewPromptId(promptId);

--- a/packages/admin-shell/src/features/flows/editor/read-only.ts
+++ b/packages/admin-shell/src/features/flows/editor/read-only.ts
@@ -1,0 +1,36 @@
+/**
+ * Decides whether the Flow Editor must open read-only, and why.
+ *
+ * Two independent reasons make a flow non-editable in the canvas:
+ *  - `'published'` — the loaded version is published (existing behaviour); unpublish
+ *    or create a new version to edit.
+ *  - `'code'` — the flow is managed in code (`authoringSource === 'code'`,
+ *    Flows-as-Code RFC §6). Edit the source and redeploy, or explicitly unlock it
+ *    for visual editing.
+ *
+ * Published takes precedence for the primary `reason` (so the existing
+ * unpublish affordance keeps working), but `isCodeOwned` is reported
+ * independently so the "Managed in code" banner can render even for a published
+ * code-owned version. Viewing and the Sandbox stay enabled in all cases — only
+ * structural edits and Save are gated by `readOnly`.
+ */
+export interface EditorReadOnlyState {
+  readOnly: boolean;
+  reason: 'published' | 'code' | null;
+  isCodeOwned: boolean;
+}
+
+/** The minimal slice of a flow this decision needs. */
+export interface ReadOnlyFlowInput {
+  isPublished?: boolean;
+  authoringSource?: 'code' | 'visual';
+}
+
+export function resolveEditorReadOnly(
+  flow: ReadOnlyFlowInput | null | undefined,
+): EditorReadOnlyState {
+  const isPublished = flow?.isPublished === true;
+  const isCodeOwned = flow?.authoringSource === 'code';
+  const reason = isPublished ? 'published' : isCodeOwned ? 'code' : null;
+  return { readOnly: isPublished || isCodeOwned, reason, isCodeOwned };
+}

--- a/packages/admin-shell/tests/dom/api/flowService.test.tsx
+++ b/packages/admin-shell/tests/dom/api/flowService.test.tsx
@@ -12,11 +12,13 @@ vi.mock('@mantine/notifications', () => ({ notifications: { show: vi.fn() } }));
 
 import axiosInstance from '../../../src/api/axiosInstance.js';
 import { notifications } from '@mantine/notifications';
-import { useGetFlows, useGetFlowConfig, useCreateFlow } from '../../../src/api/flowService.js';
+import { useGetFlows, useGetFlowConfig, useCreateFlow, useUnlockFlowForVisualEditing } from '../../../src/api/flowService.js';
+import type { FlowDefinition } from '@allma/core-types';
 import { createHookWrapper, apiOk, apiFail } from '../../_helpers/query.js';
 
 const mockGet = vi.mocked(axiosInstance.get);
 const mockPost = vi.mocked(axiosInstance.post);
+const mockPut = vi.mocked(axiosInstance.put);
 const mockNotify = vi.mocked(notifications.show);
 
 const V = ALLMA_ADMIN_API_VERSION;
@@ -92,6 +94,44 @@ describe('useCreateFlow', () => {
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(mockNotify).toHaveBeenCalledWith(
       expect.objectContaining({ title: 'Creation Failed', color: 'red' }),
+    );
+  });
+});
+
+describe('useUnlockFlowForVisualEditing', () => {
+  const codeFlow = {
+    id: 'flow-1',
+    version: 2,
+    authoringSource: 'code',
+    startStepInstanceId: 'a',
+    steps: {},
+  } as unknown as FlowDefinition;
+
+  it('PUTs the version with authoringSource flipped to visual and unwraps the result', async () => {
+    mockPut.mockResolvedValue(apiOk({ ...codeFlow, authoringSource: 'visual' }));
+
+    const { result } = renderHook(() => useUnlockFlowForVisualEditing(), { wrapper: createHookWrapper() });
+    result.current.mutate({ flowDef: codeFlow });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockPut).toHaveBeenCalledWith(
+      `/${V}${R.FLOW_VERSION_DETAIL('flow-1', 2)}`,
+      expect.objectContaining({ id: 'flow-1', version: 2, authoringSource: 'visual' }),
+    );
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Unlocked for visual editing', color: 'blue' }),
+    );
+  });
+
+  it('surfaces an error notification when the unlock fails', async () => {
+    mockPut.mockResolvedValue(apiFail('nope'));
+
+    const { result } = renderHook(() => useUnlockFlowForVisualEditing(), { wrapper: createHookWrapper() });
+    result.current.mutate({ flowDef: codeFlow });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Unlock Failed', color: 'red' }),
     );
   });
 });

--- a/packages/admin-shell/tests/dom/features/flows/FlowEditorReadOnly.test.tsx
+++ b/packages/admin-shell/tests/dom/features/flows/FlowEditorReadOnly.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import type { FlowDefinition } from '@allma/core-types';
+import { renderWithProviders } from '../../../_helpers/render.js';
+
+// --- Heavy children stubbed: this test exercises page-level gating, not the canvas. ---
+vi.mock('../../../../src/features/flows/editor/components/FlowCanvas.js', () => ({
+  FlowCanvas: () => <div data-testid="flow-canvas" />,
+}));
+vi.mock('../../../../src/features/flows/editor/components/editor-panel/StepPalette.js', () => ({
+  StepPalette: () => <div data-testid="step-palette" />,
+}));
+vi.mock('../../../../src/features/flows/editor/components/editor-panel/StepEditorPanel.js', () => ({
+  StepEditorPanel: () => <div data-testid="step-editor-panel" />,
+}));
+vi.mock('../../../../src/features/flows/editor/components/editor-panel/EdgeEditorPanel.js', () => ({
+  EdgeEditorPanel: () => <div data-testid="edge-editor-panel" />,
+}));
+
+// @allma/ui-components ships its own @mantine/core copy; stub the two used exports so the
+// page renders under the test's MantineProvider without a dual-package context mismatch.
+vi.mock('@allma/ui-components', () => ({
+  PageContainer: ({ title, rightSection, children }: { title?: ReactNode; rightSection?: ReactNode; children?: ReactNode }) => (
+    <div>
+      <div>{title}</div>
+      <div>{rightSection}</div>
+      <div>{children}</div>
+    </div>
+  ),
+  CopyableText: ({ text }: { text?: string }) => <span>{text}</span>,
+}));
+vi.mock('../../../../src/features/flows/FlowsBreadcrumbs.js', () => ({
+  FlowsBreadcrumbs: () => <nav data-testid="breadcrumbs" />,
+}));
+
+// react-router params/navigation (MemoryRouter from renderWithProviders stays real).
+vi.mock('react-router-dom', async (importActual) => {
+  const actual = await importActual<typeof import('react-router-dom')>();
+  return { ...actual, useParams: () => ({ flowId: 'flow-1', version: '1' }), useNavigate: () => vi.fn() };
+});
+
+// API hooks: return a code- or visual-owned flow per test.
+const getFlowByVersion = vi.fn();
+const getFlowConfig = vi.fn();
+vi.mock('../../../../src/api/flowService.js', () => ({
+  useGetFlowByVersion: () => getFlowByVersion(),
+  useGetFlowConfig: () => getFlowConfig(),
+  useUpdateFlowVersion: () => ({ mutate: vi.fn(), isPending: false }),
+  useUnpublishFlowVersion: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+// Editor store: a controlled, deterministic state seeded per test.
+let storeState: Record<string, unknown>;
+vi.mock('../../../../src/features/flows/editor/hooks/useFlowEditorStore.js', () => ({
+  default: (selector: (s: Record<string, unknown>) => unknown) => selector(storeState),
+}));
+
+import { FlowEditorPage } from '../../../../src/features/flows/editor/FlowEditorPage.js';
+
+const codeFlow = (overrides: Partial<FlowDefinition> = {}): FlowDefinition =>
+  ({
+    id: 'flow-1',
+    name: 'My Flow',
+    version: 1,
+    isPublished: false,
+    authoringSource: 'code',
+    startStepInstanceId: 'start',
+    steps: {},
+    ...overrides,
+  }) as unknown as FlowDefinition;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getFlowByVersion.mockReturnValue({ data: codeFlow(), isLoading: false, error: null });
+  getFlowConfig.mockReturnValue({ data: { id: 'flow-1', name: 'My Flow', description: '' } });
+});
+
+describe('FlowEditorPage read-only enforcement', () => {
+  it('opens a code-owned flow read-only: banner shown, Save hidden, canvas/sandbox kept', () => {
+    storeState = { flowDefinition: codeFlow(), isDirty: false, nodes: [], setFlow: vi.fn(), clearDirtyState: vi.fn(), deselectAll: vi.fn() };
+    renderWithProviders(<FlowEditorPage />);
+
+    // The "Managed in code" banner (the teeth of coexistence).
+    expect(screen.getByText(/Edit the source and redeploy/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Managed in code/i).length).toBeGreaterThan(0);
+    // Structural editing is gated: no Save, no add-steps palette.
+    expect(screen.queryByRole('button', { name: /^Save$/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Save & Close/ })).not.toBeInTheDocument();
+    // Unpublish is for published flows, not code-owned ones.
+    expect(screen.queryByRole('button', { name: /Unpublish/ })).not.toBeInTheDocument();
+    // Viewing + Sandbox stay available: the canvas still mounts.
+    expect(screen.getByTestId('flow-canvas')).toBeInTheDocument();
+    expect(screen.getByTestId('step-editor-panel')).toBeInTheDocument();
+  });
+
+  it('keeps a draft, editor-owned flow fully editable (Save shown, no banner)', () => {
+    const visual = codeFlow({ authoringSource: 'visual' });
+    getFlowByVersion.mockReturnValue({ data: visual, isLoading: false, error: null });
+    storeState = { flowDefinition: visual, isDirty: true, nodes: [], setFlow: vi.fn(), clearDirtyState: vi.fn(), deselectAll: vi.fn() };
+    renderWithProviders(<FlowEditorPage />);
+
+    expect(screen.queryByText(/Managed in code/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Save$/ })).toBeInTheDocument();
+  });
+});

--- a/packages/admin-shell/tests/dom/features/flows/FlowEditorReadOnly.test.tsx
+++ b/packages/admin-shell/tests/dom/features/flows/FlowEditorReadOnly.test.tsx
@@ -48,6 +48,7 @@ vi.mock('../../../../src/api/flowService.js', () => ({
   useGetFlowConfig: () => getFlowConfig(),
   useUpdateFlowVersion: () => ({ mutate: vi.fn(), isPending: false }),
   useUnpublishFlowVersion: () => ({ mutate: vi.fn(), isPending: false }),
+  useUnlockFlowForVisualEditing: () => ({ mutate: vi.fn(), isPending: false }),
 }));
 
 // Editor store: a controlled, deterministic state seeded per test.
@@ -92,6 +93,8 @@ describe('FlowEditorPage read-only enforcement', () => {
     // Viewing + Sandbox stay available: the canvas still mounts.
     expect(screen.getByTestId('flow-canvas')).toBeInTheDocument();
     expect(screen.getByTestId('step-editor-panel')).toBeInTheDocument();
+    // The one-way ownership-transfer affordance is offered.
+    expect(screen.getByRole('button', { name: /Unlock for visual editing/i })).toBeInTheDocument();
   });
 
   it('keeps a draft, editor-owned flow fully editable (Save shown, no banner)', () => {

--- a/packages/admin-shell/tests/unit/features/flows/editor/read-only.test.ts
+++ b/packages/admin-shell/tests/unit/features/flows/editor/read-only.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { resolveEditorReadOnly } from '../../../../../src/features/flows/editor/read-only.js';
+
+describe('resolveEditorReadOnly', () => {
+  it('is editable for a draft, editor-owned flow', () => {
+    expect(resolveEditorReadOnly({ isPublished: false, authoringSource: 'visual' })).toEqual({
+      readOnly: false,
+      reason: null,
+      isCodeOwned: false,
+    });
+  });
+
+  it('treats a missing flow as not read-only (still loading)', () => {
+    expect(resolveEditorReadOnly(undefined)).toEqual({ readOnly: false, reason: null, isCodeOwned: false });
+    expect(resolveEditorReadOnly(null)).toEqual({ readOnly: false, reason: null, isCodeOwned: false });
+  });
+
+  it('is read-only with reason "published" for a published flow', () => {
+    expect(resolveEditorReadOnly({ isPublished: true })).toEqual({
+      readOnly: true,
+      reason: 'published',
+      isCodeOwned: false,
+    });
+  });
+
+  it('is read-only with reason "code" for a code-owned draft', () => {
+    expect(resolveEditorReadOnly({ isPublished: false, authoringSource: 'code' })).toEqual({
+      readOnly: true,
+      reason: 'code',
+      isCodeOwned: true,
+    });
+  });
+
+  it('gives published precedence for the primary reason but still reports code ownership', () => {
+    // A published, code-owned version: the unpublish affordance must keep working
+    // (reason='published'), yet the "Managed in code" banner must still show.
+    expect(resolveEditorReadOnly({ isPublished: true, authoringSource: 'code' })).toEqual({
+      readOnly: true,
+      reason: 'published',
+      isCodeOwned: true,
+    });
+  });
+});

--- a/packages/core-types/src/flow/core.ts
+++ b/packages/core-types/src/flow/core.ts
@@ -56,6 +56,12 @@ export type FlowDefinition = {
         defaultErrorHandler?: StepErrorHandler;
     } | null;
     onCompletionActions?: OnCompletionAction[];
+    /**
+     * Which authoring surface owns this flow. `'code'` flows are managed by the
+     * `@allma/flow-builder` toolchain and the Visual Editor opens them read-only;
+     * `'visual'` (the default for existing flows) are editor-owned. See RFC §6.
+     */
+    authoringSource?: 'code' | 'visual';
     createdAt: string;
     updatedAt: string;
     publishedAt?: string | null;
@@ -85,6 +91,8 @@ export type FlowAuthoringFormat = {
         defaultErrorHandler?: StepErrorHandler;
     } | null;
     onCompletionActions?: OnCompletionAction[];
+    /** See {@link FlowDefinition.authoringSource}. The builder stamps `'code'`. */
+    authoringSource?: 'code' | 'visual';
     // Accommodate passthrough fields
     [key: string]: any;
 };
@@ -170,6 +178,7 @@ const FlowDefinitionObjectSchema = z.object({
     defaultErrorHandler: StepErrorHandlerSchema.optional(),
   }).optional().nullable(),
   onCompletionActions: z.array(OnCompletionActionSchema).optional(),
+  authoringSource: z.enum(['code', 'visual']).optional().default('visual'),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
   publishedAt: z.string().datetime().nullable().optional(),

--- a/packages/core-types/src/flow/flow-authoring.test.ts
+++ b/packages/core-types/src/flow/flow-authoring.test.ts
@@ -72,6 +72,32 @@ describe('FlowDefinitionSchema backward compatibility', () => {
   });
 });
 
+describe('authoringSource marker', () => {
+  it('defaults to "visual" so existing flows are unchanged', () => {
+    const parsed = FlowAuthoringSchema.parse(authoringFlow()) as { authoringSource: string };
+    expect(parsed.authoringSource).toBe('visual');
+  });
+
+  it('accepts an explicit "code" marker (what the builder stamps)', () => {
+    const parsed = FlowAuthoringSchema.parse({ ...authoringFlow(), authoringSource: 'code' }) as {
+      authoringSource: string;
+    };
+    expect(parsed.authoringSource).toBe('code');
+  });
+
+  it('rejects an unknown authoringSource value', () => {
+    const result = FlowAuthoringSchema.safeParse({ ...authoringFlow(), authoringSource: 'gui' });
+    expect(result.success).toBe(false);
+  });
+
+  it('round-trips on the full FlowDefinitionSchema too', () => {
+    const parsed = FlowDefinitionSchema.parse({ ...fullFlow(), authoringSource: 'code' }) as {
+      authoringSource: string;
+    };
+    expect(parsed.authoringSource).toBe('code');
+  });
+});
+
 describe('applyFlowImportDefaults', () => {
   const now = '2026-06-28T12:00:00.000Z';
 

--- a/packages/flow-builder/README.md
+++ b/packages/flow-builder/README.md
@@ -102,28 +102,72 @@ Two different `{{...}}` worlds — the builder keeps them straight:
 `stepDefinitionId` resolves to a known artifact, or is wrapped in `external(id)`
 to document an intentional out-of-dir reference.
 
+## Ergonomics: `jp()` and `class Flow`
+
+`jp('$.steps_output.x')` validates a JSONPath eagerly (a malformed path throws at
+author time) and returns it for use in `inputs`/`outputs` and conditions. Its
+comparison builders emit transition conditions in the runtime evaluator's grammar:
+
+```ts
+s.poll.when(jp.eq('$.poll.status', 'DONE'), s.done);
+s.poll.when(jp.gt('$.poll.attempts', 5), s.giveUp);
+```
+
+`class Flow` is an imperative authoring facade over the same internals as
+`defineFlow`, for teams preferring OO construction (it produces identical artifacts):
+
+```ts
+const flow = new Flow({ id: 'order-intake' });
+const load = flow.addStep('load', s3DataLoad({ sourceS3Uri: 's3://in/x' }));
+const done = flow.addStep('done', endFlow());
+load.next(done);
+flow.start(load);
+export default flow;
+```
+
 ## CLI
 
 ```
-allma-flows build "flows/**/*.flow.ts" --out config/flows   # TS -> deterministic *.flow.json
-allma-flows check "flows/**/*.flow.ts" [--out config/flows]  # validate + (with --out) drift check
+allma-flows build "flows/**/*.flow.ts" --out config/flows              # TS -> deterministic *.flow.json
+allma-flows check "flows/**/*.flow.ts" [--out config/flows] [--remote <baseUrl>]
+                                                                       # validate + drift checks
+allma-flows eject <flowId> --from "config/flows/*.json" [--out flows]  # JSON -> *.flow.ts (adoption)
 ```
 
 Flow modules must `export default` the builder. Run under a TypeScript loader
 (e.g. `tsx`) when pointing at `.flow.ts` sources. Commit the generated JSON and
 run `allma-flows check` in CI: the byte-stable artifact makes the diff meaningful
-and drift between the `.ts` source and committed `.json` fails the build.
+and drift between the `.ts` source and committed `.json` fails the build. With
+`--remote <baseUrl>` (and an `ALLMA_ADMIN_TOKEN` bearer token), `check` also fails
+if a code-owned flow's **deployed** copy was taken over in the Visual Editor.
 
 ## Coexistence with the Visual Editor
 
-The builder emits **no step positions**, so the editor's existing Dagre
-auto-layout arranges code-owned flows on first open. The persisted
-`authoringSource` marker and editor read-only enforcement are **Phase 2**.
+Code- and editor-authored flows coexist under an explicit, per-flow ownership
+model (RFC §6):
 
-## Known limitations (Phase 1)
+- The builder stamps `authoringSource: 'code'` and emits **no step positions**, so
+  the editor's existing Dagre auto-layout arranges code-owned flows on first open.
+- `@allma/admin-shell` opens `authoringSource === 'code'` flows **read-only**:
+  structural edits and Save are disabled (a "Managed in code" banner explains why),
+  while viewing and the single-step Sandbox stay available.
+- Ownership transfer is deliberate and one-way: `allma-flows eject` adopts a flow
+  **into** code (JSON → TS), and the editor's "Unlock for visual editing" action
+  flips ownership **back** to the editor.
+
+## `customConfig` validation (author-time)
+
+The builder hard-enforces each module step's `customConfig` against the centralized
+registry schema at **build time** — the earliest point any `customConfig` is
+validated. The shared `FlowDefinitionSchema` (the wire/storage contract) keeps the
+registry check **advisory** (warn-mode in the importer): a required `customConfig`
+field may legitimately be supplied at runtime via `inputMappings`, so a hard error
+there would reject valid flows. Author in code to get the strict, earliest check.
+
+## Known limitations
 
 - `customConfig` validation checks shape/type via the registry but does not
   reject unknown `customConfig` keys (the runtime strips them); leaf **payload**
   keys are strict.
-- `jp()` path helper, the `class Flow` OO facade, `allma-flows eject`/`deploy`,
-  and typed-context generics are deferred to later phases (RFC §11).
+- Typed `definePrompt`/`defineStep`/MCP object cross-references, `allma-flows
+  deploy`, and typed-context generics for mappings are **Phase 3** (RFC §11).

--- a/packages/flow-builder/src/builder.test.ts
+++ b/packages/flow-builder/src/builder.test.ts
@@ -60,6 +60,13 @@ describe('build() round-trip', () => {
     expect(FlowDefinitionSchema.safeParse(imported).success).toBe(true);
   });
 
+  it('stamps authoringSource="code" so the editor opens it read-only (RFC §6)', () => {
+    const flow = buildExampleFlow().build();
+    expect(flow.authoringSource).toBe('code');
+    const exported = buildExampleFlow().toExport();
+    expect((exported.flows![0] as Record<string, unknown>).authoringSource).toBe('code');
+  });
+
   it('resolves ref-based wiring to ids and sets the start step', () => {
     const flow = buildExampleFlow().build();
     expect(flow.startStepInstanceId).toBe('load');

--- a/packages/flow-builder/src/cli/allma-flows.ts
+++ b/packages/flow-builder/src/cli/allma-flows.ts
@@ -4,9 +4,11 @@
  *
  *   allma-flows build "<glob>" --out <dir> [--exported-at <iso>]
  *       Compile TS flow modules to deterministic *.flow.json.
- *   allma-flows check "<glob>" [--out <dir>] [--known <glob>]
- *       Validate (strict gate + deploy parity + cross-artifact resolution) and,
- *       when --out is given, fail on drift between the TS source and committed JSON.
+ *   allma-flows check "<glob>" [--out <dir>] [--known <glob>] [--remote <baseUrl>]
+ *       Validate (strict gate + deploy parity + cross-artifact resolution); when
+ *       --out is given, fail on drift between the TS source and committed JSON; when
+ *       --remote is given, fail if a code-owned flow's deployed copy was last
+ *       modified in the editor (bearer token from ALLMA_ADMIN_TOKEN).
  *   allma-flows eject <flowId> --from "<glob>" [--out <dir>]
  *       Generate a `.flow.ts` builder source from a committed/deployed flow JSON
  *       (adoption / one-way ownership transfer). Writes to --out or stdout.
@@ -21,7 +23,32 @@ import type { FlowBuilder } from '../define-flow.js';
 import { buildArtifacts, checkArtifacts, harvestCatalogIds } from './commands.js';
 import type { Catalog } from '../catalog.js';
 import { ejectFlow } from '../eject.js';
+import { detectDrift, type DeployedFlow, type LocalCodeFlow } from '../drift.js';
+import { ALLMA_ADMIN_API_VERSION, ALLMA_ADMIN_API_ROUTES } from '@allma/core-types';
 import type { FlowAuthoringFormat } from '@allma/core-types';
+
+/**
+ * Builds a `fetchDeployed` adapter that reads a flow version from the admin API.
+ * Auth is a bearer token from `ALLMA_ADMIN_TOKEN` (no service-account auth exists
+ * yet; a human admin token is used for CI). Returns `null` on 404 (not deployed).
+ */
+function makeRemoteFetcher(baseUrl: string, token: string | undefined) {
+  const root = baseUrl.replace(/\/$/, '');
+  return async (flowId: string, version: number): Promise<DeployedFlow | null> => {
+    const url = `${root}/${ALLMA_ADMIN_API_VERSION}${ALLMA_ADMIN_API_ROUTES.FLOW_VERSION_DETAIL(flowId, version)}`;
+    const res = await fetch(url, {
+      headers: token ? { authorization: `Bearer ${token}` } : {},
+    });
+    if (res.status === 404) return null;
+    if (!res.ok) throw new Error(`admin API ${res.status} fetching ${flowId} v${version} from ${url}`);
+    const body = (await res.json()) as { success?: boolean; data?: DeployedFlow } | DeployedFlow;
+    // Unwrap the AdminApiResponse envelope when present.
+    if (body && typeof body === 'object' && 'data' in body && (body as { data?: DeployedFlow }).data) {
+      return (body as { data: DeployedFlow }).data;
+    }
+    return body as DeployedFlow;
+  };
+}
 
 interface ParsedArgs {
   command: string | undefined;
@@ -127,7 +154,7 @@ async function runBuild(args: ParsedArgs): Promise<number> {
 
 async function runCheck(args: ParsedArgs): Promise<number> {
   if (!args.pattern) {
-    console.error('Usage: allma-flows check "<glob>" [--out <dir>] [--known <glob>]');
+    console.error('Usage: allma-flows check "<glob>" [--out <dir>] [--known <glob>] [--remote <baseUrl>]');
     return 2;
   }
   const files = await findFiles(args.pattern);
@@ -147,6 +174,24 @@ async function runCheck(args: ParsedArgs): Promise<number> {
   for (const issue of resolutionIssues) {
     console.error(`✗ unresolved: [${issue.flowId}] ${issue.message}`);
     failed = true;
+  }
+
+  // Out-of-band drift guard: compare each code-owned flow against the deployed copy.
+  if (args.flags.remote) {
+    const local: LocalCodeFlow[] = builders.map((builder) => {
+      const flow = (builder.toExport().flows ?? [])[0] as FlowAuthoringFormat;
+      return { flowId: flow.id, version: flow.version, flow };
+    });
+    const fetchDeployed = makeRemoteFetcher(args.flags.remote, process.env.ALLMA_ADMIN_TOKEN);
+    try {
+      for (const issue of await detectDrift(local, fetchDeployed)) {
+        console.error(`✗ drift (${issue.reason}): [${issue.flowId}] ${issue.message}`);
+        failed = true;
+      }
+    } catch (error) {
+      console.error(`✗ drift: ${error instanceof Error ? error.message : String(error)}`);
+      failed = true;
+    }
   }
 
   // Drift check: when --out is given, regenerated JSON must equal committed JSON.

--- a/packages/flow-builder/src/cli/allma-flows.ts
+++ b/packages/flow-builder/src/cli/allma-flows.ts
@@ -7,6 +7,9 @@
  *   allma-flows check "<glob>" [--out <dir>] [--known <glob>]
  *       Validate (strict gate + deploy parity + cross-artifact resolution) and,
  *       when --out is given, fail on drift between the TS source and committed JSON.
+ *   allma-flows eject <flowId> --from "<glob>" [--out <dir>]
+ *       Generate a `.flow.ts` builder source from a committed/deployed flow JSON
+ *       (adoption / one-way ownership transfer). Writes to --out or stdout.
  *
  * Flow modules must `export default defineFlow(...).<wired builder>`. Run under a
  * TypeScript loader (e.g. `tsx`) when pointing at `.flow.ts` sources.
@@ -17,6 +20,8 @@ import { pathToFileURL } from 'node:url';
 import type { FlowBuilder } from '../define-flow.js';
 import { buildArtifacts, checkArtifacts, harvestCatalogIds } from './commands.js';
 import type { Catalog } from '../catalog.js';
+import { ejectFlow } from '../eject.js';
+import type { FlowAuthoringFormat } from '@allma/core-types';
 
 interface ParsedArgs {
   command: string | undefined;
@@ -170,6 +175,55 @@ async function runCheck(args: ParsedArgs): Promise<number> {
   return 0;
 }
 
+/** Loads every flow object found in the JSON files matching `pattern`. */
+async function loadFlowsFromJson(pattern: string): Promise<FlowAuthoringFormat[]> {
+  const flows: FlowAuthoringFormat[] = [];
+  for (const file of await findFiles(pattern)) {
+    if (!file.endsWith('.json')) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(await readFile(file, 'utf8'));
+    } catch {
+      continue; // skip unreadable/non-JSON files
+    }
+    const data = parsed as { flows?: FlowAuthoringFormat[] } & Partial<FlowAuthoringFormat>;
+    if (Array.isArray(data.flows)) {
+      flows.push(...data.flows);
+    } else if (typeof data.id === 'string' && data.steps) {
+      flows.push(data as FlowAuthoringFormat);
+    }
+  }
+  return flows;
+}
+
+async function runEject(args: ParsedArgs): Promise<number> {
+  // For eject, the positional `pattern` slot is the flowId; the source glob is --from.
+  const flowId = args.pattern;
+  const from = args.flags.from;
+  if (!flowId || !from) {
+    console.error('Usage: allma-flows eject <flowId> --from "<glob>" [--out <dir>]');
+    return 2;
+  }
+  const flows = await loadFlowsFromJson(from);
+  const flow = flows.find((f) => f.id === flowId);
+  if (!flow) {
+    console.error(`No flow with id '${flowId}' found in JSON matching '${from}'.`);
+    return 1;
+  }
+  const source = ejectFlow(flow);
+  if (args.flags.out) {
+    const outDir = resolve(args.flags.out);
+    await mkdir(outDir, { recursive: true });
+    const target = join(outDir, `${flowId}.flow.ts`);
+    await writeFile(target, source, 'utf8');
+    console.log(`✓ ${flowId}.flow.ts`);
+    console.log(`Ejected '${flowId}' to ${target}.`);
+  } else {
+    process.stdout.write(source);
+  }
+  return 0;
+}
+
 async function main(): Promise<number> {
   const args = parseArgs(process.argv.slice(2));
   switch (args.command) {
@@ -177,8 +231,10 @@ async function main(): Promise<number> {
       return runBuild(args);
     case 'check':
       return runCheck(args);
+    case 'eject':
+      return runEject(args);
     default:
-      console.error('Usage: allma-flows <build|check> "<glob>" [options]');
+      console.error('Usage: allma-flows <build|check|eject> "<glob>" [options]');
       return 2;
   }
 }

--- a/packages/flow-builder/src/define-flow.ts
+++ b/packages/flow-builder/src/define-flow.ts
@@ -108,6 +108,8 @@ class FlowBuilderImpl implements FlowBuilder {
       version: this.options.version ?? 1,
       startStepInstanceId: this.startStep ? this.startStep.id : '',
       steps,
+      // Self-mark as code-owned (RFC §6): the Visual Editor opens these read-only.
+      authoringSource: 'code',
     };
     if (this.options.name !== undefined) flow.name = this.options.name;
     if (this.options.description !== undefined) flow.description = this.options.description;

--- a/packages/flow-builder/src/define-flow.ts
+++ b/packages/flow-builder/src/define-flow.ts
@@ -28,6 +28,77 @@ interface DefaultStepConfig {
   defaultErrorHandler?: StepErrorHandler;
 }
 
+/**
+ * Shared build core used by both {@link defineFlow}'s builder and the `class Flow`
+ * facade: assembles the flow object, runs the full strict authoring gate, and
+ * either throws an aggregated {@link FlowBuildError} or returns the deterministic
+ * {@link FlowAuthoringFormat}. Kept here (not duplicated) so the two authoring
+ * surfaces validate identically.
+ */
+export function buildFlowArtifact(
+  options: DefineFlowOptions,
+  stepMap: Map<string, Step>,
+  startStep: Step | undefined,
+): FlowAuthoringFormat {
+  const issues: string[] = [];
+
+  if (stepMap.size === 0) {
+    issues.push('flow has no steps; declare them via flow.steps({ ... }).');
+  }
+  if (!startStep) {
+    issues.push('no start step set; call flow.start(ref).');
+  }
+
+  const steps: Record<string, unknown> = {};
+  for (const [id, step] of stepMap) {
+    steps[id] = step._toInstance();
+  }
+
+  const flow: Record<string, unknown> = {
+    id: options.id,
+    version: options.version ?? 1,
+    startStepInstanceId: startStep ? startStep.id : '',
+    steps,
+    // Self-mark as code-owned (RFC §6): the Visual Editor opens these read-only.
+    authoringSource: 'code',
+  };
+  if (options.name !== undefined) flow.name = options.name;
+  if (options.description !== undefined) flow.description = options.description;
+  if (options.enableExecutionLogs !== undefined) flow.enableExecutionLogs = options.enableExecutionLogs;
+  if (options.variables !== undefined) flow.flowVariables = options.variables;
+  if (options.defaultStepConfig !== undefined) flow.defaultStepConfig = options.defaultStepConfig;
+  if (options.onCompletionActions !== undefined) flow.onCompletionActions = options.onCompletionActions;
+
+  // 1. Deploy-placeholder placement scan (Gap 2).
+  issues.push(...checkDeployTokens(flow));
+
+  // 2. Per-step strict leaf clone + registry customConfig parse.
+  for (const [id, step] of stepMap) {
+    const payload = step._getPayload();
+    issues.push(...checkStepPayload(id, step._getStepType(), payload));
+    issues.push(
+      ...checkModuleCustomConfig(id, payload.moduleIdentifier as string | undefined, payload.customConfig),
+    );
+  }
+
+  // 3. Shared authoring schema: cross-references + JSONPath well-formedness.
+  issues.push(...checkAuthoringSchema(flow));
+
+  if (issues.length > 0) {
+    throw new FlowBuildError(options.id, issues);
+  }
+  return flow as FlowAuthoringFormat;
+}
+
+/** Wraps a built flow in the deterministic deploy-file envelope. */
+export function toExportEnvelope(flow: FlowAuthoringFormat, exportedAt: string = STABLE_EXPORTED_AT): AllmaExportFormat {
+  return {
+    formatVersion: '1.0',
+    exportedAt,
+    flows: [flow],
+  } as unknown as AllmaExportFormat;
+}
+
 /** Options accepted by {@link defineFlow}. */
 export interface DefineFlowOptions {
   /** Stable flow id (the `flowDefinitionId`). */
@@ -89,62 +160,11 @@ class FlowBuilderImpl implements FlowBuilder {
   }
 
   build(): FlowAuthoringFormat {
-    const issues: string[] = [];
-
-    if (this.stepMap.size === 0) {
-      issues.push('flow has no steps; declare them via flow.steps({ ... }).');
-    }
-    if (!this.startStep) {
-      issues.push('no start step set; call flow.start(ref).');
-    }
-
-    const steps: Record<string, unknown> = {};
-    for (const [id, step] of this.stepMap) {
-      steps[id] = step._toInstance();
-    }
-
-    const flow: Record<string, unknown> = {
-      id: this.options.id,
-      version: this.options.version ?? 1,
-      startStepInstanceId: this.startStep ? this.startStep.id : '',
-      steps,
-      // Self-mark as code-owned (RFC §6): the Visual Editor opens these read-only.
-      authoringSource: 'code',
-    };
-    if (this.options.name !== undefined) flow.name = this.options.name;
-    if (this.options.description !== undefined) flow.description = this.options.description;
-    if (this.options.enableExecutionLogs !== undefined) flow.enableExecutionLogs = this.options.enableExecutionLogs;
-    if (this.options.variables !== undefined) flow.flowVariables = this.options.variables;
-    if (this.options.defaultStepConfig !== undefined) flow.defaultStepConfig = this.options.defaultStepConfig;
-    if (this.options.onCompletionActions !== undefined) flow.onCompletionActions = this.options.onCompletionActions;
-
-    // 1. Deploy-placeholder placement scan (Gap 2).
-    issues.push(...checkDeployTokens(flow));
-
-    // 2. Per-step strict leaf clone + registry customConfig parse.
-    for (const [id, step] of this.stepMap) {
-      const payload = step._getPayload();
-      issues.push(...checkStepPayload(id, step._getStepType(), payload));
-      issues.push(
-        ...checkModuleCustomConfig(id, payload.moduleIdentifier as string | undefined, payload.customConfig),
-      );
-    }
-
-    // 3. Shared authoring schema: cross-references + JSONPath well-formedness.
-    issues.push(...checkAuthoringSchema(flow));
-
-    if (issues.length > 0) {
-      throw new FlowBuildError(this.options.id, issues);
-    }
-    return flow as FlowAuthoringFormat;
+    return buildFlowArtifact(this.options, this.stepMap, this.startStep);
   }
 
   toExport(exportedAt: string = STABLE_EXPORTED_AT): AllmaExportFormat {
-    return {
-      formatVersion: '1.0',
-      exportedAt,
-      flows: [this.build()],
-    } as unknown as AllmaExportFormat;
+    return toExportEnvelope(this.build(), exportedAt);
   }
 }
 

--- a/packages/flow-builder/src/drift.test.ts
+++ b/packages/flow-builder/src/drift.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest';
+import { detectDrift, type DeployedFlow, type LocalCodeFlow } from './drift.js';
+import type { FlowAuthoringFormat } from '@allma/core-types';
+
+const codeFlow = (overrides: Partial<FlowAuthoringFormat> = {}): FlowAuthoringFormat =>
+  ({
+    id: 'f1',
+    version: 1,
+    authoringSource: 'code',
+    startStepInstanceId: 'a',
+    steps: { a: { stepInstanceId: 'a', stepType: 'NO_OP' } },
+    ...overrides,
+  }) as unknown as FlowAuthoringFormat;
+
+const local = (flow = codeFlow()): LocalCodeFlow[] => [{ flowId: flow.id, version: flow.version, flow }];
+
+/** The deployed copy = the local flow plus the server bookkeeping the importer stamps. */
+const deployed = (flow: FlowAuthoringFormat, overrides: Partial<DeployedFlow> = {}): DeployedFlow => ({
+  ...(flow as unknown as DeployedFlow),
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-02-02T00:00:00.000Z',
+  isPublished: false,
+  ...overrides,
+});
+
+describe('detectDrift', () => {
+  it('reports no drift when the deployed copy matches the code source', async () => {
+    const flow = codeFlow();
+    const fetchDeployed = vi.fn().mockResolvedValue(deployed(flow));
+    expect(await detectDrift(local(flow), fetchDeployed)).toEqual([]);
+  });
+
+  it('flags editor-owned drift when the deployed copy is no longer authoringSource=code', async () => {
+    const flow = codeFlow();
+    const fetchDeployed = vi.fn().mockResolvedValue(deployed(flow, { authoringSource: 'visual' }));
+    const issues = await detectDrift(local(flow), fetchDeployed);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].reason).toBe('editor-owned');
+  });
+
+  it('flags content-mismatch when an authored field differs but it is still code-owned', async () => {
+    const flow = codeFlow({ description: 'from code' });
+    const changed = deployed(codeFlow({ description: 'edited live' }));
+    const fetchDeployed = vi.fn().mockResolvedValue(changed);
+    const issues = await detectDrift(local(flow), fetchDeployed);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].reason).toBe('content-mismatch');
+  });
+
+  it('ignores server-stamped fields the source never authors', async () => {
+    const flow = codeFlow();
+    // Deployed has extra bookkeeping + a defaulted flowVariables, but the authored fields match.
+    const fetchDeployed = vi.fn().mockResolvedValue(deployed(flow, { publishedAt: null, flowVariables: {} }));
+    expect(await detectDrift(local(flow), fetchDeployed)).toEqual([]);
+  });
+
+  it('treats a not-yet-deployed flow as no drift', async () => {
+    const fetchDeployed = vi.fn().mockResolvedValue(null);
+    expect(await detectDrift(local(), fetchDeployed)).toEqual([]);
+  });
+
+  it('skips flows that are not code-owned locally', async () => {
+    const visual = codeFlow({ authoringSource: 'visual' });
+    const fetchDeployed = vi.fn().mockResolvedValue(deployed(visual, { authoringSource: 'visual' }));
+    expect(await detectDrift(local(visual), fetchDeployed)).toEqual([]);
+    expect(fetchDeployed).not.toHaveBeenCalled();
+  });
+});

--- a/packages/flow-builder/src/drift.ts
+++ b/packages/flow-builder/src/drift.ts
@@ -1,0 +1,93 @@
+import type { FlowAuthoringFormat } from '@allma/core-types';
+import { stableStringify } from './serialize.js';
+
+/**
+ * Out-of-band drift guard (RFC §6). A code-owned flow must be the single source of
+ * truth: if the deployed copy was taken over and last modified in the Visual
+ * Editor, CI should fail so the divergence is caught before it is silently
+ * overwritten on the next deploy.
+ *
+ * The pure {@link detectDrift} compares each local code-owned flow against the
+ * deployed version supplied by an injected `fetchDeployed` callback (the network/
+ * auth adapter lives in the CLI, keeping this testable with no I/O).
+ *
+ * Two signals:
+ *  - `editor-owned` — the deployed flow's `authoringSource` is no longer `'code'`.
+ *    The editor can only persist a code-owned flow after an explicit "unlock for
+ *    visual editing" (which flips the marker to `'visual'`), so this is the precise
+ *    "taken over by the editor" signal.
+ *  - `content-mismatch` — the deployed flow is still marked `'code'` but the fields
+ *    the source authored differ from what is deployed (a stale deploy, or a direct
+ *    edit). Only the keys the local artifact emits are compared, so server-stamped
+ *    defaults/bookkeeping never cause a false positive.
+ */
+
+/** Server-owned bookkeeping fields the importer stamps; never authored in code. */
+const SERVER_FIELDS = new Set(['createdAt', 'updatedAt', 'publishedAt', 'isPublished']);
+
+/** A locally-built, code-owned flow (the committed artifact). */
+export interface LocalCodeFlow {
+  flowId: string;
+  version: number;
+  flow: FlowAuthoringFormat;
+}
+
+/** The deployed flow definition as returned by the admin API (with server fields). */
+export type DeployedFlow = Record<string, unknown> & { authoringSource?: 'code' | 'visual' };
+
+/** Fetches the deployed flow for `(flowId, version)`, or `null` if not deployed yet. */
+export type FetchDeployed = (flowId: string, version: number) => Promise<DeployedFlow | null>;
+
+/** A single drift finding. */
+export interface DriftIssue {
+  flowId: string;
+  version: number;
+  reason: 'editor-owned' | 'content-mismatch';
+  message: string;
+}
+
+/** Compares the authored keys (minus server bookkeeping) of two flow objects. */
+function authoredFieldsDiffer(local: Record<string, unknown>, deployed: Record<string, unknown>): boolean {
+  for (const [key, value] of Object.entries(local)) {
+    if (SERVER_FIELDS.has(key)) continue;
+    if (stableStringify(value) !== stableStringify(deployed[key])) return true;
+  }
+  return false;
+}
+
+/**
+ * Detects drift for every local code-owned flow against its deployed counterpart.
+ * Flows whose local `authoringSource` is not `'code'` are ignored (the guard only
+ * protects code-owned flows). Flows not yet deployed (`fetchDeployed` → `null`) are
+ * not drift.
+ */
+export async function detectDrift(
+  local: LocalCodeFlow[],
+  fetchDeployed: FetchDeployed,
+): Promise<DriftIssue[]> {
+  const issues: DriftIssue[] = [];
+  for (const { flowId, version, flow } of local) {
+    if (flow.authoringSource !== 'code') continue;
+    const deployed = await fetchDeployed(flowId, version);
+    if (!deployed) continue; // not deployed yet — nothing to drift from
+
+    if (deployed.authoringSource !== 'code') {
+      issues.push({
+        flowId,
+        version,
+        reason: 'editor-owned',
+        message: `Deployed flow '${flowId}' v${version} is marked authoringSource='${deployed.authoringSource ?? 'visual'}' — it was unlocked and last modified in the Visual Editor. Re-eject it or unlock the source's ownership before redeploying.`,
+      });
+      continue;
+    }
+    if (authoredFieldsDiffer(flow as Record<string, unknown>, deployed)) {
+      issues.push({
+        flowId,
+        version,
+        reason: 'content-mismatch',
+        message: `Deployed flow '${flowId}' v${version} differs from the committed code source. Rebuild and redeploy so the live copy matches the source of truth.`,
+      });
+    }
+  }
+  return issues;
+}

--- a/packages/flow-builder/src/eject.test.ts
+++ b/packages/flow-builder/src/eject.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { writeFile, mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import {
+  defineFlow,
+  deployVar,
+  s3DataLoad,
+  s3DataSave,
+  llmInvocation,
+  customLambdaInvoke,
+  dataTransform,
+  ejectFlow,
+  flowToBuilderSpec,
+  type FlowBuilder,
+} from './index.js';
+
+/** Absolute path to the local builder entry, so generated TS imports the source under test. */
+const LOCAL_INDEX = fileURLToPath(new URL('./index.ts', import.meta.url));
+
+/** A flow exercising typed steps, a registry wrapper, an escape hatch, wiring + onError. */
+function buildSampleFlow(): FlowBuilder {
+  const flow = defineFlow({
+    id: 'eject-sample',
+    name: 'Eject Sample',
+    description: 'Round-trip fixture',
+    enableExecutionLogs: true,
+    variables: { outputBucket: deployVar('out-{{stage}}') },
+  });
+
+  const s = flow.steps({
+    load: s3DataLoad({ sourceS3Uri: 's3://in/doc.txt', outputFormat: 'TEXT' })
+      .displayName('1. Load')
+      .outputs({ '$.steps_output.doc_text': '$.body' }),
+
+    summarize: llmInvocation({ llmProvider: 'AWS_BEDROCK', modelId: 'anthropic.claude-3-sonnet' })
+      .displayName('2. Summarize')
+      .inputs({ 'prompt.document': '$.steps_output.doc_text' }),
+
+    reshape: dataTransform({ moduleIdentifier: 'consumer/custom-reshape', customConfig: { mode: 'x' } })
+      .displayName('3. Reshape'),
+
+    store: s3DataSave({ destinationS3UriTemplate: 's3://{{flow_variables.outputBucket}}/out.json' }),
+
+    handleError: customLambdaInvoke({ lambdaFunctionArnTemplate: 'arn:aws:lambda:us-east-1:1:function:on-failure' }),
+  });
+
+  s.load.next(s.summarize).onError({ fallback: s.handleError, continueOnFailure: true });
+  s.summarize.when('$.steps_output.doc_text', s.reshape);
+  s.summarize.next(s.store);
+  flow.start(s.load);
+  return flow;
+}
+
+/** Writes generated source to a temp file, imports it, and returns its default builder. */
+async function importGenerated(source: string): Promise<FlowBuilder> {
+  const dir = await mkdtemp(join(tmpdir(), 'allma-eject-'));
+  const file = join(dir, 'generated.flow.ts');
+  await writeFile(file, source, 'utf8');
+  try {
+    const mod = (await import(/* @vite-ignore */ file)) as { default: FlowBuilder };
+    return mod.default;
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe('ejectFlow', () => {
+  it('round-trips JSON -> TS -> build() back to the same artifact', async () => {
+    const original = buildSampleFlow().toExport();
+    const flow = original.flows![0];
+
+    const source = ejectFlow(flow, { importSpecifier: LOCAL_INDEX });
+    const rebuilt = await importGenerated(source);
+
+    expect(rebuilt.toExport()).toEqual(original);
+  });
+
+  it('uses the registry wrapper for known modules and the escape hatch for unknown ones', () => {
+    const flow = buildSampleFlow().toExport().flows![0];
+    const spec = flowToBuilderSpec(flow);
+    const byId = Object.fromEntries(spec.steps.map((st) => [st.id, st.factory]));
+    expect(byId.load).toBe('s3DataLoad'); // known system module -> typed wrapper
+    expect(byId.store).toBe('s3DataSave');
+    expect(byId.reshape).toBe('dataTransform'); // consumer module -> generic escape hatch
+    expect(byId.summarize).toBe('llmInvocation'); // typed-payload factory
+  });
+
+  it('defaults the import specifier to the published package name', () => {
+    const flow = buildSampleFlow().toExport().flows![0];
+    const source = ejectFlow(flow);
+    expect(source).toContain("from '@allma/flow-builder'");
+    expect(source).toContain('export default flow;');
+  });
+});

--- a/packages/flow-builder/src/eject.ts
+++ b/packages/flow-builder/src/eject.ts
@@ -1,0 +1,266 @@
+import type { FlowAuthoringFormat, FlowDefinition } from '@allma/core-types';
+import { StepType } from '@allma/core-types';
+import { TYPED_STEP_FACTORIES, MODULE_WRAPPERS, MODULE_ESCAPE_HATCHES } from './factories.js';
+import { MODULE_STEP_TYPE } from './registry.js';
+
+/**
+ * `allma-flows eject` — JSON → TS codegen (RFC §6). Turns a deployed/committed
+ * flow definition back into a `.flow.ts` source that uses the builder API, so a
+ * visual flow can be adopted into code (a one-way ownership transfer) or the
+ * existing flow set can be migrated. The emitted source is intentionally
+ * round-trippable: `build()`-ing it reproduces the original artifact (modulo the
+ * `authoringSource:'code'` stamp the builder always applies).
+ */
+
+/** A flow as it lives in storage / the committed artifact (either format works). */
+type EjectableFlow = FlowDefinition | FlowAuthoringFormat;
+
+/** Options for {@link ejectFlow}. */
+export interface EjectOptions {
+  /** Import specifier for the builder package in the emitted source. Defaults to `@allma/flow-builder`. */
+  importSpecifier?: string;
+}
+
+/** The module step types that carry `moduleIdentifier` + `customConfig`. */
+const MODULE_STEP_TYPES = new Set<StepType>([
+  StepType.DATA_LOAD,
+  StepType.DATA_SAVE,
+  StepType.DATA_TRANSFORMATION,
+  StepType.CUSTOM_LOGIC,
+]);
+
+/**
+ * Instance/wiring fields that `Step._toInstance()` emits from dedicated setters
+ * rather than from the leaf payload. They must be stripped from a step before the
+ * remainder is treated as the factory's leaf config, and are re-emitted as
+ * chained setter / wiring calls.
+ */
+const INSTANCE_FIELDS = new Set<string>([
+  'stepInstanceId',
+  'stepType',
+  'displayName',
+  'stepDefinitionId',
+  'checkpoint',
+  'position',
+  'inputMappings',
+  'outputMappings',
+  'delay',
+  'literals',
+  'disableS3Offload',
+  'forceS3Offload',
+  'defaultNextStepInstanceId',
+  'defaultNextMaxTransitions',
+  'transitions',
+  'onError',
+]);
+
+interface StepSpec {
+  /** The declaration key (the `stepInstanceId`). */
+  id: string;
+  /** Factory function name to call (e.g. `llmInvocation`, `s3DataLoad`, `dataLoad`). */
+  factory: string;
+  /** Source text of the single argument passed to the factory. */
+  argSource: string;
+  /** Chained `.method(...)` setter calls (config, not wiring). */
+  setters: string[];
+}
+
+interface WiringSpec {
+  /** `s.<id>.next(s.<target>, opts?)` */
+  defaultNext?: { target: string; maxTransitions?: number };
+  /** `s.<id>.when(condition, s.<target>, opts?)` */
+  transitions: { condition: string; target: string; maxTransitions?: number }[];
+  /** `s.<id>.onError({ ... })` */
+  onError?: Record<string, unknown> & { fallbackStepInstanceId?: string };
+}
+
+/** The structured intermediate the renderer consumes. */
+export interface BuilderSpec {
+  meta: Record<string, unknown>;
+  steps: StepSpec[];
+  wiring: Record<string, WiringSpec>;
+  start: string;
+  /** Distinct factory names used, for the import statement. */
+  factories: string[];
+}
+
+function factoryNameFor(stepType: StepType, moduleIdentifier: string | undefined): string {
+  if (MODULE_STEP_TYPES.has(stepType)) {
+    if (moduleIdentifier) {
+      const wrapper = MODULE_WRAPPERS[moduleIdentifier];
+      // Use a registry-typed wrapper only when this module is the one it targets.
+      if (wrapper && MODULE_STEP_TYPE[moduleIdentifier] === stepType) return wrapper.name;
+    }
+    const hatch = MODULE_ESCAPE_HATCHES[stepType];
+    if (hatch) return hatch.name;
+  }
+  const factory = TYPED_STEP_FACTORIES[stepType];
+  if (!factory) throw new Error(`Cannot eject step of unknown stepType '${stepType}'.`);
+  return factory.name;
+}
+
+/** Builds the structured {@link BuilderSpec} from a flow definition. */
+export function flowToBuilderSpec(flow: EjectableFlow): BuilderSpec {
+  const factories = new Set<string>();
+  const stepEntries = Object.entries((flow.steps ?? {}) as Record<string, Record<string, unknown>>);
+
+  const steps: StepSpec[] = stepEntries.map(([id, step]) => {
+    const stepType = step.stepType as StepType;
+    const moduleIdentifier = step.moduleIdentifier as string | undefined;
+    const isModule = MODULE_STEP_TYPES.has(stepType);
+    const factory = factoryNameFor(stepType, moduleIdentifier);
+    factories.add(factory);
+
+    const usesWrapper =
+      isModule && moduleIdentifier !== undefined && factory === MODULE_WRAPPERS[moduleIdentifier]?.name;
+
+    let argSource: string;
+    if (usesWrapper) {
+      // Registry-typed wrapper: argument is the customConfig.
+      argSource = literal(step.customConfig ?? {});
+    } else if (isModule) {
+      // Generic escape hatch: { moduleIdentifier, customConfig }.
+      const arg: Record<string, unknown> = { moduleIdentifier };
+      if (step.customConfig !== undefined) arg.customConfig = step.customConfig;
+      argSource = literal(arg);
+    } else {
+      // Typed-payload step: every non-instance field is the leaf config.
+      const config: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(step)) {
+        if (!INSTANCE_FIELDS.has(k) && k !== 'moduleIdentifier' && k !== 'customConfig') config[k] = v;
+      }
+      argSource = Object.keys(config).length > 0 ? literal(config) : '';
+    }
+
+    const setters = configSetters(step);
+    return { id, factory, argSource, setters };
+  });
+
+  const wiring: Record<string, WiringSpec> = {};
+  for (const [id, step] of stepEntries) {
+    const spec: WiringSpec = { transitions: [] };
+    if (typeof step.defaultNextStepInstanceId === 'string') {
+      spec.defaultNext = {
+        target: step.defaultNextStepInstanceId,
+        maxTransitions: typeof step.defaultNextMaxTransitions === 'number' ? step.defaultNextMaxTransitions : undefined,
+      };
+    } else if (typeof step.defaultNextMaxTransitions === 'number') {
+      // Cap without a default-next target — re-emit via the dedicated setter (handled below).
+    }
+    const transitions = step.transitions as { condition: string; nextStepInstanceId: string; maxTransitions?: number }[] | undefined;
+    for (const t of transitions ?? []) {
+      spec.transitions.push({ condition: t.condition, target: t.nextStepInstanceId, maxTransitions: t.maxTransitions });
+    }
+    if (step.onError && typeof step.onError === 'object') {
+      spec.onError = step.onError as WiringSpec['onError'];
+    }
+    if (spec.defaultNext || spec.transitions.length > 0 || spec.onError) wiring[id] = spec;
+  }
+
+  const meta = buildMeta(flow);
+  factories.add('defineFlow');
+
+  return { meta, steps, wiring, start: flow.startStepInstanceId, factories: [...factories].sort() };
+}
+
+/** Re-emits a step's config (non-wiring) instance fields as chained setter calls. */
+function configSetters(step: Record<string, unknown>): string[] {
+  const setters: string[] = [];
+  if (typeof step.displayName === 'string') setters.push(`.displayName(${literal(step.displayName)})`);
+  if (typeof step.stepDefinitionId === 'string') setters.push(`.fromDefinition(${literal(step.stepDefinitionId)})`);
+  if (step.inputMappings) setters.push(`.inputs(${literal(step.inputMappings)})`);
+  if (step.outputMappings) setters.push(`.outputs(${literal(step.outputMappings)})`);
+  if (step.literals) setters.push(`.literals(${literal(step.literals)})`);
+  if (step.delay) setters.push(`.delay(${literal(step.delay)})`);
+  if (step.checkpoint) setters.push(`.checkpoint(${literal(step.checkpoint)})`);
+  if (step.position) setters.push(`.position(${literal(step.position)})`);
+  if (typeof step.disableS3Offload === 'boolean') setters.push(`.disableS3Offload(${step.disableS3Offload})`);
+  if (typeof step.forceS3Offload === 'boolean') setters.push(`.forceS3Offload(${step.forceS3Offload})`);
+  // A default-next cap with NO default-next target is re-emitted via its own setter;
+  // when a target exists it is folded into `.next(target, { maxTransitions })` in wiring.
+  if (
+    typeof step.defaultNextMaxTransitions === 'number' &&
+    typeof step.defaultNextStepInstanceId !== 'string'
+  ) {
+    setters.push(`.defaultNextMaxTransitions(${step.defaultNextMaxTransitions})`);
+  }
+  return setters;
+}
+
+/** Builds the `defineFlow({...})` options object from server/authoring fields. */
+function buildMeta(flow: EjectableFlow): Record<string, unknown> {
+  const meta: Record<string, unknown> = { id: flow.id };
+  if (typeof flow.name === 'string') meta.name = flow.name;
+  if (flow.description !== undefined && flow.description !== null) meta.description = flow.description;
+  if (typeof flow.version === 'number') meta.version = flow.version;
+  if (typeof flow.enableExecutionLogs === 'boolean') meta.enableExecutionLogs = flow.enableExecutionLogs;
+  if (flow.flowVariables && Object.keys(flow.flowVariables).length > 0) meta.variables = flow.flowVariables;
+  if (flow.defaultStepConfig) meta.defaultStepConfig = flow.defaultStepConfig;
+  if (flow.onCompletionActions) meta.onCompletionActions = flow.onCompletionActions;
+  return meta;
+}
+
+/** A value serialized as a JS/TS object literal. JSON is a valid subset for our data. */
+function literal(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+/** Renders a {@link BuilderSpec} into `.flow.ts` source text. */
+export function renderBuilderSource(spec: BuilderSpec, importSpecifier = '@allma/flow-builder'): string {
+  const lines: string[] = [];
+  lines.push(`import { ${spec.factories.join(', ')} } from '${importSpecifier}';`);
+  lines.push('');
+  lines.push(`const flow = defineFlow(${literal(spec.meta)});`);
+  lines.push('');
+  lines.push('const s = flow.steps({');
+  for (const step of spec.steps) {
+    const call = `${step.factory}(${step.argSource})`;
+    if (step.setters.length === 0) {
+      lines.push(`  ${step.id}: ${call},`);
+    } else {
+      lines.push(`  ${step.id}: ${call}`);
+      step.setters.forEach((setter, i) => {
+        const tail = i === step.setters.length - 1 ? ',' : '';
+        lines.push(`    ${setter}${tail}`);
+      });
+    }
+  }
+  lines.push('});');
+  lines.push('');
+
+  for (const step of spec.steps) {
+    const w = spec.wiring[step.id];
+    if (!w) continue;
+    if (w.defaultNext) {
+      const opts = w.defaultNext.maxTransitions !== undefined ? `, { maxTransitions: ${w.defaultNext.maxTransitions} }` : '';
+      lines.push(`s.${step.id}.next(s.${w.defaultNext.target}${opts});`);
+    }
+    for (const t of w.transitions) {
+      const opts = t.maxTransitions !== undefined ? `, { maxTransitions: ${t.maxTransitions} }` : '';
+      lines.push(`s.${step.id}.when(${literal(t.condition)}, s.${t.target}${opts});`);
+    }
+    if (w.onError) {
+      lines.push(`s.${step.id}.onError(${onErrorLiteral(w.onError)});`);
+    }
+  }
+  lines.push('');
+  lines.push(`flow.start(s.${spec.start});`);
+  lines.push('');
+  lines.push('export default flow;');
+  lines.push('');
+  return lines.join('\n');
+}
+
+/** Renders an `onError` object, turning `fallbackStepInstanceId` back into a `s.<id>` ref. */
+function onErrorLiteral(onError: Record<string, unknown> & { fallbackStepInstanceId?: string }): string {
+  const { fallbackStepInstanceId, ...rest } = onError;
+  const parts: string[] = [];
+  if (fallbackStepInstanceId) parts.push(`fallback: s.${fallbackStepInstanceId}`);
+  for (const [k, v] of Object.entries(rest)) parts.push(`${k}: ${literal(v)}`);
+  return `{ ${parts.join(', ')} }`;
+}
+
+/** Convenience: flow definition → `.flow.ts` source in one call. */
+export function ejectFlow(flow: EjectableFlow, opts: EjectOptions = {}): string {
+  return renderBuilderSource(flowToBuilderSpec(flow), opts.importSpecifier);
+}

--- a/packages/flow-builder/src/flow-class.test.ts
+++ b/packages/flow-builder/src/flow-class.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import {
+  Flow,
+  defineFlow,
+  deployVar,
+  s3DataLoad,
+  llmInvocation,
+  s3DataSave,
+  customLambdaInvoke,
+  jp,
+  FlowBuildError,
+} from './index.js';
+
+/** The same flow authored with the functional builder. */
+function viaDefineFlow() {
+  const flow = defineFlow({
+    id: 'parity',
+    description: 'load -> summarize -> save',
+    variables: { outputBucket: deployVar('out-{{stage}}') },
+  });
+  const s = flow.steps({
+    load: s3DataLoad({ sourceS3Uri: 's3://in/doc.txt', outputFormat: 'TEXT' }).displayName('Load'),
+    summarize: llmInvocation({ llmProvider: 'AWS_BEDROCK', modelId: 'm' }).inputs({ 'prompt.x': jp('$.steps_output.load') }),
+    store: s3DataSave({ destinationS3UriTemplate: 's3://{{flow_variables.outputBucket}}/r.json' }),
+    onErr: customLambdaInvoke({ lambdaFunctionArnTemplate: 'arn:aws:lambda:us-east-1:1:function:f' }),
+  });
+  s.load.next(s.summarize).onError({ fallback: s.onErr });
+  s.summarize.when(jp.eq('$.steps_output.load', 'x'), s.store);
+  s.summarize.next(s.store);
+  flow.start(s.load);
+  return flow;
+}
+
+/** The same flow authored with the OO facade. */
+function viaClassFlow() {
+  const flow = new Flow({
+    id: 'parity',
+    description: 'load -> summarize -> save',
+    variables: { outputBucket: deployVar('out-{{stage}}') },
+  });
+  const load = flow.addStep('load', s3DataLoad({ sourceS3Uri: 's3://in/doc.txt', outputFormat: 'TEXT' }).displayName('Load'));
+  const summarize = flow.addStep('summarize', llmInvocation({ llmProvider: 'AWS_BEDROCK', modelId: 'm' }).inputs({ 'prompt.x': jp('$.steps_output.load') }));
+  const store = flow.addStep('store', s3DataSave({ destinationS3UriTemplate: 's3://{{flow_variables.outputBucket}}/r.json' }));
+  const onErr = flow.addStep('onErr', customLambdaInvoke({ lambdaFunctionArnTemplate: 'arn:aws:lambda:us-east-1:1:function:f' }));
+  load.next(summarize).onError({ fallback: onErr });
+  summarize.when(jp.eq('$.steps_output.load', 'x'), store);
+  summarize.next(store);
+  flow.start(load);
+  return flow;
+}
+
+describe('class Flow', () => {
+  it('produces an artifact identical to the functional builder (parity)', () => {
+    expect(viaClassFlow().toExport()).toEqual(viaDefineFlow().toExport());
+  });
+
+  it('stamps authoringSource="code" like defineFlow', () => {
+    expect(viaClassFlow().build().authoringSource).toBe('code');
+  });
+
+  it('rejects a duplicate step id', () => {
+    const flow = new Flow({ id: 'dup' });
+    flow.addStep('a', s3DataSave({ destinationS3UriTemplate: 's3://x/y' }));
+    expect(() => flow.addStep('a', s3DataSave({ destinationS3UriTemplate: 's3://x/z' }))).toThrow(/twice/);
+  });
+
+  it('runs the same strict validation gate (missing start fails)', () => {
+    const flow = new Flow({ id: 'no-start' });
+    flow.addStep('only', s3DataSave({ destinationS3UriTemplate: 's3://x/y' }));
+    expect(() => flow.build()).toThrow(FlowBuildError);
+  });
+});

--- a/packages/flow-builder/src/flow-class.ts
+++ b/packages/flow-builder/src/flow-class.ts
@@ -1,0 +1,65 @@
+import type { FlowAuthoringFormat, AllmaExportFormat } from '@allma/core-types';
+import { Step, type StepDraft, type StepRef } from './step.js';
+import {
+  buildFlowArtifact,
+  toExportEnvelope,
+  STABLE_EXPORTED_AT,
+  type DefineFlowOptions,
+} from './define-flow.js';
+
+/**
+ * `class Flow` — the OO authoring facade (RFC §5.6/§11) over the same internals
+ * as {@link defineFlow}. Teams that prefer eager, imperative construction can
+ * `new Flow(meta)`, `addStep(...)` incrementally (each returns a wired `StepRef`),
+ * then `start(...)` and `build()`/`toExport()`. It shares the exact build + strict
+ * validation core with the functional builder, so both produce identical artifacts.
+ *
+ * ```ts
+ * const flow = new Flow({ id: 'order-intake' });
+ * const load = flow.addStep('load', s3DataLoad({ sourceS3Uri: 's3://in/x' }));
+ * const done = flow.addStep('done', endFlow());
+ * load.next(done);
+ * flow.start(load);
+ * export default flow;
+ * ```
+ */
+export class Flow {
+  private readonly options: DefineFlowOptions;
+  private readonly stepMap = new Map<string, Step>();
+  private startStep: Step | undefined;
+
+  constructor(options: DefineFlowOptions) {
+    this.options = options;
+  }
+
+  /**
+   * Declares a step under `id` and returns its wired {@link StepRef}. Unlike the
+   * functional builder's single `steps({...})` call, steps may be added one at a
+   * time; the id is assigned immediately so the returned ref can be wired right away.
+   */
+  addStep(id: string, draft: StepDraft): StepRef {
+    if (this.stepMap.has(id)) {
+      throw new Error(`Flow('${this.options.id}').addStep('${id}') was called twice for the same id.`);
+    }
+    const step = draft as Step;
+    step._assignId(id);
+    this.stepMap.set(id, step);
+    return step as StepRef;
+  }
+
+  /** Sets the flow's start step. */
+  start(step: StepRef): this {
+    this.startStep = step as Step;
+    return this;
+  }
+
+  /** Strict authoring gate → the deterministic `FlowAuthoringFormat`. */
+  build(): FlowAuthoringFormat {
+    return buildFlowArtifact(this.options, this.stepMap, this.startStep);
+  }
+
+  /** Wrap `build()` in the deploy file envelope (`AllmaExportFormat`). */
+  toExport(exportedAt: string = STABLE_EXPORTED_AT): AllmaExportFormat {
+    return toExportEnvelope(this.build(), exportedAt);
+  }
+}

--- a/packages/flow-builder/src/index.ts
+++ b/packages/flow-builder/src/index.ts
@@ -7,6 +7,11 @@
 export { defineFlow, STABLE_EXPORTED_AT } from './define-flow.js';
 export type { FlowBuilder, DefineFlowOptions } from './define-flow.js';
 
+export { Flow } from './flow-class.js';
+
+export { jp } from './jp.js';
+export type { JsonPath, Comparable, Jp } from './jp.js';
+
 export type { StepDraft, StepRef, OnErrorInput, Checkpoint, Position } from './step.js';
 
 export * from './factories.js';

--- a/packages/flow-builder/src/index.ts
+++ b/packages/flow-builder/src/index.ts
@@ -22,3 +22,6 @@ export { stableStringify, sortKeysDeep } from './serialize.js';
 
 export { collectFlowReferences, resolveReferences } from './catalog.js';
 export type { Catalog, ArtifactReference, ReferenceKind, ResolutionIssue } from './catalog.js';
+
+export { ejectFlow, flowToBuilderSpec, renderBuilderSource } from './eject.js';
+export type { EjectOptions, BuilderSpec } from './eject.js';

--- a/packages/flow-builder/src/index.ts
+++ b/packages/flow-builder/src/index.ts
@@ -25,3 +25,6 @@ export type { Catalog, ArtifactReference, ReferenceKind, ResolutionIssue } from 
 
 export { ejectFlow, flowToBuilderSpec, renderBuilderSource } from './eject.js';
 export type { EjectOptions, BuilderSpec } from './eject.js';
+
+export { detectDrift } from './drift.js';
+export type { DriftIssue, LocalCodeFlow, DeployedFlow, FetchDeployed } from './drift.js';

--- a/packages/flow-builder/src/jp.test.ts
+++ b/packages/flow-builder/src/jp.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { jp } from './jp.js';
+
+describe('jp() path validation (typo detection)', () => {
+  it('returns a well-formed path unchanged', () => {
+    expect(jp('$.steps_output.doc_text')).toBe('$.steps_output.doc_text');
+    expect(jp('$.flow_variables.outputBucket')).toBe('$.flow_variables.outputBucket');
+  });
+
+  it('throws on a path that does not start with $.', () => {
+    expect(() => jp('steps_output.x')).toThrow(/not a valid JSONPath/);
+    expect(() => jp('x.y.z')).toThrow(/not a valid JSONPath/);
+    expect(() => jp('')).toThrow(/not a valid JSONPath/);
+  });
+
+  it('is usable as a mapping key and value (stays a primitive string)', () => {
+    const mapping = { [jp('$.steps_output.summary')]: jp('$.text') };
+    expect(JSON.parse(JSON.stringify(mapping))).toEqual({ '$.steps_output.summary': '$.text' });
+  });
+});
+
+describe('jp comparison builders', () => {
+  it('quotes string literals and emits the runtime condition grammar', () => {
+    expect(jp.eq('$.poll.status', 'DONE')).toBe("$.poll.status === 'DONE'");
+    expect(jp.ne('$.poll.status', 'PENDING')).toBe("$.poll.status !== 'PENDING'");
+  });
+
+  it('emits numbers, booleans, and null without quotes', () => {
+    expect(jp.gt('$.poll.attempts', 5)).toBe('$.poll.attempts > 5');
+    expect(jp.gte('$.poll.attempts', 3)).toBe('$.poll.attempts >= 3');
+    expect(jp.lt('$.score', 0.5)).toBe('$.score < 0.5');
+    expect(jp.eq('$.flags.enabled', true)).toBe('$.flags.enabled === true');
+    expect(jp.eq('$.result', null)).toBe('$.result === null');
+  });
+
+  it('treats a right-side JSONPath as a reference, not a quoted literal', () => {
+    expect(jp.eq('$.a', jp('$.b'))).toBe('$.a === $.b');
+    expect(jp.eq('$.a', '$.b')).toBe('$.a === $.b');
+  });
+
+  it('validates the left-hand path too (typo detection)', () => {
+    expect(() => jp.eq('poll.status', 'DONE')).toThrow(/not a valid JSONPath/);
+  });
+
+  it('rejects a literal containing both quote types', () => {
+    expect(() => jp.eq('$.x', `a'b"c`)).toThrow(/both quote types/);
+  });
+});

--- a/packages/flow-builder/src/jp.ts
+++ b/packages/flow-builder/src/jp.ts
@@ -1,0 +1,82 @@
+import { JsonPathStringSchema } from '@allma/core-types';
+
+/**
+ * `jp()` — a typed JSONPath helper with build-time typo detection (RFC §5.2/§11).
+ *
+ * `jp('$.steps_output.x')` validates the path eagerly (reusing the shared
+ * `JsonPathStringSchema`) and returns it as a branded `JsonPath` string — so a
+ * malformed path fails at author/build time instead of slipping through to deploy
+ * or runtime. Because it returns a real string, it is usable everywhere a
+ * JSONPath string is expected: `inputMappings`/`outputMappings` keys and values,
+ * transition conditions, and right-hand comparison operands. (It must stay a
+ * primitive string so it serializes correctly inside mapping records — hence the
+ * comparison builders below are attached to `jp` itself rather than chained off
+ * its result, which an object would require.)
+ *
+ * Comparison builders produce transition-condition strings in the grammar the
+ * runtime `evaluateCondition` understands (`<jsonpath> <op> <literal|jsonpath>`):
+ *
+ * ```ts
+ * s.poll.when(jp.eq('$.poll.status', 'DONE'), s.done);
+ * s.poll.when(jp.gt('$.poll.attempts', 5), s.giveUp);
+ * ```
+ */
+
+/** A JSONPath string validated by {@link jp}. */
+export type JsonPath = string & { readonly __allmaJsonPath: unique symbol };
+
+/** A value comparable in a condition: a literal, or a (right-side) JSONPath. */
+export type Comparable = string | number | boolean | null | JsonPath;
+
+function validatePath(path: string): JsonPath {
+  const result = JsonPathStringSchema.safeParse(path);
+  if (!result.success) {
+    throw new Error(
+      `jp(${JSON.stringify(path)}) is not a valid JSONPath: ${result.error.issues[0]?.message ?? 'invalid'}`,
+    );
+  }
+  return path as JsonPath;
+}
+
+/** Renders the right-hand side of a comparison: a JSONPath raw, other strings quoted. */
+function renderOperand(value: Comparable): string {
+  if (value === null) return 'null';
+  if (typeof value === 'boolean' || typeof value === 'number') return String(value);
+  // A right-side JSONPath is emitted raw (the evaluator resolves it from context).
+  if (value.startsWith('$.')) return value;
+  if (value.includes("'") && value.includes('"')) {
+    throw new Error(`jp comparison literal cannot contain both quote types: ${JSON.stringify(value)}`);
+  }
+  return value.includes("'") ? `"${value}"` : `'${value}'`;
+}
+
+function compare(path: string, op: string, value: Comparable): string {
+  return `${validatePath(path)} ${op} ${renderOperand(value)}`;
+}
+
+/** The callable `jp` plus its comparison builders. */
+export interface Jp {
+  /** Validate a JSONPath and return it (branded). Throws on a malformed path. */
+  (path: string): JsonPath;
+  /** `path === value` */
+  eq(path: string, value: Comparable): string;
+  /** `path !== value` */
+  ne(path: string, value: Comparable): string;
+  /** `path > value` */
+  gt(path: string, value: Comparable): string;
+  /** `path >= value` */
+  gte(path: string, value: Comparable): string;
+  /** `path < value` */
+  lt(path: string, value: Comparable): string;
+  /** `path <= value` */
+  lte(path: string, value: Comparable): string;
+}
+
+export const jp: Jp = Object.assign((path: string): JsonPath => validatePath(path), {
+  eq: (path: string, value: Comparable): string => compare(path, '===', value),
+  ne: (path: string, value: Comparable): string => compare(path, '!==', value),
+  gt: (path: string, value: Comparable): string => compare(path, '>', value),
+  gte: (path: string, value: Comparable): string => compare(path, '>=', value),
+  lt: (path: string, value: Comparable): string => compare(path, '<', value),
+  lte: (path: string, value: Comparable): string => compare(path, '<=', value),
+});


### PR DESCRIPTION
## Flows-as-Code — Phase 2 (coexistence & ergonomics)

Builds on Phase 0/1 (`feat/flows-as-code-phase-1`, the PR base). Implements RFC §6 (the
ownership/coexistence model) plus the Phase 2 ergonomics from §11. Six reviewable commits.

> Base is `feat/flows-as-code-phase-1` (Phase 0/1) so this diff is **Phase 2 only**. Phase 0/1
> still needs its own PR into `main`.

### What's in here

| Commit | Change | Packages | Bump |
| --- | --- | --- | --- |
| authoringSource marker | optional `authoringSource: 'code' \| 'visual'` on both hand-written types + `FlowDefinitionObjectSchema` (default `'visual'`); builder stamps `'code'` | core-types, flow-builder | minor |
| editor read-only | shared `resolveEditorReadOnly` gates structural edits + Save across page/canvas/panels; "Managed in code" banner; Sandbox stays live | admin-shell | minor |
| `allma-flows eject` | JSON → TS codegen, round-trippable | flow-builder | minor |
| drift guard + unlock | pure `detectDrift` + opt-in `check --remote`; `useUnlockFlowForVisualEditing` + editor action | flow-builder, admin-shell | minor ×2 |
| `jp()` + `class Flow` | typed JSONPath helper (eager typo detection) + OO facade over the shared build core | flow-builder | minor |
| docs | README + author-time enforcement note | flow-builder | patch |

### Key decisions
- **warn→enforce = author-time only** (human-confirmed): `FlowDefinitionSchema` stays
  backward-compatible — **no `major`**, no wire-contract break. The builder enforces `customConfig`
  strictly at build time; the importer keeps warn-mode. A `customConfig` field can legitimately be
  supplied at runtime via `inputMappings`, so a hard error in the shared schema would reject valid
  flows. Confirmed **0 customConfig warnings** across the in-repo flow set.
- `jp()` and `class Flow` shipped in Phase 2 (small, additive, directly testable).
- `authoringSource` lives on the flow **version** (consistent with the builder's authoring format and
  the editor's existing version-level read-only state).

### TS7056 / product-agnostic
- `authoringSource` added as a plain `z.enum([...]).optional()` to the private object schema + the two
  hand-written types — no inference blow-up; the flow-builder **type-cost guard still passes**.
- No consumer/app names in `packages/*`; samples stay under `packages/flow-builder/samples/`.

### Reviewer notes
- **Drift guard auth**: no service-account auth exists, so `check --remote <baseUrl>` uses a human
  admin bearer token from `ALLMA_ADMIN_TOKEN`. Without `--remote`, `check` does **no** network I/O
  (fully backward compatible).
- **admin-shell major cascade**: a core-types release cascades `@allma/admin-shell` to `major` via the
  exact-pinned peerDependency. Left to release tooling (mechanical, not a real break) — not hand-written.
- **Unlock on published versions**: the unlock button only appears for the `code` read-only reason; a
  published code-owned version shows the existing Unpublish flow.

### Testing
- Root `npm run build`, `npm test`, `npm run lint` all pass (0 lint errors; pre-existing warnings only).
- flow-builder: 47 tests (incl. type-cost guard, eject round-trip, drift, jp typo-detection, class Flow
  parity). admin-shell: 192 tests (incl. read-only enforcement + unlock hook). core-types backward-compat
  schema tests green. The gitignored consumer apps that depend on admin-shell/core-types build + test clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
