### PR TITLE
chore: enable Dependabot for npm + GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      aws-sdk:
+        patterns:
+          - "@aws-sdk/*"
+      aws-cdk:
+        patterns:
+          - "aws-cdk*"
+          - "@aws-cdk/*"
+          - "cdk-nag"
+      langchain:
+        patterns:
+          - "@langchain/*"
+          - "langchain"
+
+  - package-ecosystem: "npm"
+    directory: "/allma.cdk"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      aws-cdk:
+        patterns:
+          - "aws-cdk*"
+          - "@aws-cdk/*"
+
+  - package-ecosystem: "npm"
+    directory: "/docs.allma.dev"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      docusaurus:
+        patterns:
+          - "@docusaurus/*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

Enable Dependabot on the `allma-core` repo so vulnerable transitive dependencies surface as PRs (the lockfiles live here, so this is where Dependabot actually has teeth).

## What it watches

| Ecosystem | Directory | Why |
|-----------|-----------|-----|
| `npm` | `/` | Workspace root — covers root `package.json` + `packages/*` via npm workspaces |
| `npm` | `/allma.cdk` | Independent install root with its own `package-lock.json` |
| `npm` | `/docs.allma.dev` | Independent install root with its own `package-lock.json` |
| `github-actions` | `/` | Workflow versions |

Each npm entry sets `open-pull-requests-limit: 5` and groups noisy ecosystems (`@aws-sdk/*`, `aws-cdk*`/`@aws-cdk/*`/`cdk-nag`, `@langchain/*`/`langchain`, `@docusaurus/*`) to keep PR volume reasonable.

`examples/*` workspaces are gitignored in this repo, so Dependabot won't see them — they're managed in their own repos (see [Symanty/OptiroqAllma#63](https://github.com/Symanty/OptiroqAllma/pull/63) for an example mirroring the same pattern downstream).

## Why now

`npm audit` at this repo's root currently reports 45 vulnerabilities (37 moderate, 6 high, 2 critical). Many are transitive — exactly the kind of thing Dependabot scans the lockfile for and the consumer repos can't see (their lockfiles don't exist; this is the only one). Enabling here means alerts and remediation PRs flow into one place.

## Scope

- Pure repo automation config. No package source touched, no behavior change.
- No changeset added — no published `@allma/*` package is affected by this file.

## Test plan

- [x] `.github/dependabot.yml` is valid YAML (verified via js-yaml).
- [x] Each `directory:` exists in the repo and has a `package.json` / install root.
- [x] Group patterns match real dependencies present in those install roots.
- [ ] Once merged, watch for the first batch of Dependabot PRs and confirm grouping is working as intended.