### PR TITLE
feat(flows-as-code): Phase 3 — config-as-code, typed refs, deploy, typed context

### DIFF
--- a/.changeset/flows-as-code-phase-3-docs.md
+++ b/.changeset/flows-as-code-phase-3-docs.md
@@ -1,0 +1,9 @@
+---
+---
+
+docs: add a how-to guide ("Authoring Flows in Code") and a "Flow Builder Reference"
+page for `@allma/flow-builder` (defineFlow/definePrompt/defineStep/defineMcpConnection,
+jp + flowContext, the build gate, cross-artifact resolution, and the
+build/check/eject/deploy CLI incl. the coexistence/ownership model). Wired into the
+sidebar under How-To Guides and Reference. Docs-site-only; the site package is
+private and unpublished, so this changeset is intentionally empty.

--- a/.changeset/flows-as-code-phase-3.md
+++ b/.changeset/flows-as-code-phase-3.md
@@ -1,0 +1,31 @@
+---
+"@allma/flow-builder": minor
+---
+
+Flows-as-Code Phase 3 — config-as-code, typed object references, typed context,
+and an admin-API deploy command. All additive and backward compatible.
+
+- **`definePrompt` / `defineStep` / `defineMcpConnection`**: author prompt
+  templates, reusable step definitions, and MCP connections in code with the same
+  strict build gate and deterministic emit as `defineFlow`. Each returns a typed
+  handle (`{ id, kind, build(), toExport() }`). `allma-flows build`/`check` now
+  emit and validate these alongside flows (one file per artifact, suffixed by kind:
+  `*.flow.json` / `*.prompt.json` / `*.step.json` / `*.mcp.json`). These artifacts
+  carry a fixed placeholder `createdAt`/`updatedAt` so the committed JSON stays
+  byte-stable while satisfying the deploy validator (the server overwrites it on
+  import).
+- **Typed object references**: `promptTemplateId`, `subFlowDefinitionId`,
+  `flowDefinitionId`, `mcpConnectionId`, and `.fromDefinition(...)` now accept the
+  authored handle (or its typed ref) in addition to a bare string id. A
+  `FlowBuilder`/`Flow` is itself a `FlowRef`. The builder normalizes a handle to its
+  string id, so the wire contract is unchanged; `external('id')` still works. The
+  cross-artifact resolution pass and the CLI catalog now cover `mcpConnectionId`.
+- **`flowContext<Ctx>()`**: an opt-in `jp`-shaped helper whose path argument is
+  constrained to a context type's dotted key paths (bounded to recursion depth 3),
+  turning a stale context path into a compile error. Default `jp`/`inputs`/`outputs`
+  remain plain `string`; the CI type-cost guard stays within budget.
+- **`allma-flows deploy`**: promote built artifacts to a running environment via
+  the admin `POST /v1/allma/import` route (bearer token from `ALLMA_ADMIN_TOKEN`),
+  with optional `--publish`. Honors the importer's version-slot contract and
+  surfaces per-item errors. Network/auth live behind a thin adapter, so the
+  `planDeploy`/`executeDeploy` core is pure and unit-tested with a stubbed adapter.

--- a/docs.allma.dev/docs/how-to-guides/authoring-flows-in-code.md
+++ b/docs.allma.dev/docs/how-to-guides/authoring-flows-in-code.md
@@ -1,0 +1,185 @@
+---
+title: Authoring Flows in Code (TypeScript)
+sidebar_position: 6
+---
+
+# Authoring Flows in Code (TypeScript)
+
+Allma flows are normally authored in the Visual Flow Editor or hand-written as
+`*.flow.json`. The **`@allma/flow-builder`** package lets you author them in
+**TypeScript** instead — with compile-time type safety, refactor-safe references,
+a strict build-time gate, and a deterministic JSON artifact the existing deploy
+pipeline consumes unchanged.
+
+This guide walks through building a flow in code, referencing reusable artifacts
+(prompts, step definitions, MCP connections), validating, and deploying — all from
+a repo, reviewable as a normal pull request.
+
+:::info When to use code vs. the Visual Editor
+Both are first-class. Code authoring shines when you want flows in version
+control, code review, and refactor safety. A flow is owned by **either** code
+**or** the editor at a time (never both) — see [Coexistence](#coexistence-with-the-visual-editor).
+:::
+
+## Prerequisites
+
+- An Allma deployment (see [Quick Start](../getting-started/quick-start.md)).
+- A project that can take `@allma/flow-builder` as a `devDependency`.
+- A TypeScript runner such as [`tsx`](https://github.com/privatenumber/tsx) to run
+  the CLI against `.ts` sources.
+
+```bash
+npm install --save-dev @allma/flow-builder tsx
+```
+
+## 1. Define a flow
+
+A flow is declared in two phases: declare every step (`flow.steps({...})`, which
+returns a typed record of **refs**), then wire those refs. Because every ref
+exists before wiring, forward and backward edges are symmetric and fully typed —
+there are no stringly-typed step ids to drift out of sync.
+
+```ts title="flows/extract-and-store.flow.ts"
+import { defineFlow, deployVar, s3DataLoad, llmInvocation, s3DataSave, customLambdaInvoke }
+  from '@allma/flow-builder';
+
+const flow = defineFlow({
+  id: 'extract-and-store',
+  description: 'Load a document, summarize it, and store the result.',
+  enableExecutionLogs: true,
+  // The only place deploy placeholders are rendered (by the importer).
+  variables: { outputBucket: deployVar('my-output-{{stage}}') },
+});
+
+const s = flow.steps({
+  load: s3DataLoad({ sourceS3Uri: 's3://my-input/document.txt', outputFormat: 'TEXT' })
+    .displayName('1. Load document')
+    .outputs({ '$.steps_output.doc_text': '$.body' }),
+
+  summarize: llmInvocation({ llmProvider: 'AWS_BEDROCK', modelId: 'anthropic.claude-3-sonnet-20240229-v1:0' })
+    .displayName('2. Summarize')
+    .inputs({ 'prompt.document': '$.steps_output.doc_text' })
+    .outputs({ '$.steps_output.summary': '$.text' }),
+
+  store: s3DataSave({ destinationS3UriTemplate: 's3://{{flow_variables.outputBucket}}/summary.json' })
+    .displayName('3. Store summary'),
+
+  onError: customLambdaInvoke({ lambdaFunctionArnTemplate: 'arn:aws:lambda:us-east-1:0:function:on-failure' }),
+});
+
+s.load.next(s.summarize).onError({ fallback: s.onError });
+s.summarize.next(s.store).onError({ fallback: s.onError });
+flow.start(s.load);
+
+export default flow;
+```
+
+A wrong key for the step type, an unknown `customConfig` field, a deleted-step
+fallback, a malformed JSONPath, or a deploy placeholder in the wrong place are all
+**compile-time or build-time** errors — none reach deploy.
+
+## 2. Author reusable artifacts (config-as-code)
+
+Prompts, reusable step definitions, and MCP connections can be authored in code
+too. Each `define*` returns a typed **handle** you reference by object, not by a
+bare string id — so a renamed artifact is a compile error.
+
+```ts title="config/summary-prompt.prompt.ts"
+import { definePrompt } from '@allma/flow-builder';
+
+export default definePrompt({
+  id: 'summary-prompt',
+  name: 'Document summary',
+  content: 'Summarize the following document in 3 sentences:\n\n{{document}}',
+});
+```
+
+```ts title="flows/uses-prompt.flow.ts"
+import { defineFlow, llmInvocation, endFlow } from '@allma/flow-builder';
+import summaryPrompt from '../config/summary-prompt.prompt.js';
+
+const flow = defineFlow({ id: 'uses-prompt' });
+const s = flow.steps({
+  summarize: llmInvocation({
+    llmProvider: 'AWS_BEDROCK',
+    modelId: 'anthropic.claude-3-sonnet-20240229-v1:0',
+    promptTemplateId: summaryPrompt,        // typed object reference, not a string
+  }),
+  done: endFlow(),
+});
+s.summarize.next(s.done);
+flow.start(s.summarize);
+export default flow;
+```
+
+The same pattern works for `defineStep` (reference via `.fromDefinition(handle)`),
+`defineMcpConnection` (`mcpCall({ mcpConnectionId: handle, ... })`), and sub-flows
+(`startSubFlow({ subFlowDefinitionId: someFlow })`). For an id that lives outside
+your config dir (e.g. a platform-managed flow), wrap it in `external('that-id')` to
+document the intent and skip the resolution check.
+
+## 3. Type-safe context paths (optional)
+
+`flowContext<Ctx>()` constrains JSONPath arguments to the keys of a context type,
+so a renamed context field fails compilation:
+
+```ts
+import { flowContext } from '@allma/flow-builder';
+
+interface Ctx { steps_output: { summarize: { text: string } } }
+const $ = flowContext<Ctx>();
+
+s.store.outputs({ [$('$.steps_output.summarize.text')]: '$.text' });   // ✅
+s.store.outputs({ [$('$.steps_output.summarize.txet')]: '$.text' });   // ❌ compile error
+```
+
+## 4. Build, check, deploy
+
+```bash
+# Compile TS → deterministic JSON (one file per artifact, suffixed by kind).
+npx tsx node_modules/@allma/flow-builder/dist/cli/allma-flows.js \
+  build "flows/**/*.ts" "config/**/*.ts" --out config/flows
+
+# Validate + fail on drift between the TS source and the committed JSON.
+npx ... allma-flows.js check "flows/**/*.ts" "config/**/*.ts" --out config/flows
+```
+
+Commit the generated JSON. In CI, run `check` so the byte-stable artifact makes
+the PR diff meaningful and any drift between `.ts` and `.json` fails the build. The
+existing CDK config-importer picks up the JSON unchanged — deploy stays a pure
+"ship these files" step.
+
+To promote **without** a CDK redeploy, use `deploy`, which merges the built
+artifacts and `POST`s them to the admin import API (a bearer token from
+`ALLMA_ADMIN_TOKEN`):
+
+```bash
+ALLMA_ADMIN_TOKEN=… npx ... allma-flows.js deploy "config/flows/*.json" \
+  --remote https://api.my-allma.example.com --publish
+```
+
+`deploy` honors the importer's version-slot contract: a brand-new flow id is
+created; an existing flow id only *updates* a version slot that already exists.
+See the [Versioning & Publishing](../getting-started/key-concepts/versioning-publishing.md)
+concept and the [Flow Builder Reference](../reference/flow-builder-reference.md)
+for the exact rules.
+
+## Coexistence with the Visual Editor
+
+Ownership is per-flow and explicit. The builder stamps `authoringSource: 'code'`
+and emits no step positions, so the editor's auto-layout arranges code-owned flows
+on first open. The editor opens such flows **read-only** (viewing and the Sandbox
+stay enabled; structural edits and Save are disabled, with a "Managed in code"
+banner). Ownership transfer is deliberate and one-way:
+
+- `allma-flows eject <flowId> --from "config/flows/*.json"` adopts a visual flow
+  **into** code (JSON → TS).
+- The editor's "Unlock for visual editing" action flips ownership **back**.
+
+With `--remote`, `allma-flows check` also fails if a code-owned flow's deployed
+copy was taken over in the editor, catching divergence before the next deploy.
+
+## Next steps
+
+- The complete API and CLI surface: [Flow Builder Reference](../reference/flow-builder-reference.md).
+- The JSON the builder emits: [Flow Definition Reference](../reference/flow-definition-reference.md).

--- a/docs.allma.dev/docs/reference/flow-builder-reference.md
+++ b/docs.allma.dev/docs/reference/flow-builder-reference.md
@@ -1,0 +1,154 @@
+---
+title: Flow Builder Reference
+sidebar_position: 2
+---
+
+# Flow Builder Reference
+
+`@allma/flow-builder` is a **build-time** tool for authoring Allma artifacts in
+TypeScript. It introduces no new runtime, orchestrator, or storage schema — it
+emits the existing `AllmaExportFormat` JSON (see the
+[Flow Definition Reference](./flow-definition-reference.md)). This page is the
+exhaustive reference for its API and CLI. For a task-oriented walkthrough, see
+[Authoring Flows in Code](../how-to-guides/authoring-flows-in-code.md).
+
+## `defineFlow(options)`
+
+Returns a fluent **`FlowBuilder`**. Two-phase: declare, then wire.
+
+| Option | Type | Notes |
+| --- | --- | --- |
+| `id` | `string` | The `flowDefinitionId`. Required. |
+| `name` | `string` | Optional display name. |
+| `description` | `string \| null` | Optional. |
+| `version` | `number` | Target version slot for the importer. Defaults to `1`. |
+| `enableExecutionLogs` | `boolean` | Per-step execution logs. |
+| `variables` | `Record<string, unknown>` | Becomes `flowVariables` — the only place deploy placeholders render. |
+| `defaultStepConfig` | object | Flow-wide default inference params / customConfig / error handler. |
+| `onCompletionActions` | `OnCompletionAction[]` | Actions to run on completion. |
+
+```ts
+const flow = defineFlow({ id: 'my-flow' });
+const s = flow.steps({ /* … */ });   // Phase 1 — returns a typed record of refs
+// Phase 2 — wire with refs
+flow.start(s.first);
+flow.build();                        // strict gate → FlowAuthoringFormat
+flow.toExport();                     // → AllmaExportFormat envelope
+```
+
+A `FlowBuilder` also carries a readonly `id` and `kind: 'flow'`, so it is itself a
+typed `FlowRef` usable in `startSubFlow`/`startFlowExecution`.
+
+### Step refs (wiring)
+
+Each ref returned by `flow.steps({...})` exposes:
+
+| Method | Purpose |
+| --- | --- |
+| `.next(ref, { maxTransitions? })` | Default (unconditional) transition. |
+| `.when(condition, ref, { maxTransitions? })` | Conditional transition (JSONPath condition). |
+| `.onError({ retries?, retryOnContentError?, fallback?, continueOnFailure? })` | Error policy; `fallback` is a typed ref. |
+
+Config setters available on every step (before or during wiring): `.displayName`,
+`.inputs`, `.outputs`, `.delay`, `.checkpoint`, `.position`, `.fromDefinition`,
+`.defaultNextMaxTransitions`, `.disableS3Offload`, `.forceS3Offload`, `.literals`.
+
+## Step factories
+
+- **17 typed-payload factories**, one per non-module step type — config typed from
+  each step's own leaf schema: `llmInvocation`, `apiCall`, `mcpCall`,
+  `customLambdaInvoke`, `parallelForkManager`, `startSubFlow`, `startFlowExecution`,
+  `noOp`, `endFlow`, `waitForExternalEvent`, `pollExternalApi`, `sqsSend`,
+  `snsPublish`, `emailSend`, `emailStartPoint`, `scheduleStartPoint`, `fileDownload`.
+- **16 typed module wrappers**, one per registered system module — config typed
+  from `SYSTEM_MODULE_CONFIG_SCHEMAS`: `s3DataLoad`, `dynamoDataLoad`,
+  `ddbQueryToS3Manifest`, `s3ListFiles`, `sqsGetQueueAttributes`,
+  `sqsReceiveMessages`, `s3DataSave`, `dynamoUpdateItem`, `dynamoQueryAndUpdate`,
+  `arrayAggregator`, `composeObjectFromInput`, `dateTimeCalculator`, `flattenArray`,
+  `generateArray`, `joinData`, `generateUuid`.
+- **4 generic escape hatches** for any other module: `dataLoad`, `dataSave`,
+  `dataTransform`, `customLogic` — `{ moduleIdentifier, customConfig }`.
+
+## Config-as-code artifacts
+
+Each returns a typed **handle** (`{ id, kind, build(), toExport() }`) that doubles
+as a cross-artifact reference.
+
+| Function | Authors | Reference field it satisfies |
+| --- | --- | --- |
+| `definePrompt(spec)` | a prompt template | `promptTemplateId` (`PromptRef`) |
+| `defineStep(meta, draft)` | a reusable step definition | `stepDefinitionId` via `.fromDefinition(handle)` (`StepDefRef`) |
+| `defineMcpConnection(spec)` | an MCP connection | `mcpConnectionId` (`McpConnectionRef`) |
+| `defineFlow(options)` | a flow | `subFlowDefinitionId` / `flowDefinitionId` (`FlowRef`) |
+
+```ts
+const prompt = definePrompt({ id: 'p', name: 'P', content: 'Summarize {{document}}' });
+llmInvocation({ llmProvider: 'AWS_BEDROCK', modelId, promptTemplateId: prompt });
+```
+
+The builder normalizes a handle to its string `id` in the emitted artifact, so the
+wire contract is unchanged. `external('id')` keeps a bare string for an
+intentional out-of-dir reference.
+
+:::note Authoring-time timestamps
+Prompts, step definitions, and MCP connections emit the fixed placeholder
+`createdAt`/`updatedAt` of `1970-01-01T00:00:00.000Z`. This keeps the committed
+artifact byte-stable while satisfying the deploy validator (which requires the
+field). The server overwrites it on import.
+:::
+
+## The build gate
+
+`build()` runs, in order: a deploy-token placement scan; a `.strict()` clone of
+each step's leaf schema (catching unknown keys the persisted `.passthrough()`
+schemas allow); `customConfig` validation via `SYSTEM_MODULE_CONFIG_SCHEMAS`; and
+the shared `FlowAuthoringSchema` (cross-references + JSONPath well-formedness).
+Failures aggregate into a single `FlowBuildError` (flows) or `ArtifactBuildError`
+(prompts/steps/MCP), each issue prefixed with the offending id and field path.
+
+## `jp` and `flowContext`
+
+`jp('$.path')` validates a JSONPath eagerly and returns it for use in
+`inputs`/`outputs` and conditions. Its comparison builders emit transition
+conditions in the runtime evaluator's grammar: `jp.eq`, `jp.ne`, `jp.gt`,
+`jp.gte`, `jp.lt`, `jp.lte`.
+
+`flowContext<Ctx>()` returns a `jp`-shaped helper whose path argument is
+constrained to the dotted key paths of `Ctx` (bounded to depth 3) — an **opt-in**
+typed-context check. Default `jp`/`inputs`/`outputs` remain plain `string`.
+
+## Cross-artifact resolution
+
+`resolveReferences(flows, known)` (and `allma-flows check`) verify every
+`subFlowDefinitionId` / `flowDefinitionId` / `promptTemplateId` /
+`stepDefinitionId` / `mcpConnectionId` resolves to a known artifact or is wrapped
+in `external(id)`. Artifacts built together seed the catalog automatically.
+
+## CLI: `allma-flows`
+
+| Command | Purpose |
+| --- | --- |
+| `build "<glob>" --out <dir> [--exported-at <iso>]` | Compile TS → deterministic `*.<kind>.json`. |
+| `check "<glob>" [--out <dir>] [--known <glob>] [--remote <baseUrl>]` | Validate; fail on drift vs committed JSON (`--out`) or vs the deployed copy (`--remote`). |
+| `eject <flowId> --from "<glob>" [--out <dir>]` | JSON → `*.flow.ts` (adoption / one-way ownership transfer). |
+| `deploy "<glob>" --remote <baseUrl> [--publish] [--overwrite false]` | Promote via the admin import API (no CDK redeploy). |
+
+Modules must `export default` a builder or a `define*` handle. Run under a
+TypeScript loader (e.g. `tsx`). Auth for `--remote`/`deploy` is a bearer token in
+`ALLMA_ADMIN_TOKEN`.
+
+### Version-slot contract (`deploy`)
+
+`deploy` merges artifacts into one `AllmaExportFormat` and `POST`s it to
+`/v1/allma/import` — the same importer `cdk deploy` uses. Therefore: a **new** flow
+id is created at its declared version; an **existing** flow id only *updates* a
+version slot that already exists. Bumping an existing flow to a not-yet-existing
+version requires the admin version-management API first. `--publish` then publishes
+each imported flow version. The importer's per-item errors are surfaced, not masked.
+
+## Coexistence & ownership
+
+The builder stamps `authoringSource: 'code'`. Such flows open **read-only** in the
+Visual Editor (view + Sandbox only). `eject` adopts a flow into code; the editor's
+"Unlock for visual editing" reverts ownership. See
+[Authoring Flows in Code](../how-to-guides/authoring-flows-in-code.md#coexistence-with-the-visual-editor).

--- a/docs.allma.dev/sidebars.ts
+++ b/docs.allma.dev/sidebars.ts
@@ -44,6 +44,7 @@ const sidebars: SidebarsConfig = {
         'how-to-guides/orchestrating-parallel-workloads',
         'how-to-guides/managing-long-running-processes',
         'how-to-guides/advanced-error-handling',
+        'how-to-guides/authoring-flows-in-code',
       ],
     },
     {
@@ -52,6 +53,7 @@ const sidebars: SidebarsConfig = {
       collapsed: true,
       items: [
         'reference/flow-definition-reference',
+        'reference/flow-builder-reference',
         'reference/execution-status-notifications',
         {
           type: 'category',

--- a/packages/flow-builder/README.md
+++ b/packages/flow-builder/README.md
@@ -95,12 +95,56 @@ Two different `{{...}}` worlds — the builder keeps them straight:
   **allowed in any string field**. (The build gate deliberately does *not* flag
   these — only the three deploy tokens when misplaced.)
 
+## Config-as-code: prompts, step definitions & MCP connections
+
+The cross-artifact entities a flow references can themselves be authored in code,
+each with the same strict gate and deterministic emit as `defineFlow`:
+
+```ts
+import { definePrompt, defineStep, defineMcpConnection, llmInvocation } from '@allma/flow-builder';
+
+export const summaryPrompt = definePrompt({
+  id: 'summary-prompt', name: 'Summary', content: 'Summarize: {{document}}',
+});
+
+export const summarize = defineStep(
+  { id: 'summarize-doc', name: 'Summarize document' },
+  llmInvocation({ llmProvider: 'AWS_BEDROCK', modelId: 'anthropic.claude-3-sonnet-20240229-v1:0' }),
+);
+
+export const githubMcp = defineMcpConnection({
+  id: 'github-mcp', name: 'GitHub MCP',
+  serverUrl: 'https://mcp.example.com', authentication: { type: 'NONE' },
+});
+```
+
+Each returns a typed **handle** (`{ id, kind, build(), toExport() }`). The handle
+*is* a typed object reference: pass it straight into a step instead of a bare
+string id, and a renamed or deleted artifact becomes a **compile error**.
+
+```ts
+llmInvocation({ llmProvider: 'AWS_BEDROCK', modelId, promptTemplateId: summaryPrompt });
+mcpCall({ mcpConnectionId: githubMcp, toolName: 'search' });
+startSubFlow({ subFlowDefinitionId: childFlow });        // a flow is a FlowRef too
+s.step.fromDefinition(summarize);                         // step-def handle
+```
+
+The builder normalizes a handle to its `id` in the emitted artifact, so the wire
+contract is unchanged. `external('id')` still wraps an intentional out-of-dir id.
+
+> These artifacts carry the fixed placeholder timestamp `1970-01-01T00:00:00.000Z`
+> for `createdAt`/`updatedAt` — byte-stable for the drift check, and overwritten by
+> the server on import (the deploy validator requires the field to be present).
+
 ## Cross-artifact resolution
 
 `resolveReferences(flows, known)` (and `allma-flows check`) verify that every
 `subFlowDefinitionId` / `flowDefinitionId` / `promptTemplateId` /
-`stepDefinitionId` resolves to a known artifact, or is wrapped in `external(id)`
-to document an intentional out-of-dir reference.
+`stepDefinitionId` / `mcpConnectionId` resolves to a known artifact, or is wrapped
+in `external(id)` to document an intentional out-of-dir reference. When prompts,
+step definitions, MCP connections and flows are built together (one `check`/`build`
+run), locally-authored artifacts seed the catalog automatically, so a flow that
+references a sibling prompt handle resolves with no extra wiring.
 
 ## Ergonomics: `jp()` and `class Flow`
 
@@ -125,21 +169,59 @@ flow.start(load);
 export default flow;
 ```
 
+## Typed context for mappings (opt-in)
+
+`flowContext<Ctx>()` returns a `jp`-shaped helper whose path argument is
+constrained to the dotted key paths of a context type `Ctx` — so a stale or
+mistyped context path is a **compile error**, not a silent runtime miss:
+
+```ts
+interface Ctx { steps_output: { summarize: { text: string } } }
+const $ = flowContext<Ctx>();
+
+s.store.outputs({ [$('$.steps_output.summarize.text')]: '$.text' });   // ok
+s.store.outputs({ [$('$.steps_output.summarize.txet')]: '$.text' });   // compile error
+```
+
+This is **opt-in** by design: the generic lives only on this helper (not threaded
+through every step), and the path-enumeration type is bounded to a recursion depth
+of 3 to stay clear of the inferred-type blow-up the package guards against (RFC §9).
+Default `jp`/`inputs`/`outputs` remain plain `string`. A CI type-cost guard
+measures this file; deepen the bound deliberately and re-measure if you need it.
+
 ## CLI
 
 ```
-allma-flows build "flows/**/*.flow.ts" --out config/flows              # TS -> deterministic *.flow.json
-allma-flows check "flows/**/*.flow.ts" [--out config/flows] [--remote <baseUrl>]
+allma-flows build  "flows/**/*.ts" --out config/flows                  # TS -> deterministic *.<kind>.json
+allma-flows check  "flows/**/*.ts" [--out config/flows] [--remote <baseUrl>]
                                                                        # validate + drift checks
-allma-flows eject <flowId> --from "config/flows/*.json" [--out flows]  # JSON -> *.flow.ts (adoption)
+allma-flows eject  <flowId> --from "config/flows/*.json" [--out flows] # JSON -> *.flow.ts (adoption)
+allma-flows deploy "flows/**/*.ts" --remote <baseUrl> [--publish] [--overwrite false]
+                                                                       # promote via admin API (no CDK redeploy)
 ```
 
-Flow modules must `export default` the builder. Run under a TypeScript loader
-(e.g. `tsx`) when pointing at `.flow.ts` sources. Commit the generated JSON and
-run `allma-flows check` in CI: the byte-stable artifact makes the diff meaningful
-and drift between the `.ts` source and committed `.json` fails the build. With
-`--remote <baseUrl>` (and an `ALLMA_ADMIN_TOKEN` bearer token), `check` also fails
-if a code-owned flow's **deployed** copy was taken over in the Visual Editor.
+Modules must `export default` a builder or a `define*` artifact handle. `build`
+emits one file per artifact, suffixed by kind (`*.flow.json`, `*.prompt.json`,
+`*.step.json`, `*.mcp.json`). Run under a TypeScript loader (e.g. `tsx`) when
+pointing at `.ts` sources. Commit the generated JSON and run `allma-flows check`
+in CI: the byte-stable artifact makes the diff meaningful and drift between the
+`.ts` source and committed `.json` fails the build. With `--remote <baseUrl>` (and
+an `ALLMA_ADMIN_TOKEN` bearer token), `check` also fails if a code-owned flow's
+**deployed** copy was taken over in the Visual Editor.
+
+### `deploy` — promote to a running environment
+
+`allma-flows deploy` merges the built artifacts into one `AllmaExportFormat` and
+`POST`s it to the admin **`/v1/allma/import`** route (`ALLMA_ADMIN_TOKEN` bearer),
+so CI can ship a flow/prompt/step/MCP change without a CDK redeploy. It uses the
+same importer as `cdk deploy`, so the same **version-slot contract** applies: a
+brand-new flow id is created; an existing flow id only *updates* a version slot
+that already exists ("creating new versions for existing flows on import is not
+supported"). Bumping an existing flow to a not-yet-existing version is an admin
+version-management step first; `deploy` surfaces the importer's per-item errors
+rather than masking them. `--publish` then publishes each imported flow version.
+The network/auth lives behind a thin adapter, so `planDeploy`/`executeDeploy` are
+pure and unit-tested with a stubbed adapter.
 
 ## Coexistence with the Visual Editor
 
@@ -169,5 +251,11 @@ there would reject valid flows. Author in code to get the strict, earliest check
 - `customConfig` validation checks shape/type via the registry but does not
   reject unknown `customConfig` keys (the runtime strips them); leaf **payload**
   keys are strict.
-- Typed `definePrompt`/`defineStep`/MCP object cross-references, `allma-flows
-  deploy`, and typed-context generics for mappings are **Phase 3** (RFC §11).
+- `defineStep` ignores graph-dependent wiring (transitions, `onError.fallback`) —
+  a stored step definition has no sibling steps; wire those on the step instance.
+- Typed-context (`flowContext`) checks **context-side** paths and is bounded to a
+  recursion depth of 3; `inputs()`/`outputs()` keys (step-input dot-paths) stay
+  untyped to avoid threading a pervasive generic through the step union (RFC §9).
+- `eject` covers flows (round-trips, including typed object references, which
+  serialize back to string ids); prompts/step-defs/MCP connections are authored
+  forward in code, not ejected.

--- a/packages/flow-builder/samples/config-as-code.flow.ts
+++ b/packages/flow-builder/samples/config-as-code.flow.ts
@@ -1,0 +1,40 @@
+/**
+ * Reference example: a flow that references a code-authored prompt by typed
+ * OBJECT (Phase 3), and uses an opt-in typed context for refactor-safe mappings.
+ *
+ * Build the whole config dir together so the cross-artifact reference resolves:
+ *
+ *   allma-flows build  "packages/flow-builder/samples/*.ts" --out ./out
+ *   allma-flows check  "packages/flow-builder/samples/*.ts" --out ./out
+ *   allma-flows deploy "packages/flow-builder/samples/*.ts" --remote $ALLMA_API --publish
+ */
+import { defineFlow, llmInvocation, endFlow, flowContext } from '@allma/flow-builder';
+import summaryPrompt from './summary-prompt.prompt.js';
+
+/** The shape of this flow's runtime context — drives compile-time path checking. */
+interface Ctx {
+  steps_output: { summarize: { text: string } };
+}
+const $ = flowContext<Ctx>();
+
+const flow = defineFlow({
+  id: 'config-as-code-summary',
+  name: 'Config-as-code summary',
+  description: 'Summarize using a code-authored prompt referenced by object.',
+});
+
+const s = flow.steps({
+  summarize: llmInvocation({
+    llmProvider: 'AWS_BEDROCK',
+    modelId: 'anthropic.claude-3-sonnet-20240229-v1:0',
+    // Typed object reference — not a bare string id.
+    promptTemplateId: summaryPrompt,
+  }).outputs({ [$('$.steps_output.summarize.text')]: '$.text' }),
+
+  done: endFlow(),
+});
+
+s.summarize.next(s.done);
+flow.start(s.summarize);
+
+export default flow;

--- a/packages/flow-builder/samples/summary-prompt.prompt.ts
+++ b/packages/flow-builder/samples/summary-prompt.prompt.ts
@@ -1,0 +1,22 @@
+/**
+ * Reference example: a reusable prompt template authored in code (Phase 3).
+ *
+ * Compile it alongside flows with:
+ *
+ *   allma-flows build "packages/flow-builder/samples/*.ts" --out ./out
+ *
+ * to produce a deterministic `summary-prompt.prompt.json`. A flow references this
+ * by importing the handle and passing it as a typed object (see
+ * `config-as-code.flow.ts`), so a renamed prompt is a compile error.
+ */
+import { definePrompt } from '@allma/flow-builder';
+
+const summaryPrompt = definePrompt({
+  id: 'summary-prompt',
+  name: 'Document summary',
+  description: 'Summarizes a document into a few sentences.',
+  content: 'Summarize the following document in 3 sentences:\n\n{{document}}',
+  tags: ['summary'],
+});
+
+export default summaryPrompt;

--- a/packages/flow-builder/src/artifacts.test.ts
+++ b/packages/flow-builder/src/artifacts.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { validateAllmaConfig } from '@allma/core-sdk';
+import {
+  definePrompt,
+  defineStep,
+  defineMcpConnection,
+  llmInvocation,
+  s3DataLoad,
+  ArtifactBuildError,
+  STABLE_TIMESTAMP,
+  STABLE_EXPORTED_AT,
+} from './index.js';
+import { stableStringify } from './serialize.js';
+
+describe('definePrompt', () => {
+  it('builds a deterministic, deploy-valid prompt template', () => {
+    const prompt = definePrompt({ id: 'summary-prompt', name: 'Summary', content: 'Summarize: {{doc}}' });
+    expect(prompt.id).toBe('summary-prompt');
+    expect(prompt.kind).toBe('prompt');
+
+    const built = prompt.build();
+    expect(built.createdAt).toBe(STABLE_TIMESTAMP);
+    expect(built.updatedAt).toBe(STABLE_TIMESTAMP);
+    expect(built.version).toBe(1);
+
+    const exported = prompt.toExport();
+    expect(exported.exportedAt).toBe(STABLE_EXPORTED_AT);
+    expect(exported.promptTemplates).toHaveLength(1);
+    const result = validateAllmaConfig(exported, 'summary-prompt.prompt.json');
+    expect(result.success, JSON.stringify((result as { error?: unknown }).error)).toBe(true);
+  });
+
+  it('is byte-stable across builds', () => {
+    const make = () => definePrompt({ id: 'p', name: 'P', content: 'x' }).toExport();
+    expect(stableStringify(make())).toBe(stableStringify(make()));
+  });
+
+  it('rejects an unknown key via the strict gate', () => {
+    const prompt = definePrompt({ id: 'p', name: 'P', content: 'x', bogus: 1 } as never);
+    expect(() => prompt.build()).toThrow(ArtifactBuildError);
+  });
+
+  it('rejects an empty content via the schema', () => {
+    expect(() => definePrompt({ id: 'p', name: 'P', content: '' }).build()).toThrow(ArtifactBuildError);
+  });
+});
+
+describe('defineMcpConnection', () => {
+  it('builds a deterministic, deploy-valid connection', () => {
+    const conn = defineMcpConnection({
+      id: 'github-mcp',
+      name: 'GitHub MCP',
+      serverUrl: 'https://mcp.example.com',
+      authentication: { type: 'NONE' },
+    });
+    expect(conn.kind).toBe('mcpConnection');
+    const built = conn.build();
+    expect(built.createdAt).toBe(STABLE_TIMESTAMP);
+
+    const result = validateAllmaConfig(conn.toExport(), 'github-mcp.mcp.json');
+    expect(result.success, JSON.stringify((result as { error?: unknown }).error)).toBe(true);
+  });
+
+  it('rejects an invalid serverUrl', () => {
+    const conn = defineMcpConnection({
+      id: 'bad',
+      name: 'Bad',
+      serverUrl: 'not-a-url',
+      authentication: { type: 'NONE' },
+    });
+    expect(() => conn.build()).toThrow(ArtifactBuildError);
+  });
+});
+
+describe('defineStep', () => {
+  it('builds a deploy-valid step definition from a typed factory', () => {
+    const def = defineStep(
+      { id: 'summarize-doc', name: 'Summarize document' },
+      llmInvocation({ llmProvider: 'AWS_BEDROCK', modelId: 'anthropic.claude-3-sonnet' }).outputs({
+        '$.steps_output.summary': '$.text',
+      }),
+    );
+    expect(def.kind).toBe('stepDefinition');
+    const built = def.build();
+    expect(built.id).toBe('summarize-doc');
+    expect((built as Record<string, unknown>).stepType).toBe('LLM_INVOCATION');
+    expect((built as Record<string, unknown>).outputMappings).toEqual({ '$.steps_output.summary': '$.text' });
+
+    const result = validateAllmaConfig(def.toExport(), 'summarize-doc.step.json');
+    expect(result.success, JSON.stringify((result as { error?: unknown }).error)).toBe(true);
+  });
+
+  it('builds a module-based step definition with registry-validated customConfig', () => {
+    const def = defineStep(
+      { id: 'load-doc', name: 'Load document' },
+      s3DataLoad({ sourceS3Uri: 's3://bucket/doc.txt', outputFormat: 'TEXT' }),
+    );
+    const result = validateAllmaConfig(def.toExport(), 'load-doc.step.json');
+    expect(result.success, JSON.stringify((result as { error?: unknown }).error)).toBe(true);
+  });
+
+  it('rejects an unknown payload key via the per-leaf strict gate', () => {
+    const def = defineStep(
+      { id: 'bad-step', name: 'Bad' },
+      llmInvocation({ llmProvider: 'AWS_BEDROCK', modelId: 'm', bogusField: true } as never),
+    );
+    expect(() => def.build()).toThrow(ArtifactBuildError);
+  });
+});

--- a/packages/flow-builder/src/artifacts.ts
+++ b/packages/flow-builder/src/artifacts.ts
@@ -1,0 +1,209 @@
+import { z } from 'zod';
+import {
+  PromptTemplateSchema,
+  McpConnectionSchema,
+  StepDefinitionSchema,
+} from '@allma/core-types';
+import type { AllmaExportFormat, PromptTemplate, McpConnection, StepDefinition } from '@allma/core-types';
+import { Step, type StepDraft } from './step.js';
+import {
+  ArtifactBuildError,
+  checkModuleCustomConfig,
+  checkStepPayload,
+  collectSchemaIssues,
+} from './validate.js';
+import { STABLE_EXPORTED_AT } from './define-flow.js';
+import type { PromptRef, StepDefRef, McpConnectionRef } from './refs.js';
+
+/**
+ * Config-as-code authoring of the cross-artifact entities a flow references —
+ * prompt templates, reusable step definitions, and MCP connections (RFC §11).
+ * Each `define*` mirrors `defineFlow`'s contract: lazy, two-phase-friendly
+ * (the `id` is available immediately so a flow can reference the handle before
+ * `build()` runs), a strict build-time gate (a `.strict()` clone catches unknown
+ * keys the persisted `.passthrough()`/`.and()` schemas would allow), and a
+ * deterministic emit.
+ *
+ * ### Why these artifacts carry a fixed timestamp
+ * Unlike flows — which the importer stamps with real `createdAt`/`updatedAt` and
+ * whose `FlowAuthoringSchema` omits them — the deploy validator
+ * (`validateAllmaConfig`) parses prompts/step-defs/MCP connections **directly**
+ * against schemas that **require** `createdAt`/`updatedAt`. To stay both
+ * deploy-valid and byte-stable for the §8 drift check, the builder emits the
+ * deterministic placeholder {@link STABLE_EXPORTED_AT}. The server overwrites it
+ * on import (MCP connections are stripped; prompt timestamps are stamped by the
+ * versioned entity manager), so the placeholder never carries semantic meaning.
+ */
+
+/** The deterministic placeholder stamped into authoring-time `createdAt`/`updatedAt`. */
+export const STABLE_TIMESTAMP = STABLE_EXPORTED_AT;
+
+/** Common shape every code-authored artifact exposes (a typed handle + emitters). */
+export interface DefinedArtifact {
+  readonly id: string;
+  readonly kind: 'prompt' | 'stepDefinition' | 'mcpConnection';
+  toExport(exportedAt?: string): AllmaExportFormat;
+}
+
+// --- Prompt templates ----------------------------------------------------------
+
+const PROMPT_SERVER_FIELDS = {
+  isPublished: true,
+  createdAt: true,
+  updatedAt: true,
+  publishedAt: true,
+} as const;
+
+/** The author-facing prompt-template schema (server-owned fields removed). */
+const PromptAuthoringSchema = PromptTemplateSchema.omit(PROMPT_SERVER_FIELDS);
+
+/** Input accepted by {@link definePrompt} — a prompt template minus server fields. */
+export type PromptInput = z.input<typeof PromptAuthoringSchema>;
+
+/** A prompt template authored in code: a typed {@link PromptRef} plus emitters. */
+export interface DefinedPrompt extends PromptRef, DefinedArtifact {
+  readonly kind: 'prompt';
+  /** Strict authoring gate → the deterministic, deploy-valid `PromptTemplate`. */
+  build(): PromptTemplate;
+}
+
+/** Authors a reusable prompt template in code. */
+export function definePrompt(spec: PromptInput): DefinedPrompt {
+  const id = spec.id;
+  const build = (): PromptTemplate => {
+    const result = PromptAuthoringSchema.strict().safeParse(spec);
+    if (!result.success) {
+      throw new ArtifactBuildError('Prompt', id, formatIssues(result.error, id, 'prompt'));
+    }
+    return { ...result.data, createdAt: STABLE_TIMESTAMP, updatedAt: STABLE_TIMESTAMP } as PromptTemplate;
+  };
+  return {
+    id,
+    kind: 'prompt',
+    build,
+    toExport: (exportedAt = STABLE_EXPORTED_AT): AllmaExportFormat =>
+      ({ formatVersion: '1.0', exportedAt, promptTemplates: [build()] }) as unknown as AllmaExportFormat,
+  };
+}
+
+// --- MCP connections -----------------------------------------------------------
+
+const McpAuthoringSchema = McpConnectionSchema.omit({ createdAt: true, updatedAt: true });
+
+/** Input accepted by {@link defineMcpConnection} — an MCP connection minus timestamps. */
+export type McpConnectionInput = z.input<typeof McpAuthoringSchema>;
+
+/** An MCP connection authored in code: a typed {@link McpConnectionRef} plus emitters. */
+export interface DefinedMcpConnection extends McpConnectionRef, DefinedArtifact {
+  readonly kind: 'mcpConnection';
+  /** Strict authoring gate → the deterministic, deploy-valid `McpConnection`. */
+  build(): McpConnection;
+}
+
+/** Authors a reusable MCP connection in code. */
+export function defineMcpConnection(spec: McpConnectionInput): DefinedMcpConnection {
+  const id = spec.id;
+  const build = (): McpConnection => {
+    const result = McpAuthoringSchema.strict().safeParse(spec);
+    if (!result.success) {
+      throw new ArtifactBuildError('MCP connection', id, formatIssues(result.error, id, 'mcpConnection'));
+    }
+    return { ...result.data, createdAt: STABLE_TIMESTAMP, updatedAt: STABLE_TIMESTAMP } as McpConnection;
+  };
+  return {
+    id,
+    kind: 'mcpConnection',
+    build,
+    toExport: (exportedAt = STABLE_EXPORTED_AT): AllmaExportFormat =>
+      ({ formatVersion: '1.0', exportedAt, mcpConnections: [build()] }) as unknown as AllmaExportFormat,
+  };
+}
+
+// --- Step definitions ----------------------------------------------------------
+
+/** Metadata for a reusable step definition (the payload comes from a {@link StepDraft}). */
+export interface StepDefinitionMeta {
+  /** Stable step-definition id (the `stepDefinitionId` a step references). */
+  id: string;
+  /** Human-friendly name. */
+  name: string;
+  /** Optional description. */
+  description?: string | null;
+  /** Target version slot for the importer. Defaults to `1`. */
+  version?: number;
+}
+
+/** A reusable step definition authored in code: a typed {@link StepDefRef} plus emitters. */
+export interface DefinedStepDefinition extends StepDefRef, DefinedArtifact {
+  readonly kind: 'stepDefinition';
+  /** Strict authoring gate → the deterministic, deploy-valid `StepDefinition`. */
+  build(): StepDefinition;
+}
+
+/**
+ * Authors a reusable step definition from a typed step draft. The payload reuses
+ * the exact same typed factories as a flow step (`llmInvocation(...)`,
+ * `s3DataLoad(...)`, …), so a step definition gets the same per-leaf type safety
+ * and the same registry-driven `customConfig` validation.
+ *
+ * @example
+ *   export default defineStep(
+ *     { id: 'summarize-doc', name: 'Summarize document' },
+ *     llmInvocation({ llmProvider: 'BEDROCK', modelId: 'anthropic.claude-...' }),
+ *   );
+ */
+export function defineStep(meta: StepDefinitionMeta, draft: StepDraft): DefinedStepDefinition {
+  const build = (): StepDefinition => {
+    const step = draft as Step;
+    const stepType = step._getStepType();
+    const payload = step._getPayload();
+    const issues: string[] = [];
+
+    // Per-leaf strict gate + registry customConfig parse (the "stricter than
+    // deploy" guarantee, shared with flow steps).
+    issues.push(...checkStepPayload(meta.id, stepType, payload));
+    issues.push(
+      ...checkModuleCustomConfig(meta.id, payload.moduleIdentifier as string | undefined, payload.customConfig),
+    );
+
+    let body: Record<string, unknown> = { stepType, ...payload };
+    try {
+      body = step._toDefinitionBody();
+    } catch (error) {
+      issues.push(`step definition '${meta.id}': ${error instanceof Error ? error.message : String(error)}`);
+    }
+
+    const obj: Record<string, unknown> = {
+      id: meta.id,
+      name: meta.name,
+      version: meta.version ?? 1,
+      ...(meta.description !== undefined && meta.description !== null ? { description: meta.description } : {}),
+      ...body,
+      createdAt: STABLE_TIMESTAMP,
+      updatedAt: STABLE_TIMESTAMP,
+    };
+
+    // Full-schema gate: id/name/cross-field refinement (e.g. system id↔module match).
+    issues.push(...collectSchemaIssues(StepDefinitionSchema, obj, `stepDefinition '${meta.id}'`));
+
+    if (issues.length > 0) throw new ArtifactBuildError('Step definition', meta.id, issues);
+    return obj as unknown as StepDefinition;
+  };
+
+  return {
+    id: meta.id,
+    kind: 'stepDefinition',
+    build,
+    toExport: (exportedAt = STABLE_EXPORTED_AT): AllmaExportFormat =>
+      ({ formatVersion: '1.0', exportedAt, stepDefinitions: [build()] }) as unknown as AllmaExportFormat,
+  };
+}
+
+/** Renders a Zod error into prefixed issue strings (mirrors validate.ts internals). */
+function formatIssues(error: z.ZodError, id: string, kind: string): string[] {
+  return error.issues.map((issue) => {
+    const path = issue.path.join('.');
+    const prefix = `${kind} '${id}'`;
+    return path ? `${prefix} ${path}: ${issue.message}` : `${prefix}: ${issue.message}`;
+  });
+}

--- a/packages/flow-builder/src/catalog.ts
+++ b/packages/flow-builder/src/catalog.ts
@@ -10,7 +10,7 @@ import { isExternal } from './external.js';
  * artifact or is explicitly wrapped in `external(...)`.
  */
 
-export type ReferenceKind = 'flow' | 'prompt' | 'stepDefinition';
+export type ReferenceKind = 'flow' | 'prompt' | 'stepDefinition' | 'mcpConnection';
 
 /** A single cross-artifact reference found in a flow. */
 export interface ArtifactReference {
@@ -25,6 +25,7 @@ export interface Catalog {
   flowIds: Set<string>;
   promptTemplateIds: Set<string>;
   stepDefinitionIds: Set<string>;
+  mcpConnectionIds: Set<string>;
 }
 
 /** A reference that resolved to neither a known artifact nor an `external(...)` marker. */
@@ -49,12 +50,18 @@ export function collectFlowReferences(flow: FlowAuthoringFormat): ArtifactRefere
     push('flow', 'flowDefinitionId');
     push('prompt', 'promptTemplateId');
     push('stepDefinition', 'stepDefinitionId');
+    push('mcpConnection', 'mcpConnectionId');
   }
   return refs;
 }
 
 function emptyCatalog(): Catalog {
-  return { flowIds: new Set(), promptTemplateIds: new Set(), stepDefinitionIds: new Set() };
+  return {
+    flowIds: new Set(),
+    promptTemplateIds: new Set(),
+    stepDefinitionIds: new Set(),
+    mcpConnectionIds: new Set(),
+  };
 }
 
 /**
@@ -71,12 +78,14 @@ export function resolveReferences(
   for (const id of known.flowIds ?? []) catalog.flowIds.add(id);
   for (const id of known.promptTemplateIds ?? []) catalog.promptTemplateIds.add(id);
   for (const id of known.stepDefinitionIds ?? []) catalog.stepDefinitionIds.add(id);
+  for (const id of known.mcpConnectionIds ?? []) catalog.mcpConnectionIds.add(id);
   for (const flow of flows) catalog.flowIds.add(flow.id);
 
   const setFor: Record<ReferenceKind, Set<string>> = {
     flow: catalog.flowIds,
     prompt: catalog.promptTemplateIds,
     stepDefinition: catalog.stepDefinitionIds,
+    mcpConnection: catalog.mcpConnectionIds,
   };
 
   const issues: ResolutionIssue[] = [];

--- a/packages/flow-builder/src/cli.test.ts
+++ b/packages/flow-builder/src/cli.test.ts
@@ -46,9 +46,27 @@ describe('cli commands', () => {
   });
 
   it('harvestCatalogIds collects ids from an export-shaped JSON object', () => {
-    const catalog: Catalog = { flowIds: new Set(), promptTemplateIds: new Set(), stepDefinitionIds: new Set() };
-    harvestCatalogIds({ flows: [{ id: 'f1' }], promptTemplates: [{ id: 'p1' }], stepDefinitions: [{ id: 's1' }] }, catalog);
-    expect([...catalog.flowIds, ...catalog.promptTemplateIds, ...catalog.stepDefinitionIds]).toEqual(['f1', 'p1', 's1']);
+    const catalog: Catalog = {
+      flowIds: new Set(),
+      promptTemplateIds: new Set(),
+      stepDefinitionIds: new Set(),
+      mcpConnectionIds: new Set(),
+    };
+    harvestCatalogIds(
+      {
+        flows: [{ id: 'f1' }],
+        promptTemplates: [{ id: 'p1' }],
+        stepDefinitions: [{ id: 's1' }],
+        mcpConnections: [{ id: 'm1' }],
+      },
+      catalog,
+    );
+    expect([
+      ...catalog.flowIds,
+      ...catalog.promptTemplateIds,
+      ...catalog.stepDefinitionIds,
+      ...catalog.mcpConnectionIds,
+    ]).toEqual(['f1', 'p1', 's1', 'm1']);
   });
 
   it('round-trips through a discardable empty-start guard', () => {

--- a/packages/flow-builder/src/cli/allma-flows.ts
+++ b/packages/flow-builder/src/cli/allma-flows.ts
@@ -19,13 +19,18 @@
 import { readdir, readFile, writeFile, mkdir, stat } from 'node:fs/promises';
 import { join, resolve, dirname } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import type { FlowBuilder } from '../define-flow.js';
-import { buildArtifacts, checkArtifacts, harvestCatalogIds } from './commands.js';
+import { buildArtifacts, checkArtifacts, harvestCatalogIds, type ArtifactExporter } from './commands.js';
 import type { Catalog } from '../catalog.js';
 import { ejectFlow } from '../eject.js';
 import { detectDrift, type DeployedFlow, type LocalCodeFlow } from '../drift.js';
+import {
+  planDeploy,
+  executeDeploy,
+  type DeployAdapter,
+  type ImportResultSummary,
+} from '../deploy.js';
 import { ALLMA_ADMIN_API_VERSION, ALLMA_ADMIN_API_ROUTES } from '@allma/core-types';
-import type { FlowAuthoringFormat } from '@allma/core-types';
+import type { AllmaExportFormat, FlowAuthoringFormat } from '@allma/core-types';
 
 /**
  * Builds a `fetchDeployed` adapter that reads a flow version from the admin API.
@@ -47,6 +52,41 @@ function makeRemoteFetcher(baseUrl: string, token: string | undefined) {
       return (body as { data: DeployedFlow }).data;
     }
     return body as DeployedFlow;
+  };
+}
+
+/**
+ * Builds the {@link DeployAdapter} that promotes artifacts via the admin API.
+ * Bulk import goes to `/v1/allma/import`; publishing uses the flow version-publish
+ * route. Auth is a bearer token from `ALLMA_ADMIN_TOKEN` (no service-account auth
+ * exists yet — a human admin token is used for CI), mirroring `makeRemoteFetcher`.
+ */
+function makeDeployAdapter(baseUrl: string, token: string | undefined): DeployAdapter {
+  const root = baseUrl.replace(/\/$/, '');
+  const authHeaders: Record<string, string> = {
+    'content-type': 'application/json',
+    ...(token ? { authorization: `Bearer ${token}` } : {}),
+  };
+  return {
+    importConfig: async (payload, options): Promise<ImportResultSummary> => {
+      const url = `${root}/${ALLMA_ADMIN_API_VERSION}${ALLMA_ADMIN_API_ROUTES.IMPORT}`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: authHeaders,
+        body: JSON.stringify({ ...payload, options }),
+      });
+      if (!res.ok) throw new Error(`admin API ${res.status} importing to ${url}`);
+      const body = (await res.json()) as { data?: ImportResultSummary } | ImportResultSummary;
+      if (body && typeof body === 'object' && 'data' in body && (body as { data?: ImportResultSummary }).data) {
+        return (body as { data: ImportResultSummary }).data;
+      }
+      return body as ImportResultSummary;
+    },
+    publishFlow: async (flowId, version): Promise<void> => {
+      const url = `${root}/${ALLMA_ADMIN_API_VERSION}${ALLMA_ADMIN_API_ROUTES.FLOW_VERSION_PUBLISH(flowId, version)}`;
+      const res = await fetch(url, { method: 'POST', headers: authHeaders });
+      if (!res.ok) throw new Error(`admin API ${res.status} publishing ${flowId} v${version} at ${url}`);
+    },
   };
 }
 
@@ -104,20 +144,27 @@ async function findFiles(pattern: string): Promise<string[]> {
   return out.sort();
 }
 
-async function loadBuilders(files: string[]): Promise<FlowBuilder[]> {
-  const builders: FlowBuilder[] = [];
+async function loadExporters(files: string[]): Promise<ArtifactExporter[]> {
+  const exporters: ArtifactExporter[] = [];
   for (const file of files) {
-    const mod = (await import(pathToFileURL(file).href)) as { default?: FlowBuilder };
+    const mod = (await import(pathToFileURL(file).href)) as { default?: ArtifactExporter };
     if (!mod.default || typeof mod.default.toExport !== 'function') {
-      throw new Error(`${file} does not 'export default' a flow builder (defineFlow(...)).`);
+      throw new Error(
+        `${file} does not 'export default' a flow builder or artifact (defineFlow/definePrompt/defineStep/defineMcpConnection(...)).`,
+      );
     }
-    builders.push(mod.default);
+    exporters.push(mod.default);
   }
-  return builders;
+  return exporters;
 }
 
 async function loadKnownCatalog(pattern: string | undefined): Promise<Partial<Catalog>> {
-  const catalog: Catalog = { flowIds: new Set(), promptTemplateIds: new Set(), stepDefinitionIds: new Set() };
+  const catalog: Catalog = {
+    flowIds: new Set(),
+    promptTemplateIds: new Set(),
+    stepDefinitionIds: new Set(),
+    mcpConnectionIds: new Set(),
+  };
   if (!pattern) return catalog;
   for (const file of await findFiles(pattern)) {
     if (!file.endsWith('.json')) continue;
@@ -140,8 +187,8 @@ async function runBuild(args: ParsedArgs): Promise<number> {
     console.error(`No flow files matched '${args.pattern}'.`);
     return 1;
   }
-  const builders = await loadBuilders(files);
-  const artifacts = buildArtifacts(builders, args.flags['exported-at']);
+  const exporters = await loadExporters(files);
+  const artifacts = buildArtifacts(exporters, args.flags['exported-at']);
   const outDir = resolve(args.flags.out);
   await mkdir(outDir, { recursive: true });
   for (const artifact of artifacts) {
@@ -162,9 +209,9 @@ async function runCheck(args: ParsedArgs): Promise<number> {
     console.error(`No flow files matched '${args.pattern}'.`);
     return 1;
   }
-  const builders = await loadBuilders(files);
+  const exporters = await loadExporters(files);
   const known = await loadKnownCatalog(args.flags.known);
-  const { validationIssues, resolutionIssues } = checkArtifacts(builders, known);
+  const { validationIssues, resolutionIssues } = checkArtifacts(exporters, known);
 
   let failed = false;
   for (const issue of validationIssues) {
@@ -178,10 +225,9 @@ async function runCheck(args: ParsedArgs): Promise<number> {
 
   // Out-of-band drift guard: compare each code-owned flow against the deployed copy.
   if (args.flags.remote) {
-    const local: LocalCodeFlow[] = builders.map((builder) => {
-      const flow = (builder.toExport().flows ?? [])[0] as FlowAuthoringFormat;
-      return { flowId: flow.id, version: flow.version, flow };
-    });
+    const local: LocalCodeFlow[] = exporters
+      .flatMap((exporter) => (exporter.toExport().flows ?? []) as FlowAuthoringFormat[])
+      .map((flow) => ({ flowId: flow.id, version: flow.version, flow }));
     const fetchDeployed = makeRemoteFetcher(args.flags.remote, process.env.ALLMA_ADMIN_TOKEN);
     try {
       for (const issue of await detectDrift(local, fetchDeployed)) {
@@ -197,7 +243,7 @@ async function runCheck(args: ParsedArgs): Promise<number> {
   // Drift check: when --out is given, regenerated JSON must equal committed JSON.
   if (args.flags.out) {
     const outDir = resolve(args.flags.out);
-    for (const artifact of buildArtifacts(builders, args.flags['exported-at'])) {
+    for (const artifact of buildArtifacts(exporters, args.flags['exported-at'])) {
       const target = join(outDir, artifact.fileName);
       let committed: string | undefined;
       try {
@@ -216,7 +262,7 @@ async function runCheck(args: ParsedArgs): Promise<number> {
   }
 
   if (failed) return 1;
-  console.log(`✓ ${builders.length} flow(s) valid.`);
+  console.log(`✓ ${exporters.length} artifact(s) valid.`);
   return 0;
 }
 
@@ -269,6 +315,48 @@ async function runEject(args: ParsedArgs): Promise<number> {
   return 0;
 }
 
+async function runDeploy(args: ParsedArgs): Promise<number> {
+  if (!args.pattern || !args.flags.remote) {
+    console.error(
+      'Usage: allma-flows deploy "<glob>" --remote <baseUrl> [--publish] [--overwrite false]',
+    );
+    return 2;
+  }
+  const files = await findFiles(args.pattern);
+  if (files.length === 0) {
+    console.error(`No artifact files matched '${args.pattern}'.`);
+    return 1;
+  }
+  const exporters = await loadExporters(files);
+  const envelopes: AllmaExportFormat[] = exporters.map((exporter) => exporter.toExport());
+  const plan = planDeploy(envelopes, {
+    overwrite: args.flags.overwrite ? args.flags.overwrite !== 'false' : true,
+    publish: args.flags.publish === 'true',
+  });
+
+  const adapter = makeDeployAdapter(args.flags.remote, process.env.ALLMA_ADMIN_TOKEN);
+  const result = await executeDeploy(plan, adapter);
+
+  const errors = result.import.errors ?? [];
+  for (const err of errors) {
+    console.error(`✗ import (${err.type} '${err.id}'): ${err.message}`);
+  }
+  const tally = (label: string, rec: Record<string, number> | undefined): void => {
+    const entries = Object.entries(rec ?? {}).filter(([, n]) => n > 0);
+    if (entries.length > 0) console.log(`  ${label}: ${entries.map(([k, n]) => `${k}=${n}`).join(', ')}`);
+  };
+  tally('created', result.import.created);
+  tally('updated', result.import.updated);
+  tally('skipped', result.import.skipped);
+  for (const target of result.published) {
+    console.log(`✓ published ${target.flowId} v${target.version}`);
+  }
+
+  if (errors.length > 0) return 1;
+  console.log(`✓ deployed ${envelopes.length} artifact(s).`);
+  return 0;
+}
+
 async function main(): Promise<number> {
   const args = parseArgs(process.argv.slice(2));
   switch (args.command) {
@@ -278,8 +366,10 @@ async function main(): Promise<number> {
       return runCheck(args);
     case 'eject':
       return runEject(args);
+    case 'deploy':
+      return runDeploy(args);
     default:
-      console.error('Usage: allma-flows <build|check|eject> "<glob>" [options]');
+      console.error('Usage: allma-flows <build|check|eject|deploy> "<glob>" [options]');
       return 2;
   }
 }

--- a/packages/flow-builder/src/cli/commands.ts
+++ b/packages/flow-builder/src/cli/commands.ts
@@ -1,24 +1,54 @@
 import { validateAllmaConfig } from '@allma/core-sdk';
-import type { FlowAuthoringFormat } from '@allma/core-types';
-import type { FlowBuilder } from '../define-flow.js';
-import { FlowBuildError } from '../validate.js';
+import type { AllmaExportFormat, FlowAuthoringFormat } from '@allma/core-types';
+import { ArtifactBuildError, FlowBuildError } from '../validate.js';
 import { stableStringify } from '../serialize.js';
 import { resolveReferences, type Catalog, type ResolutionIssue } from '../catalog.js';
 
-/** One built flow ready to be written to disk. */
+/**
+ * Anything the CLI can compile to a deploy file: a `defineFlow` builder, the
+ * `class Flow` facade, or a `define*` artifact handle (prompt / step / MCP). All
+ * expose `toExport()` returning an {@link AllmaExportFormat} envelope.
+ */
+export interface ArtifactExporter {
+  toExport(exportedAt?: string): AllmaExportFormat;
+}
+
+/** The artifact kinds the builder can emit, with their file-name suffix. */
+const ENVELOPE_KINDS = [
+  { array: 'flows', suffix: 'flow' },
+  { array: 'promptTemplates', suffix: 'prompt' },
+  { array: 'stepDefinitions', suffix: 'step' },
+  { array: 'mcpConnections', suffix: 'mcp' },
+  { array: 'agents', suffix: 'agent' },
+] as const;
+
+/** One built artifact ready to be written to disk. */
 export interface BuiltArtifact {
-  flowId: string;
+  /** The artifact's id. */
+  id: string;
+  /** Deterministic file name, e.g. `my-flow.flow.json` / `my-prompt.prompt.json`. */
   fileName: string;
   /** Deterministic, byte-stable JSON (AllmaExportFormat envelope). */
   json: string;
 }
 
-/** Builds every flow to its deterministic `*.flow.json` content. Throws on invalid flows. */
-export function buildArtifacts(builders: FlowBuilder[], exportedAt?: string): BuiltArtifact[] {
-  return builders.map((builder) => {
-    const exported = builder.toExport(exportedAt);
-    const flow = (exported.flows ?? [])[0] as { id: string };
-    return { flowId: flow.id, fileName: `${flow.id}.flow.json`, json: stableStringify(exported) };
+/** Identifies which artifact array an envelope carries and the single item's id. */
+function envelopeInfo(env: AllmaExportFormat): { suffix: string; id: string } {
+  for (const { array, suffix } of ENVELOPE_KINDS) {
+    const items = (env as unknown as Record<string, { id?: string }[]>)[array];
+    if (Array.isArray(items) && items.length > 0) {
+      return { suffix, id: items[0].id ?? 'unknown' };
+    }
+  }
+  return { suffix: 'flow', id: 'unknown' };
+}
+
+/** Builds every exporter to its deterministic `*.<kind>.json` content. Throws on invalid artifacts. */
+export function buildArtifacts(exporters: ArtifactExporter[], exportedAt?: string): BuiltArtifact[] {
+  return exporters.map((exporter) => {
+    const exported = exporter.toExport(exportedAt);
+    const { suffix, id } = envelopeInfo(exported);
+    return { id, fileName: `${id}.${suffix}.json`, json: stableStringify(exported) };
   });
 }
 
@@ -29,22 +59,35 @@ export interface CheckResult {
 }
 
 /**
- * Validates every flow with both the builder's strict gate (via `build()`) and
+ * Validates every artifact with the builder's strict gate (via `toExport()`) and
  * the exact deploy validator (`validateAllmaConfig` from `@allma/core-sdk`), then
- * runs the project-level cross-artifact resolution pass.
+ * runs the project-level cross-artifact resolution pass. Ids of every artifact in
+ * the build set (flows, prompts, step-defs, MCP connections) seed the catalog, so
+ * a flow that references a locally-authored prompt/step/connection resolves.
  */
-export function checkArtifacts(builders: FlowBuilder[], known: Partial<Catalog> = {}): CheckResult {
+export function checkArtifacts(exporters: ArtifactExporter[], known: Partial<Catalog> = {}): CheckResult {
   const validationIssues: string[] = [];
   const flows: FlowAuthoringFormat[] = [];
+  const localCatalog: Catalog = {
+    flowIds: new Set(known.flowIds ?? []),
+    promptTemplateIds: new Set(known.promptTemplateIds ?? []),
+    stepDefinitionIds: new Set(known.stepDefinitionIds ?? []),
+    mcpConnectionIds: new Set(known.mcpConnectionIds ?? []),
+  };
 
-  for (const builder of builders) {
+  for (const exporter of exporters) {
     try {
-      const exported = builder.toExport();
-      const flow = (exported.flows ?? [])[0] as FlowAuthoringFormat;
-      flows.push(flow);
+      const exported = exporter.toExport();
+
+      for (const p of exported.promptTemplates ?? []) if (p.id) localCatalog.promptTemplateIds.add(p.id);
+      for (const s of exported.stepDefinitions ?? []) if (s.id) localCatalog.stepDefinitionIds.add(s.id);
+      for (const m of exported.mcpConnections ?? []) if (m.id) localCatalog.mcpConnectionIds.add(m.id);
+      for (const f of exported.flows ?? []) {
+        flows.push(f as FlowAuthoringFormat);
+      }
 
       // Deploy-parity gate: exactly what the importer runs.
-      const result = validateAllmaConfig(exported, `${flow.id}.flow.json`);
+      const result = validateAllmaConfig(exported, fileNameFor(exported));
       if (!result.success) {
         for (const err of result.error.formErrors) validationIssues.push(err);
         for (const [field, errs] of Object.entries(result.error.fieldErrors)) {
@@ -52,15 +95,21 @@ export function checkArtifacts(builders: FlowBuilder[], known: Partial<Catalog> 
         }
       }
     } catch (error) {
-      if (error instanceof FlowBuildError) {
-        validationIssues.push(...error.issues.map((i) => `[${builder.constructor.name}] ${i}`));
+      if (error instanceof FlowBuildError || error instanceof ArtifactBuildError) {
+        validationIssues.push(...error.issues);
       } else {
         throw error;
       }
     }
   }
 
-  return { validationIssues, resolutionIssues: resolveReferences(flows, known) };
+  return { validationIssues, resolutionIssues: resolveReferences(flows, localCatalog) };
+}
+
+/** A descriptive file name for validator error prefixes. */
+function fileNameFor(env: AllmaExportFormat): string {
+  const { suffix, id } = envelopeInfo(env);
+  return `${id}.${suffix}.json`;
 }
 
 /** Harvests known artifact ids from a parsed `AllmaExportFormat`-shaped JSON object. */
@@ -69,8 +118,10 @@ export function harvestCatalogIds(parsed: unknown, into: Catalog): void {
     flows?: { id?: string }[];
     promptTemplates?: { id?: string }[];
     stepDefinitions?: { id?: string }[];
+    mcpConnections?: { id?: string }[];
   };
   for (const f of data.flows ?? []) if (f.id) into.flowIds.add(f.id);
   for (const p of data.promptTemplates ?? []) if (p.id) into.promptTemplateIds.add(p.id);
   for (const s of data.stepDefinitions ?? []) if (s.id) into.stepDefinitionIds.add(s.id);
+  for (const m of data.mcpConnections ?? []) if (m.id) into.mcpConnectionIds.add(m.id);
 }

--- a/packages/flow-builder/src/define-flow.ts
+++ b/packages/flow-builder/src/define-flow.ts
@@ -121,6 +121,10 @@ export interface DefineFlowOptions {
 
 /** The fluent builder returned by {@link defineFlow}. */
 export interface FlowBuilder {
+  /** The flow's stable id — makes a builder usable as a typed {@link FlowRef}. */
+  readonly id: string;
+  /** Discriminates this as a flow handle (so it can't be passed where a prompt ref is expected). */
+  readonly kind: 'flow';
   /** Phase 1: declare steps; returns a typed record of refs keyed by the same keys. */
   steps<M extends Record<string, StepDraft>>(map: M): { [K in keyof M]: StepRef };
   /** Set the flow's start step. */
@@ -132,6 +136,7 @@ export interface FlowBuilder {
 }
 
 class FlowBuilderImpl implements FlowBuilder {
+  readonly kind = 'flow' as const;
   private readonly options: DefineFlowOptions;
   private readonly stepMap = new Map<string, Step>();
   private startStep: Step | undefined;
@@ -139,6 +144,10 @@ class FlowBuilderImpl implements FlowBuilder {
 
   constructor(options: DefineFlowOptions) {
     this.options = options;
+  }
+
+  get id(): string {
+    return this.options.id;
   }
 
   steps<M extends Record<string, StepDraft>>(map: M): { [K in keyof M]: StepRef } {

--- a/packages/flow-builder/src/deploy.test.ts
+++ b/packages/flow-builder/src/deploy.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import type { AllmaExportFormat } from '@allma/core-types';
+import {
+  planDeploy,
+  executeDeploy,
+  definePrompt,
+  defineFlow,
+  noOp,
+  type DeployAdapter,
+  type ImportResultSummary,
+  type PublishTarget,
+} from './index.js';
+
+function flowEnvelope(id: string, version = 1): AllmaExportFormat {
+  const flow = defineFlow({ id, version });
+  const s = flow.steps({ only: noOp() });
+  flow.start(s.only);
+  return flow.toExport();
+}
+
+const promptEnvelope = definePrompt({ id: 'p1', name: 'P', content: 'x' }).toExport();
+
+/** A stubbed adapter that records calls instead of touching the network. */
+function recordingAdapter(importResult: ImportResultSummary = {}) {
+  const imports: { payload: AllmaExportFormat; options: { overwrite: boolean } }[] = [];
+  const publishes: PublishTarget[] = [];
+  const adapter: DeployAdapter = {
+    importConfig: async (payload, options) => {
+      imports.push({ payload, options });
+      return importResult;
+    },
+    publishFlow: async (flowId, version) => {
+      publishes.push({ flowId, version });
+    },
+  };
+  return { adapter, imports, publishes };
+}
+
+describe('planDeploy', () => {
+  it('merges every artifact array across envelopes into one import payload', () => {
+    const plan = planDeploy([flowEnvelope('a'), flowEnvelope('b'), promptEnvelope]);
+    expect(plan.import.flows?.map((f) => f.id)).toEqual(['a', 'b']);
+    expect(plan.import.promptTemplates?.map((p) => p.id)).toEqual(['p1']);
+    expect(plan.importOptions.overwrite).toBe(true);
+    expect(plan.publish).toEqual([]);
+  });
+
+  it('computes publish targets from flow ids/versions when publish is set', () => {
+    const plan = planDeploy([flowEnvelope('a', 3)], { publish: true });
+    expect(plan.publish).toEqual([{ flowId: 'a', version: 3 }]);
+  });
+
+  it('honors an explicit overwrite=false', () => {
+    expect(planDeploy([flowEnvelope('a')], { overwrite: false }).importOptions.overwrite).toBe(false);
+  });
+});
+
+describe('executeDeploy', () => {
+  it('imports once and publishes each target', async () => {
+    const plan = planDeploy([flowEnvelope('a', 2)], { publish: true });
+    const { adapter, imports, publishes } = recordingAdapter();
+    const result = await executeDeploy(plan, adapter);
+
+    expect(imports).toHaveLength(1);
+    expect(imports[0].options).toEqual({ overwrite: true });
+    expect(publishes).toEqual([{ flowId: 'a', version: 2 }]);
+    expect(result.published).toEqual([{ flowId: 'a', version: 2 }]);
+  });
+
+  it('does not publish when the import reported per-item errors', async () => {
+    const plan = planDeploy([flowEnvelope('a')], { publish: true });
+    const { adapter, publishes } = recordingAdapter({
+      errors: [{ id: 'a', type: 'flow', message: 'version 1 does not exist' }],
+    });
+    const result = await executeDeploy(plan, adapter);
+
+    expect(publishes).toEqual([]);
+    expect(result.published).toEqual([]);
+    expect(result.import.errors).toHaveLength(1);
+  });
+
+  it('skips publishing entirely when publish is not requested', async () => {
+    const plan = planDeploy([flowEnvelope('a')]);
+    const { adapter, imports, publishes } = recordingAdapter();
+    await executeDeploy(plan, adapter);
+    expect(imports).toHaveLength(1);
+    expect(publishes).toEqual([]);
+  });
+});

--- a/packages/flow-builder/src/deploy.ts
+++ b/packages/flow-builder/src/deploy.ts
@@ -1,0 +1,143 @@
+import type { AllmaExportFormat } from '@allma/core-types';
+import { STABLE_EXPORTED_AT } from './define-flow.js';
+
+/**
+ * `allma-flows deploy` core (RFC §8 "Optional Phase 3" / §11). Promotes
+ * code-authored artifacts to a running Allma environment via the flow-management
+ * admin API — **no CDK redeploy** — so CI can ship a flow/prompt/step-def/MCP
+ * change as a pure API call.
+ *
+ * ## Why the bulk import route (not the granular create-version flow)
+ * The builder already emits an {@link AllmaExportFormat} envelope carrying every
+ * artifact kind (flows, prompts, step definitions, MCP connections). The bulk
+ * `POST /v1/allma/import` route accepts exactly that shape and is the same
+ * importer the CDK deploy pipeline uses, so a `deploy` and a `cdk deploy` apply
+ * identical semantics. The granular `FLOW_CREATE_VERSION` + `FLOW_VERSION_PUBLISH`
+ * routes are flow-only and would need bespoke ordering for cross-artifact refs.
+ *
+ * ## Version-slot contract (honored, not worked around)
+ * The importer (`allma-importer.service.ts`) **creates** a brand-new flow id at
+ * the version in the envelope, but for an **existing** flow id it only *updates*
+ * a version slot that already exists — "Creating new versions for existing flows
+ * on import is not supported". `deploy` therefore matches `cdk deploy`: bumping an
+ * existing flow to a not-yet-existing version must be done via the admin
+ * version-management API first. `deploy` surfaces the importer's per-item errors
+ * rather than masking them.
+ *
+ * The module is pure: all network/auth lives behind the injected
+ * {@link DeployAdapter} (mirrors `detectDrift`'s `fetchDeployed`), so the planning
+ * and orchestration are unit-testable with a stubbed adapter and zero I/O.
+ */
+
+/** Options controlling a deploy. */
+export interface DeployOptions {
+  /** Overwrite existing version slots (the importer's `options.overwrite`). Defaults to `true`. */
+  overwrite?: boolean;
+  /** After import, publish each flow version via the admin API. Defaults to `false`. */
+  publish?: boolean;
+}
+
+/** A flow version targeted for publishing. */
+export interface PublishTarget {
+  flowId: string;
+  version: number;
+}
+
+/** A planned deploy: one merged import payload plus optional per-flow publishes. */
+export interface DeployPlan {
+  /** The single, merged `AllmaExportFormat` to POST to the import route. */
+  import: AllmaExportFormat;
+  /** The importer options (`overwrite`). */
+  importOptions: { overwrite: boolean };
+  /** Flow versions to publish after a successful import (empty unless `publish`). */
+  publish: PublishTarget[];
+}
+
+/** The importer's per-item error, surfaced verbatim. */
+export interface ImportItemError {
+  id: string;
+  type: string;
+  message: string;
+}
+
+/** A loose summary of the import endpoint's response (created/updated/skipped/errors). */
+export interface ImportResultSummary {
+  created?: Record<string, number>;
+  updated?: Record<string, number>;
+  skipped?: Record<string, number>;
+  errors?: ImportItemError[];
+}
+
+/** The network/auth boundary `executeDeploy` calls. Implemented by the CLI with `fetch`. */
+export interface DeployAdapter {
+  /** POST the merged envelope to `/v1/allma/import` with the given options. */
+  importConfig(payload: AllmaExportFormat, options: { overwrite: boolean }): Promise<ImportResultSummary>;
+  /** POST `/v1/allma/flows/{flowId}/versions/{version}/publish`. */
+  publishFlow(flowId: string, version: number): Promise<void>;
+}
+
+/** The outcome of an `executeDeploy` run. */
+export interface DeployResult {
+  import: ImportResultSummary;
+  published: PublishTarget[];
+}
+
+const ARTIFACT_ARRAYS = ['flows', 'promptTemplates', 'stepDefinitions', 'mcpConnections', 'agents'] as const;
+
+/**
+ * Merges every artifact array across the given envelopes into a single
+ * deterministic import payload, and (when `publish` is set) computes the flow
+ * versions to publish afterwards.
+ */
+export function planDeploy(envelopes: AllmaExportFormat[], options: DeployOptions = {}): DeployPlan {
+  const merged: Record<string, unknown[]> = {};
+  for (const key of ARTIFACT_ARRAYS) {
+    const items: unknown[] = [];
+    for (const env of envelopes) {
+      const arr = (env as unknown as Record<string, unknown[]>)[key];
+      if (Array.isArray(arr)) items.push(...arr);
+    }
+    if (items.length > 0) merged[key] = items;
+  }
+
+  const importPayload = {
+    formatVersion: '1.0',
+    exportedAt: STABLE_EXPORTED_AT,
+    ...merged,
+  } as unknown as AllmaExportFormat;
+
+  const publish: PublishTarget[] = [];
+  if (options.publish) {
+    for (const flow of (importPayload.flows ?? []) as { id: string; version?: number }[]) {
+      publish.push({ flowId: flow.id, version: typeof flow.version === 'number' ? flow.version : 1 });
+    }
+  }
+
+  return {
+    import: importPayload,
+    importOptions: { overwrite: options.overwrite ?? true },
+    publish,
+  };
+}
+
+/**
+ * Executes a {@link DeployPlan} through the injected {@link DeployAdapter}: one
+ * import call, then (if any) the publishes. Publishing only proceeds when the
+ * import reported no per-item errors, so a half-applied import is not published.
+ */
+export async function executeDeploy(plan: DeployPlan, adapter: DeployAdapter): Promise<DeployResult> {
+  const importResult = await adapter.importConfig(plan.import, plan.importOptions);
+
+  const published: PublishTarget[] = [];
+  if (plan.publish.length > 0) {
+    if (importResult.errors && importResult.errors.length > 0) {
+      return { import: importResult, published };
+    }
+    for (const target of plan.publish) {
+      await adapter.publishFlow(target.flowId, target.version);
+      published.push(target);
+    }
+  }
+
+  return { import: importResult, published };
+}

--- a/packages/flow-builder/src/factories.ts
+++ b/packages/flow-builder/src/factories.ts
@@ -40,6 +40,7 @@ import {
 } from '@allma/core-types';
 import { Step, type StepDraft } from './step.js';
 import { MODULE_STEP_TYPE } from './registry.js';
+import { normalizeRefs, type PromptRef, type FlowRef, type McpConnectionRef } from './refs.js';
 
 /**
  * The config a factory accepts: the leaf payload's input shape minus the
@@ -61,14 +62,22 @@ const moduleStep = (moduleIdentifier: string, customConfig: unknown): StepDraft 
 
 // --- Typed-payload factories (one per non-module StepType) ---------------------
 
-export const llmInvocation = (config: LeafConfig<typeof LlmInvocationStepSchema>): StepDraft =>
-  typedStep(StepType.LLM_INVOCATION, config);
+/** LLM config, but `promptTemplateId` also accepts a typed {@link PromptRef}. */
+type LlmConfig = Omit<LeafConfig<typeof LlmInvocationStepSchema>, 'promptTemplateId'> & {
+  promptTemplateId?: string | PromptRef;
+};
+export const llmInvocation = (config: LlmConfig): StepDraft =>
+  typedStep(StepType.LLM_INVOCATION, normalizeRefs(config, ['promptTemplateId']));
 
 export const apiCall = (config: LeafConfig<typeof ApiCallStepSchema>): StepDraft =>
   typedStep(StepType.API_CALL, config);
 
-export const mcpCall = (config: LeafConfig<typeof McpCallStepSchema>): StepDraft =>
-  typedStep(StepType.MCP_CALL, config);
+/** MCP config, but `mcpConnectionId` also accepts a typed {@link McpConnectionRef}. */
+type McpCallConfig = Omit<LeafConfig<typeof McpCallStepSchema>, 'mcpConnectionId'> & {
+  mcpConnectionId: string | McpConnectionRef;
+};
+export const mcpCall = (config: McpCallConfig): StepDraft =>
+  typedStep(StepType.MCP_CALL, normalizeRefs(config, ['mcpConnectionId']));
 
 export const customLambdaInvoke = (config: LeafConfig<typeof CustomLambdaInvokeStepSchema>): StepDraft =>
   typedStep(StepType.CUSTOM_LAMBDA_INVOKE, config);
@@ -76,11 +85,19 @@ export const customLambdaInvoke = (config: LeafConfig<typeof CustomLambdaInvokeS
 export const parallelForkManager = (config: LeafConfig<typeof ParallelForkManagerStepSchema>): StepDraft =>
   typedStep(StepType.PARALLEL_FORK_MANAGER, config);
 
-export const startSubFlow = (config: LeafConfig<typeof StartSubFlowStepSchema>): StepDraft =>
-  typedStep(StepType.START_SUB_FLOW, config);
+/** Sub-flow config, but `subFlowDefinitionId` also accepts a typed {@link FlowRef}. */
+type StartSubFlowConfig = Omit<LeafConfig<typeof StartSubFlowStepSchema>, 'subFlowDefinitionId'> & {
+  subFlowDefinitionId: string | FlowRef;
+};
+export const startSubFlow = (config: StartSubFlowConfig): StepDraft =>
+  typedStep(StepType.START_SUB_FLOW, normalizeRefs(config, ['subFlowDefinitionId']));
 
-export const startFlowExecution = (config: LeafConfig<typeof StartFlowExecutionStepSchema>): StepDraft =>
-  typedStep(StepType.START_FLOW_EXECUTION, config);
+/** Start-flow config, but `flowDefinitionId` also accepts a typed {@link FlowRef}. */
+type StartFlowExecutionConfig = Omit<LeafConfig<typeof StartFlowExecutionStepSchema>, 'flowDefinitionId'> & {
+  flowDefinitionId: string | FlowRef;
+};
+export const startFlowExecution = (config: StartFlowExecutionConfig): StepDraft =>
+  typedStep(StepType.START_FLOW_EXECUTION, normalizeRefs(config, ['flowDefinitionId']));
 
 export const noOp = (config: LeafConfig<typeof NoOpStepSchema> = {}): StepDraft =>
   typedStep(StepType.NO_OP, config);

--- a/packages/flow-builder/src/flow-class.ts
+++ b/packages/flow-builder/src/flow-class.ts
@@ -24,12 +24,19 @@ import {
  * ```
  */
 export class Flow {
+  /** Discriminates this as a flow handle (a typed `FlowRef`). */
+  readonly kind = 'flow' as const;
   private readonly options: DefineFlowOptions;
   private readonly stepMap = new Map<string, Step>();
   private startStep: Step | undefined;
 
   constructor(options: DefineFlowOptions) {
     this.options = options;
+  }
+
+  /** The flow's stable id — makes the instance usable as a typed `FlowRef`. */
+  get id(): string {
+    return this.options.id;
   }
 
   /**

--- a/packages/flow-builder/src/index.ts
+++ b/packages/flow-builder/src/index.ts
@@ -21,7 +21,29 @@ export type { DeployVar, AllowedDeployToken, TokenIssue } from './deploy-var.js'
 
 export { external, isExternal } from './external.js';
 
-export { FlowBuildError } from './validate.js';
+export {
+  definePrompt,
+  defineStep,
+  defineMcpConnection,
+  STABLE_TIMESTAMP,
+} from './artifacts.js';
+export type {
+  DefinedArtifact,
+  DefinedPrompt,
+  DefinedStepDefinition,
+  DefinedMcpConnection,
+  PromptInput,
+  McpConnectionInput,
+  StepDefinitionMeta,
+} from './artifacts.js';
+
+export { refId } from './refs.js';
+export type { PromptRef, FlowRef, StepDefRef, McpConnectionRef, AnyArtifactRef } from './refs.js';
+
+export { flowContext } from './typed-context.js';
+export type { TypedJp, ContextPaths } from './typed-context.js';
+
+export { FlowBuildError, ArtifactBuildError } from './validate.js';
 
 export { stableStringify, sortKeysDeep } from './serialize.js';
 
@@ -33,3 +55,14 @@ export type { EjectOptions, BuilderSpec } from './eject.js';
 
 export { detectDrift } from './drift.js';
 export type { DriftIssue, LocalCodeFlow, DeployedFlow, FetchDeployed } from './drift.js';
+
+export { planDeploy, executeDeploy } from './deploy.js';
+export type {
+  DeployOptions,
+  DeployPlan,
+  DeployAdapter,
+  DeployResult,
+  PublishTarget,
+  ImportResultSummary,
+  ImportItemError,
+} from './deploy.js';

--- a/packages/flow-builder/src/refs.test.ts
+++ b/packages/flow-builder/src/refs.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import {
+  defineFlow,
+  definePrompt,
+  defineMcpConnection,
+  llmInvocation,
+  mcpCall,
+  startSubFlow,
+  endFlow,
+  noOp,
+  external,
+  resolveReferences,
+} from './index.js';
+import { checkArtifacts } from './cli/commands.js';
+
+const prompt = definePrompt({ id: 'summary-prompt', name: 'Summary', content: 'Summarize {{doc}}' });
+const conn = defineMcpConnection({
+  id: 'github-mcp',
+  name: 'GitHub MCP',
+  serverUrl: 'https://mcp.example.com',
+  authentication: { type: 'NONE' },
+});
+
+/** A flow that references a prompt handle and an MCP connection handle by OBJECT. */
+function flowUsingHandles() {
+  const flow = defineFlow({ id: 'uses-handles' });
+  const s = flow.steps({
+    summarize: llmInvocation({
+      llmProvider: 'AWS_BEDROCK',
+      modelId: 'anthropic.claude-3-sonnet',
+      promptTemplateId: prompt,
+    }),
+    tool: mcpCall({ mcpConnectionId: conn, toolName: 'search' }),
+    done: endFlow(),
+  });
+  s.summarize.next(s.tool);
+  s.tool.next(s.done);
+  flow.start(s.summarize);
+  return flow;
+}
+
+describe('typed object refs', () => {
+  it('normalizes a prompt handle to its string id in the emitted artifact', () => {
+    const flow = flowUsingHandles().build();
+    const steps = flow.steps as Record<string, Record<string, unknown>>;
+    expect(steps.summarize.promptTemplateId).toBe('summary-prompt');
+    expect(steps.tool.mcpConnectionId).toBe('github-mcp');
+  });
+
+  it('normalizes a flow handle in a sub-flow reference', () => {
+    const child = defineFlow({ id: 'child' });
+    const cs = child.steps({ only: noOp() });
+    child.start(cs.only);
+
+    const parent = defineFlow({ id: 'parent' });
+    const ps = parent.steps({ start: startSubFlow({ subFlowDefinitionId: child }), done: endFlow() });
+    ps.start.next(ps.done);
+    parent.start(ps.start);
+
+    const steps = parent.build().steps as Record<string, Record<string, unknown>>;
+    expect(steps.start.subFlowDefinitionId).toBe('child');
+  });
+});
+
+describe('cross-artifact resolution across all artifact kinds', () => {
+  it('flags a dangling prompt and mcp reference when not in the catalog', () => {
+    const issues = resolveReferences([flowUsingHandles().build()]);
+    const kinds = issues.map((i) => i.kind).sort();
+    expect(kinds).toEqual(['mcpConnection', 'prompt']);
+  });
+
+  it('resolves prompt/mcp refs supplied via a known catalog', () => {
+    const issues = resolveReferences([flowUsingHandles().build()], {
+      promptTemplateIds: new Set(['summary-prompt']),
+      mcpConnectionIds: new Set(['github-mcp']),
+    });
+    expect(issues).toHaveLength(0);
+  });
+
+  it('honors external() for an intentionally out-of-dir mcp connection', () => {
+    const flow = defineFlow({ id: 'ext' });
+    const s = flow.steps({
+      tool: mcpCall({ mcpConnectionId: external('platform-managed-mcp'), toolName: 'x' }),
+      done: endFlow(),
+    });
+    s.tool.next(s.done);
+    flow.start(s.tool);
+    expect(resolveReferences([flow.build()])).toHaveLength(0);
+  });
+
+  it('resolves locally-authored prompt/mcp handles when built together (checkArtifacts)', () => {
+    const { validationIssues, resolutionIssues } = checkArtifacts([prompt, conn, flowUsingHandles()]);
+    expect(validationIssues).toEqual([]);
+    expect(resolutionIssues).toEqual([]);
+  });
+});

--- a/packages/flow-builder/src/refs.ts
+++ b/packages/flow-builder/src/refs.ts
@@ -1,0 +1,68 @@
+/**
+ * Typed cross-artifact object references (RFC §5.7 endgame / Phase 3).
+ *
+ * Phase 1/2 turned *intra*-flow wiring into object refs (no string step ids).
+ * The remaining stringly-typed surface is *cross*-artifact: a step's
+ * `promptTemplateId`, `subFlowDefinitionId`, `flowDefinitionId`, and
+ * `mcpConnectionId` were bare strings. Phase 3 lets the factories accept the
+ * authored artifact object (or its typed handle) directly, so a renamed prompt
+ * or a typo is a compile/build error instead of a dangling id.
+ *
+ * Each ref carries a discriminating `kind`, so a `PromptRef` cannot be passed
+ * where a `FlowRef` is expected. `external('id')` still returns a plain string,
+ * which remains assignable to the `string` side of every ref-accepting field.
+ */
+
+/** A handle to a prompt template authored by {@link definePrompt}. */
+export interface PromptRef {
+  readonly id: string;
+  readonly kind: 'prompt';
+}
+
+/** A handle to a flow authored by `defineFlow` / `class Flow`. */
+export interface FlowRef {
+  readonly id: string;
+  readonly kind: 'flow';
+}
+
+/** A handle to a reusable step definition authored by {@link defineStep}. */
+export interface StepDefRef {
+  readonly id: string;
+  readonly kind: 'stepDefinition';
+}
+
+/** A handle to an MCP connection authored by {@link defineMcpConnection}. */
+export interface McpConnectionRef {
+  readonly id: string;
+  readonly kind: 'mcpConnection';
+}
+
+/** Any typed cross-artifact handle. */
+export type AnyArtifactRef = PromptRef | FlowRef | StepDefRef | McpConnectionRef;
+
+/**
+ * Resolves a cross-artifact reference to its bare string id. Accepts either an
+ * `external('id')` / hand-written string, or any object carrying an `id` (a
+ * typed ref/handle). Used by the factories to normalize a ref into the wire
+ * field the artifact stores.
+ */
+export function refId(value: string | { readonly id: string }): string {
+  return typeof value === 'string' ? value : value.id;
+}
+
+/**
+ * Returns a shallow copy of `config` with each listed key normalized from a
+ * possible object ref to its string id. Keys that are absent are left untouched.
+ * Accepts any object shape (the typed factory configs) and returns the plain
+ * record the `Step` payload stores.
+ */
+export function normalizeRefs(config: object, keys: readonly string[]): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...(config as Record<string, unknown>) };
+  for (const key of keys) {
+    const value = out[key];
+    if (value !== undefined && value !== null && typeof value === 'object' && 'id' in (value as object)) {
+      out[key] = (value as { id: string }).id;
+    }
+  }
+  return out;
+}

--- a/packages/flow-builder/src/step.ts
+++ b/packages/flow-builder/src/step.ts
@@ -1,4 +1,5 @@
 import type { StepType, DelayOptions, StepErrorHandler } from '@allma/core-types';
+import { refId, type StepDefRef } from './refs.js';
 
 /** A progress-milestone tag attached to a step (mirrors `StepInstance.checkpoint`). */
 export interface Checkpoint {
@@ -39,8 +40,8 @@ export interface StepDraft {
   checkpoint(checkpoint: Checkpoint): this;
   /** Override canvas position. Omit to let the editor auto-layout. */
   position(position: Position): this;
-  /** Reference a reusable, stored step definition to merge from. */
-  fromDefinition(stepDefinitionId: string): this;
+  /** Reference a reusable, stored step definition to merge from (id or typed handle). */
+  fromDefinition(stepDefinitionId: string | StepDefRef): this;
   /** Cap how many times the default (`next`) transition may be taken (0 = infinite). */
   defaultNextMaxTransitions(max: number): this;
   /** Disable S3 payload offload for this step. */
@@ -129,6 +130,31 @@ export class Step implements StepRef {
     return this.payload;
   }
 
+  /**
+   * @internal Emits the reusable **step-definition** body: the leaf payload plus
+   * the non-wiring config (`inputMappings`/`outputMappings`/`literals`/`onError`).
+   * Instance-only concerns (id, displayName, position, checkpoint, transitions,
+   * default-next) are deliberately omitted — a stored {@link defineStep} definition
+   * has no graph context. Throws if a graph-dependent `onError.fallback` was set,
+   * since a standalone definition has no sibling step to reference.
+   */
+  _toDefinitionBody(): Record<string, unknown> {
+    const body: Record<string, unknown> = { stepType: this.stepType, ...this.payload };
+    if (this._inputMappings !== undefined) body.inputMappings = this._inputMappings;
+    if (this._outputMappings !== undefined) body.outputMappings = this._outputMappings;
+    if (this._literals !== undefined) body.literals = this._literals;
+    if (this._onError !== undefined) {
+      const { fallback, ...rest } = this._onError;
+      if (fallback !== undefined) {
+        throw new Error(
+          'onError.fallback is not supported in a reusable step definition (no sibling steps to reference). Wire the fallback on the step instance instead.',
+        );
+      }
+      body.onError = { ...rest };
+    }
+    return body;
+  }
+
   // --- Config setters (Phase 1) ---
   displayName(name: string): this {
     this._displayName = name;
@@ -154,8 +180,8 @@ export class Step implements StepRef {
     this._position = position;
     return this;
   }
-  fromDefinition(stepDefinitionId: string): this {
-    this._stepDefinitionId = stepDefinitionId;
+  fromDefinition(stepDefinitionId: string | StepDefRef): this {
+    this._stepDefinitionId = refId(stepDefinitionId);
     return this;
   }
   defaultNextMaxTransitions(max: number): this {

--- a/packages/flow-builder/src/typed-context.ts
+++ b/packages/flow-builder/src/typed-context.ts
@@ -1,0 +1,82 @@
+import { jp, type JsonPath, type Comparable } from './jp.js';
+
+/**
+ * Opt-in typed-context generics for JSONPath authoring (RFC §11).
+ *
+ * `jp(...)` validates a path's *grammar* at build time, but cannot know whether
+ * `$.steps_output.summarize.text` actually exists in a given flow's context — a
+ * renamed context field stays a silent runtime miss. `flowContext<Ctx>()` closes
+ * that gap **opt-in**: it returns a `jp`-shaped helper whose path argument is
+ * constrained to the dotted key paths of a caller-supplied context type `Ctx`, so
+ * a typo or a stale path is a **compile error**.
+ *
+ * ```ts
+ * interface Ctx { steps_output: { summarize: { text: string } }; flow_variables: { bucket: string } }
+ * const $ = flowContext<Ctx>();
+ * s.store.inputs({ 'body': $('$.steps_output.summarize.text') });   // ok
+ * s.store.inputs({ 'body': $('$.steps_output.summarize.txet') });   // compile error
+ * ```
+ *
+ * ### Why opt-in, and why bounded depth (the TS7056 guard)
+ * Threading `Ctx` through `Step`/`StepRef`/`StepDraft` would re-instantiate types
+ * across the 21-member step union — exactly the inference blow-up this package is
+ * built to avoid (RFC §9). Instead the generic lives **only** on this helper, and
+ * the path-enumeration type {@link ContextPaths} is bounded to a recursion depth
+ * of 3. Default `jp`/`inputs`/`outputs` are untouched (plain `string`). The CI
+ * type-cost guard measures the cost of this file; if a deeper context is needed,
+ * raise the depth deliberately and re-measure rather than letting it grow
+ * implicitly. Arrays are treated as leaves (index into them with runtime `jp`).
+ */
+
+/** Decrements the depth counter for bounded recursion. */
+type PrevDepth = [never, 0, 1, 2, 3];
+
+/** Joins a key with a nested sub-path, omitting the dot when the tail is empty. */
+type Join<K extends string, R extends string> = R extends '' ? K : `${K}.${R}`;
+
+/** Enumerates dotted key paths of `T` up to `Depth` levels (arrays are leaves). */
+type DottedPaths<T, Depth extends number> = [Depth] extends [never]
+  ? never
+  : Depth extends 0
+    ? never
+    : T extends readonly unknown[]
+      ? never
+      : T extends object
+        ? {
+            [K in keyof T & string]: NonNullable<T[K]> extends readonly unknown[]
+              ? K
+              : NonNullable<T[K]> extends object
+                ? K | Join<K, DottedPaths<NonNullable<T[K]>, PrevDepth[Depth]>>
+                : K;
+          }[keyof T & string]
+        : never;
+
+/** Every `$.`-rooted JSONPath valid for a context shaped like `Ctx` (plus bare `$`). */
+export type ContextPaths<Ctx> = '$' | `$.${DottedPaths<Ctx, 3>}`;
+
+/** A `jp`-shaped helper whose path argument is constrained to `ContextPaths<Ctx>`. */
+export interface TypedJp<Ctx> {
+  /** Validate a context path (typo-checked against `Ctx`) and return it branded. */
+  (path: ContextPaths<Ctx>): JsonPath;
+  /** `path === value` */
+  eq(path: ContextPaths<Ctx>, value: Comparable): string;
+  /** `path !== value` */
+  ne(path: ContextPaths<Ctx>, value: Comparable): string;
+  /** `path > value` */
+  gt(path: ContextPaths<Ctx>, value: Comparable): string;
+  /** `path >= value` */
+  gte(path: ContextPaths<Ctx>, value: Comparable): string;
+  /** `path < value` */
+  lt(path: ContextPaths<Ctx>, value: Comparable): string;
+  /** `path <= value` */
+  lte(path: ContextPaths<Ctx>, value: Comparable): string;
+}
+
+/**
+ * Returns a {@link TypedJp} bound to a caller-supplied context type `Ctx`. The
+ * runtime behavior is identical to {@link jp} (the same grammar validation runs);
+ * the only difference is the compile-time path constraint.
+ */
+export function flowContext<Ctx>(): TypedJp<Ctx> {
+  return jp as unknown as TypedJp<Ctx>;
+}

--- a/packages/flow-builder/src/typed-context.type.test.ts
+++ b/packages/flow-builder/src/typed-context.type.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const projectDir = join(here, '..');
+
+/**
+ * Type-level test for the opt-in typed-context generic: compiles the
+ * `*.typetest.ts` fixtures under a dedicated tsconfig. The fixtures use
+ * `@ts-expect-error` on every bad context path, so `tsc` passes only when each
+ * typo is still caught — a regression in {@link flowContext}'s path typing turns
+ * an unused directive into an error and fails this test.
+ */
+describe('typed-context type-test', () => {
+  it('catches context-path typos at compile time', () => {
+    const result = spawnSync(
+      'npx',
+      ['tsc', '-p', join(projectDir, 'tsconfig.typetest.json')],
+      { cwd: projectDir, encoding: 'utf8' },
+    );
+    expect(`${result.stdout ?? ''}${result.stderr ?? ''}`).toBe('');
+    expect(result.status).toBe(0);
+  }, 60_000);
+});

--- a/packages/flow-builder/src/typed-context.typetest.ts
+++ b/packages/flow-builder/src/typed-context.typetest.ts
@@ -1,0 +1,40 @@
+/**
+ * Compile-fail fixtures for the opt-in typed-context generic (RFC §11). This
+ * file is type-checked by `tsconfig.typetest.json` (run from `typed-context.type.test.ts`),
+ * NOT by the build or the type-cost guard. Each `@ts-expect-error` asserts that a
+ * bad context path is a COMPILE error; if the type ever stops catching it, the
+ * unused-directive error fails the type-test. It is never executed.
+ */
+import { flowContext } from './typed-context.js';
+
+interface Ctx {
+  steps_output: { summarize: { text: string }; counts: number[] };
+  flow_variables: { bucket: string };
+}
+
+const $ = flowContext<Ctx>();
+
+// --- Valid paths: these must compile cleanly. ---
+$('$');
+$('$.steps_output');
+$('$.steps_output.summarize');
+$('$.steps_output.summarize.text');
+$('$.steps_output.counts');
+$('$.flow_variables.bucket');
+$.eq('$.steps_output.summarize.text', 'done');
+$.gt('$.steps_output.counts', 0);
+
+// --- Invalid paths: each must be a compile error. ---
+// @ts-expect-error - typo in a leaf key
+$('$.steps_output.summarize.txet');
+// @ts-expect-error - unknown top-level key
+$('$.nope');
+// @ts-expect-error - missing the `$.` root
+$('steps_output');
+// @ts-expect-error - descending into an array leaf
+$('$.steps_output.counts.length');
+// @ts-expect-error - typo in a comparison path
+$.eq('$.flow_variables.bouquet', 'x');
+
+// Reference the bindings so `noUnusedLocals` (if enabled) stays satisfied.
+export const _typetestMarker = $;

--- a/packages/flow-builder/src/validate.ts
+++ b/packages/flow-builder/src/validate.ts
@@ -16,6 +16,34 @@ export class FlowBuildError extends Error {
   }
 }
 
+/**
+ * Thrown by a non-flow artifact's `build()` (prompt / step definition / MCP
+ * connection) when it fails its authoring gate, aggregating all issues. The
+ * flow-specific {@link FlowBuildError} stays separate for backward compatibility.
+ */
+export class ArtifactBuildError extends Error {
+  readonly kind: string;
+  readonly id: string;
+  readonly issues: string[];
+  constructor(kind: string, id: string, issues: string[]) {
+    super(
+      `${kind} '${id}' failed validation with ${issues.length} issue(s):\n` +
+        issues.map((i) => `  - ${i}`).join('\n'),
+    );
+    this.name = 'ArtifactBuildError';
+    this.kind = kind;
+    this.id = id;
+    this.issues = issues;
+  }
+}
+
+/** Parses `value` against `schema`, returning prefixed issue strings (empty on success). */
+export function collectSchemaIssues(schema: z.ZodTypeAny, value: unknown, prefix: string): string[] {
+  const result = schema.safeParse(value);
+  if (result.success) return [];
+  return formatZodIssues(result.error, prefix);
+}
+
 /** Renders Zod issues with a leading context prefix and a dotted field path. */
 function formatZodIssues(error: z.ZodError, prefix: string): string[] {
   return error.issues.map((issue) => {

--- a/packages/flow-builder/tsconfig.json
+++ b/packages/flow-builder/tsconfig.json
@@ -16,7 +16,7 @@
     "types": ["node"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.typetest.ts"],
   "references": [
     { "path": "../core-types" },
     { "path": "../core-sdk" }

--- a/packages/flow-builder/tsconfig.typetest.json
+++ b/packages/flow-builder/tsconfig.typetest.json
@@ -8,6 +8,6 @@
     "incremental": false,
     "noEmit": true
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.typetest.ts"]
+  "include": ["src/**/*.typetest.ts", "src/typed-context.ts", "src/jp.ts"],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Flows-as-Code — Phase 3 (RFC `design/flows-as-code.md` §11)

Stacked on **#72** (Phase 2). Base is `feat/flows-as-code-phase-2`; this will auto-retarget to `main` once the lower PRs merge. Additive and backward compatible — **no `core-types` change** (so no `@allma/admin-shell` major cascade), no `major` bump.

### What's here
- **Config-as-code authoring** — `definePrompt` / `defineStep` / `defineMcpConnection` author prompts, reusable step definitions, and MCP connections in code with the same strict gate + deterministic emit as `defineFlow`. `allma-flows build`/`check` emit and validate them alongside flows (`*.prompt.json` / `*.step.json` / `*.mcp.json`).
- **Typed object references** — `promptTemplateId` / `subFlowDefinitionId` / `flowDefinitionId` / `mcpConnectionId` / `.fromDefinition()` accept the authored handle (or its typed ref), normalized to the string id on emit. A `FlowBuilder`/`Flow` is itself a `FlowRef`. `external('id')` still works; cross-artifact resolution now covers `mcpConnectionId`.
- **`allma-flows deploy`** — promote built artifacts via the admin `POST /v1/allma/import` route (`ALLMA_ADMIN_TOKEN` bearer), optional `--publish`. Honors the importer's version-slot contract and surfaces per-item errors. Pure `planDeploy`/`executeDeploy` + injected adapter (mirrors `detectDrift`); **no network in tests**.
- **`flowContext<Ctx>()`** — opt-in typed-context for JSONPath args (bounded recursion depth 3), turning a stale context path into a compile error. Default `jp`/`inputs`/`outputs` stay plain `string`.
- **Docs** — new how-to (`authoring-flows-in-code`) + reference (`flow-builder-reference`) pages, wired into the sidebar; README + samples updated.

### Grounding note worth a look in review
Unlike flows (stamped by `applyFlowImportDefaults`), the deploy validator parses prompts/step-defs/MCP **directly** against schemas that **require** `createdAt`/`updatedAt`. So these artifacts emit a fixed placeholder `1970-01-01T00:00:00.000Z` — byte-stable for the drift check **and** deploy-valid; the server overwrites it on import.

### TS7056 / type-cost
Per-leaf field overrides only (no union instantiation); typed-context is opt-in and depth-bounded. Type-cost guard: **151k / 400k instantiations** (baseline ~105k). A dedicated `tsconfig.typetest.json` compiles `*.typetest.ts` compile-fail fixtures to prove typo detection.

### Verification
- `@allma/flow-builder`: **69 tests pass** (47 prior + 22 new), lint clean, type-cost green, eject round-trips with typed refs, end-to-end CLI build/check/deploy smoke-tested.
- Docs build clean (`onBrokenLinks: throw`).
- **Full monorepo `turbo build lint test`: 25/25 tasks, exit 0** — no Phase 0/1/2 regressions.

### Changesets
- `@allma/flow-builder`: **minor**
- docs site: **empty** (private/unpublished)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
