### PR TITLE
fix(flow-engine): prevent Runtime.OutOfMemory on sub-flow return

### DIFF
--- a/.changeset/fix-subflow-return-oom.md
+++ b/.changeset/fix-subflow-return-oom.md
@@ -1,0 +1,23 @@
+---
+"@allma/core-sdk": minor
+"@allma/core-cdk": patch
+---
+
+Fix `Runtime.OutOfMemory` when returning from a sub-flow whose output mixes inline fields with
+S3-offloaded (`_s3_output_pointer`) values.
+
+The template renderer used to hydrate the **entire** context on every `render()` call
+(`hydrateInputFromS3Pointers`), so rendering even a one-token template (an ARN, a URL, a flow id)
+pulled every offloaded blob in the context back into Lambda memory at once — undoing the offloading
+the sub-flow performed to stay small. `renderNestedTemplates` amplified this by rendering each field
+of a step's config in parallel, each re-hydrating the whole context concurrently, which is what
+exhausted memory even when the returned `steps_output` looked small.
+
+`TemplateService.render()` now statically inspects the Handlebars template and hydrates only the S3
+pointers the template actually references, leaving unreferenced offloaded branches as pointers. It
+falls back to full hydration only for constructs whose data dependencies can't be resolved
+statically (block helpers, `../`, `@root`, bare `this`) — so behavior is unchanged for those.
+
+`@allma/core-sdk` adds an optional `S3HydrationCache` (and `resolveS3PointerCached`) that
+`hydrateInputFromS3Pointers` accepts; a single cache is now shared across all fields of a config so a
+pointer referenced by many fields is downloaded once instead of once per field.

--- a/packages/app-logic/src/allma-core/template-service.ts
+++ b/packages/app-logic/src/allma-core/template-service.ts
@@ -1,7 +1,15 @@
 import Handlebars from 'handlebars';
 import { JSONPath } from 'jsonpath-plus';
 import { MappingEvent, MappingEventStatus, MappingEventType, TemplateContextMappingItem, isS3OutputPointerWrapper } from '@allma/core-types';
-import { log_debug, log_warn, resolveS3Pointer, hydrateInputFromS3Pointers } from '@allma/core-sdk';
+import {
+  log_debug,
+  log_warn,
+  hydrateInputFromS3Pointers,
+  resolveS3PointerCached,
+  deepMerge,
+  isObject,
+  type S3HydrationCache,
+} from '@allma/core-sdk';
 import { getSmartValueByJsonPath } from './data-mapper.js'; // Import the smart resolver
 
 /**
@@ -41,10 +49,23 @@ export class TemplateService {
         template: string,
         context: Record<string, any>,
         correlationId?: string,
+        cache?: S3HydrationCache,
     ): Promise<string> {
-        // Hydrate the entire context to resolve any S3 pointers before rendering.
-        const hydratedContext = await hydrateInputFromS3Pointers(context, correlationId);
-        
+        // Handlebars is synchronous, so any S3 pointers referenced by the template must be resolved
+        // up front. The naive approach — hydrating the *entire* context — is catastrophic when the
+        // context carries offloaded payloads it doesn't reference (e.g. a sub-flow return whose
+        // fields were offloaded to S3): rendering a one-token template like an ARN would pull every
+        // offloaded blob back into memory at once, defeating the offloading and risking OutOfMemory.
+        //
+        // Instead we statically inspect the template and hydrate only the pointers it actually
+        // references, leaving unreferenced offloaded branches as pointers. We fall back to full
+        // hydration only for constructs whose data dependencies can't be resolved statically.
+        const hydrationCache: S3HydrationCache = cache ?? new Map();
+        const { paths, needsFullContext } = this.analyzeTemplatePaths(template);
+        const hydratedContext = needsFullContext
+            ? await hydrateInputFromS3Pointers(context, correlationId, hydrationCache)
+            : await this.hydrateReferencedPaths(context, paths, hydrationCache, correlationId);
+
         const compiledTemplate = this.handlebars.compile(template, {
             noEscape: true, // We are not generating HTML, so we don't need escaping.
             strict: false,  // Be lenient with missing properties, they'll just be empty.
@@ -60,6 +81,173 @@ export class TemplateService {
         
         // Coerce other types (number, boolean) to string, which is the expected behavior.
         return String(result ?? '');
+    }
+
+    /**
+     * Statically inspects a Handlebars template to determine which context paths it references.
+     *
+     * Returns the concrete top-level paths the template reads (so the caller can hydrate only those
+     * S3 pointers) and a `needsFullContext` flag. The flag is set — meaning the caller must fall
+     * back to hydrating the whole context — whenever the template uses a construct whose data
+     * dependencies can't be resolved statically: block helpers (`#each`/`#with`/…) that rebind the
+     * inner scope, parent-context references (`../`), `@root`, a bare `this`/`.`, partials, or any
+     * node type we don't explicitly understand. This keeps the optimization strictly correctness-
+     * preserving: in the worst case we hydrate exactly as much as the previous implementation did.
+     */
+    private analyzeTemplatePaths(template: string): { paths: string[][]; needsFullContext: boolean } {
+        const paths: string[][] = [];
+        const state = { needsFullContext: false };
+
+        let ast: hbs.AST.Program;
+        try {
+            ast = this.handlebars.parse(template);
+        } catch {
+            // Malformed template: compile() will surface the error. Hydrate fully to be safe.
+            return { paths: [], needsFullContext: true };
+        }
+
+        const recordPath = (path: hbs.AST.PathExpression): void => {
+            if (path.data) {
+                // `@`-variable. Only `@root` reaches the whole context; loop metadata (`@index`,
+                // `@key`, `@first`, …) carries no context data dependency.
+                if (path.parts[0] === 'root') state.needsFullContext = true;
+                return;
+            }
+            if ((path.depth ?? 0) > 0) {
+                // `../` parent-scope reference — not statically resolvable to an absolute path.
+                state.needsFullContext = true;
+                return;
+            }
+            if (!path.parts || path.parts.length === 0) {
+                // Bare `this` / `.` — references the entire current scope.
+                state.needsFullContext = true;
+                return;
+            }
+            paths.push(path.parts);
+        };
+
+        const walkExpression = (expr: hbs.AST.Expression | undefined): void => {
+            if (!expr) return;
+            if (expr.type === 'PathExpression') {
+                recordPath(expr as hbs.AST.PathExpression);
+            } else if (expr.type === 'SubExpression') {
+                walkCall(expr as hbs.AST.SubExpression);
+            }
+            // Literals carry no data dependency.
+        };
+
+        const walkCall = (node: hbs.AST.MustacheStatement | hbs.AST.SubExpression): void => {
+            const hasArgs =
+                (node.params && node.params.length > 0) ||
+                (node.hash && node.hash.pairs && node.hash.pairs.length > 0);
+            if (hasArgs) {
+                // A helper invocation: `node.path` is the helper *name*, not a data path. Its data
+                // dependencies live in the params and hash values.
+                for (const param of node.params) walkExpression(param);
+                if (node.hash) for (const pair of node.hash.pairs) walkExpression(pair.value);
+            } else {
+                // Plain interpolation `{{a.b.c}}`: `node.path` is the data path itself.
+                walkExpression(node.path);
+            }
+        };
+
+        const walkStatement = (node: hbs.AST.Statement | hbs.AST.Program): void => {
+            switch (node.type) {
+                case 'Program':
+                    for (const stmt of (node as hbs.AST.Program).body) walkStatement(stmt);
+                    break;
+                case 'ContentStatement':
+                case 'CommentStatement':
+                    break;
+                case 'MustacheStatement':
+                    walkCall(node as hbs.AST.MustacheStatement);
+                    break;
+                case 'BlockStatement':
+                    // Block helpers rebind the inner scope, so references inside the block body
+                    // can't be mapped back to absolute context paths. Be conservative.
+                    state.needsFullContext = true;
+                    break;
+                default:
+                    // Partials, decorators, and anything unrecognized: hydrate fully.
+                    state.needsFullContext = true;
+            }
+        };
+
+        walkStatement(ast);
+        return { paths, needsFullContext: state.needsFullContext };
+    }
+
+    /**
+     * Produces a context in which S3 pointers along/under the given referenced paths are resolved,
+     * while every unreferenced branch is passed through untouched (its pointers are never
+     * downloaded). Intermediate objects are shallow-cloned so the caller's context is never mutated.
+     */
+    private async hydrateReferencedPaths(
+        context: Record<string, any>,
+        paths: string[][],
+        cache: S3HydrationCache,
+        correlationId?: string,
+    ): Promise<Record<string, any>> {
+        // Each pass returns a fresh top-level clone with one referenced path hydrated, carrying the
+        // previously-hydrated branches forward by reference. Shared path prefixes are simply
+        // re-cloned (cheap) and the pointer cache guarantees no blob is fetched twice.
+        let result: any = context;
+        for (const parts of paths) {
+            result = await this.hydrateNodeAtPath(result, parts, cache, correlationId);
+        }
+        return result;
+    }
+
+    /**
+     * Walks `node` along `parts`, resolving S3 pointers encountered en route, and fully hydrates the
+     * subtree at the target. Returns a shallow-cloned copy along the traversed path; sibling branches
+     * are preserved by reference so their pointers stay unresolved.
+     */
+    private async hydrateNodeAtPath(
+        node: any,
+        parts: string[],
+        cache: S3HydrationCache,
+        correlationId?: string,
+    ): Promise<any> {
+        // A pointer at this level must be resolved before we can descend (or to become the target).
+        if (isS3OutputPointerWrapper(node)) {
+            const resolved = await resolveS3PointerCached(node._s3_output_pointer, correlationId, cache);
+            const { _s3_output_pointer, ...otherKeys } = node;
+            if (Object.keys(otherKeys).length === 0) {
+                node = resolved;
+            } else {
+                const hydratedOther = await hydrateInputFromS3Pointers(otherKeys, correlationId, cache);
+                node = isObject(resolved) ? deepMerge(resolved, hydratedOther) : { content: resolved, ...hydratedOther };
+            }
+        }
+
+        if (parts.length === 0) {
+            // Target reached: hydrate everything beneath it (the template may read the whole subtree).
+            return hydrateInputFromS3Pointers(node, correlationId, cache);
+        }
+
+        const [head, ...rest] = parts;
+
+        if (Array.isArray(node)) {
+            const index = Number(head);
+            if (Number.isInteger(index) && index >= 0 && index < node.length) {
+                const clone = [...node];
+                clone[index] = await this.hydrateNodeAtPath(node[index], rest, cache, correlationId);
+                return clone;
+            }
+            // A non-numeric segment against an array (e.g. `items.name` used loosely): the referenced
+            // property may exist on any element, so descend into each.
+            return Promise.all(node.map(item => this.hydrateNodeAtPath(item, parts, cache, correlationId)));
+        }
+
+        if (isObject(node) && Object.prototype.hasOwnProperty.call(node, head)) {
+            const clone = { ...node };
+            clone[head] = await this.hydrateNodeAtPath(node[head], rest, cache, correlationId);
+            return clone;
+        }
+
+        // Referenced key is absent (or node is a primitive): nothing to hydrate.
+        return node;
     }
 
   /**

--- a/packages/app-logic/src/allma-core/utils/template-renderer.ts
+++ b/packages/app-logic/src/allma-core/utils/template-renderer.ts
@@ -1,4 +1,4 @@
-import { log_error, log_warn, isObject } from '@allma/core-sdk';
+import { log_error, log_warn, isObject, type S3HydrationCache } from '@allma/core-sdk';
 import { JSONPath } from 'jsonpath-plus';
 import { TemplateService } from '../template-service.js';
 import { getSmartValueByJsonPath } from '../data-mapper.js';
@@ -19,14 +19,14 @@ import { getSmartValueByJsonPath } from '../data-mapper.js';
  * @param correlationId Optional correlation ID for logging.
  * @returns The final, rendered value.
  */
-async function renderValue(value: any, contextData: Record<string, any>, correlationId?: string): Promise<any> {
+async function renderValue(value: any, contextData: Record<string, any>, correlationId?: string, cache?: S3HydrationCache): Promise<any> {
     // For non-string values, recurse into arrays/objects or return primitives as is.
     if (typeof value !== 'string') {
         if (Array.isArray(value)) {
-            return Promise.all(value.map(item => renderValue(item, contextData, correlationId)));
+            return Promise.all(value.map(item => renderValue(item, contextData, correlationId, cache)));
         }
         if (isObject(value)) {
-            return await renderNestedTemplates(value as Record<string, any>, contextData, correlationId);
+            return await renderNestedTemplates(value as Record<string, any>, contextData, correlationId, cache);
         }
         return value; // Primitives like numbers, booleans, null
     }
@@ -36,9 +36,11 @@ async function renderValue(value: any, contextData: Record<string, any>, correla
     const templateService = TemplateService.getInstance();
 
     // Pass 1: Render any Handlebars templates within the string.
-    // This resolves `{{...}}` placeholders.
+    // This resolves `{{...}}` placeholders. The shared cache ensures that when many fields of the
+    // same config reference the same offloaded (S3-pointer) value, it is downloaded once rather
+    // than re-hydrated per field — the difference between bounded memory and OutOfMemory.
     if (processedValue.includes('{{')) {
-        processedValue = await templateService.render(processedValue, contextData, correlationId);
+        processedValue = await templateService.render(processedValue, contextData, correlationId, cache);
     }
     
     // Pass 2: Check if the *entire resulting string* is a JSONPath expression.
@@ -56,7 +58,7 @@ async function renderValue(value: any, contextData: Record<string, any>, correla
             // The result of the JSONPath might itself be another template string that needs rendering.
             // We recurse, but prevent infinite loops if a path resolves to itself.
             if (typeof resolved === 'string' && resolved !== processedValue) {
-                return renderValue(resolved, contextData, correlationId);
+                return renderValue(resolved, contextData, correlationId, cache);
             }
             
             return resolved;
@@ -83,17 +85,23 @@ async function renderValue(value: any, contextData: Record<string, any>, correla
  * @param correlationId Optional correlation ID for logging.
  * @returns A new object with all template strings rendered.
  */
-export async function renderNestedTemplates(obj: Record<string, any> | undefined, contextData: Record<string, any>, correlationId?: string): Promise<Record<string, any> | undefined> {
+export async function renderNestedTemplates(obj: Record<string, any> | undefined, contextData: Record<string, any>, correlationId?: string, cache?: S3HydrationCache): Promise<Record<string, any> | undefined> {
   if (!obj) return undefined;
 
   const renderedObj: Record<string, any> = {};
-  
+
+  // All fields of one config are rendered against the same context, so they share a single
+  // S3-hydration cache: a pointer resolved for one field is reused by the others instead of being
+  // fetched concurrently N times. A fresh cache is created for the top-level call and threaded
+  // through nested objects/arrays.
+  const hydrationCache: S3HydrationCache = cache ?? new Map();
+
   // Process keys in parallel
   const keys = Object.keys(obj);
   const values = Object.values(obj);
-  
+
   const renderedValues = await Promise.all(
-      values.map(v => renderValue(v, contextData, correlationId))
+      values.map(v => renderValue(v, contextData, correlationId, hydrationCache))
   );
 
   for (let i = 0; i < keys.length; i++) {

--- a/packages/app-logic/tests/unit/allma-core/template-service.test.ts
+++ b/packages/app-logic/tests/unit/allma-core/template-service.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3';
 import { MappingEventStatus, MappingEventType, type TemplateContextMappingItem } from '@allma/core-types';
 import { TemplateService } from '../../../src/allma-core/template-service.js';
+import { renderNestedTemplates } from '../../../src/allma-core/utils/template-renderer.js';
 import { mockClient, resetAwsClientMocks } from '../_helpers/aws-mock.js';
 
 /**
@@ -95,6 +96,73 @@ describe('TemplateService.render — S3-aware context', () => {
     s3Json({ name: 'Ada' });
     const out = await svc.render('Hi {{user.name}}', { user: { _s3_output_pointer: { bucket: 'b', key: 'k' } } }, cid);
     expect(out).toBe('Hi Ada');
+    expect(s3Mock).toHaveReceivedCommandTimes(GetObjectCommand, 1);
+  });
+
+  it('does NOT hydrate offloaded pointers the template never references', async () => {
+    // Regression guard: a sub-flow return is a mix of inline fields and S3 pointers. Rendering a
+    // template that touches only one small field must not pull every offloaded blob into memory
+    // (the cause of Runtime.OutOfMemory on sub-flow return).
+    s3Json({ huge: 'x'.repeat(1000) });
+    const context = {
+      steps_output: {
+        extract_subflow_output: {
+          smallField: 'ok',
+          bigFieldA: { _s3_output_pointer: { bucket: 'b', key: 'a' } },
+          bigFieldB: { _s3_output_pointer: { bucket: 'b', key: 'c' } },
+        },
+      },
+    };
+    const out = await svc.render('value={{steps_output.extract_subflow_output.smallField}}', context, cid);
+    expect(out).toBe('value=ok');
+    // Neither offloaded field was referenced, so neither was downloaded.
+    expect(s3Mock).toHaveReceivedCommandTimes(GetObjectCommand, 0);
+  });
+
+  it('hydrates only the referenced offloaded field, leaving siblings as pointers', async () => {
+    s3Json({ text: 'resolved' });
+    const context = {
+      steps_output: {
+        sub: {
+          wanted: { _s3_output_pointer: { bucket: 'b', key: 'wanted' } },
+          ignored: { _s3_output_pointer: { bucket: 'b', key: 'ignored' } },
+        },
+      },
+    };
+    const out = await svc.render('{{steps_output.sub.wanted.text}}', context, cid);
+    expect(out).toBe('resolved');
+    expect(s3Mock).toHaveReceivedCommandTimes(GetObjectCommand, 1);
+  });
+
+  it('falls back to full hydration for whole-context constructs (block helpers)', async () => {
+    // `#each` rebinds scope, so referenced paths cannot be resolved statically; we conservatively
+    // hydrate the whole context — matching the original behavior for such templates.
+    s3Json({ v: 'z' });
+    const context = {
+      items: [
+        { _s3_output_pointer: { bucket: 'b', key: 'i0' } },
+        { _s3_output_pointer: { bucket: 'b', key: 'i1' } },
+      ],
+    };
+    const out = await svc.render('{{#each items}}{{this.v}}{{/each}}', context, cid);
+    expect(out).toBe('zz');
+    expect(s3Mock).toHaveReceivedCommandTimes(GetObjectCommand, 2);
+  });
+});
+
+describe('renderNestedTemplates — shared hydration cache', () => {
+  it('downloads a pointer shared by many fields only once', async () => {
+    // The amplifier fix: a config whose fields all reference the same offloaded value must fetch
+    // it once, not once per field (concurrent per-field re-hydration is what exhausts memory).
+    s3Json({ val: 'V' });
+    const context = { shared: { _s3_output_pointer: { bucket: 'b', key: 'shared' } } };
+    const config = {
+      a: 'A={{shared.val}}',
+      b: 'B={{shared.val}}',
+      c: 'C={{shared.val}}',
+    };
+    const rendered = await renderNestedTemplates(config, context, cid);
+    expect(rendered).toEqual({ a: 'A=V', b: 'B=V', c: 'C=V' });
     expect(s3Mock).toHaveReceivedCommandTimes(GetObjectCommand, 1);
   });
 });

--- a/packages/core-sdk/src/hydrationUtils.ts
+++ b/packages/core-sdk/src/hydrationUtils.ts
@@ -1,25 +1,63 @@
 import { resolveS3Pointer } from './s3Utils.js';
 import { isS3OutputPointerWrapper } from '@allma/core-types';
+import type { S3Pointer } from '@allma/core-types';
 import { deepMerge, isObject } from './objectUtils.js';
 
 /**
- * Recursively traverses an object or array and resolves any S3 pointers it finds.
+ * A short-lived memoization cache for S3 pointer resolutions, keyed by bucket/key/version.
+ * Sharing one cache across a single logical operation (e.g. rendering every field of a step's
+ * config) ensures a pointer referenced by many fields is downloaded once instead of N times —
+ * which is what turns a modestly-sized offloaded payload into a `Runtime.OutOfMemory` when it is
+ * re-hydrated concurrently per field. Values are the in-flight/resolved promises so concurrent
+ * callers coalesce onto a single request.
  */
-export async function hydrateInputFromS3Pointers(data: any, correlationId?: string): Promise<any> {
+export type S3HydrationCache = Map<string, Promise<any>>;
+
+const pointerCacheKey = (pointer: S3Pointer): string =>
+  `${pointer.bucket}#${pointer.key}#${pointer.versionId ?? ''}`;
+
+/**
+ * Resolves an S3 pointer, coalescing duplicate/concurrent resolutions through the provided cache.
+ * When no cache is supplied it behaves exactly like {@link resolveS3Pointer}.
+ */
+export async function resolveS3PointerCached(
+  pointer: S3Pointer,
+  correlationId?: string,
+  cache?: S3HydrationCache,
+): Promise<any> {
+  if (!cache) {
+    return resolveS3Pointer(pointer, correlationId);
+  }
+  const key = pointerCacheKey(pointer);
+  let pending = cache.get(key);
+  if (!pending) {
+    pending = resolveS3Pointer(pointer, correlationId);
+    cache.set(key, pending);
+  }
+  return pending;
+}
+
+/**
+ * Recursively traverses an object or array and resolves any S3 pointers it finds.
+ *
+ * Pass a {@link S3HydrationCache} to deduplicate repeated pointers within a single hydration pass
+ * (and across sibling passes that share the same cache).
+ */
+export async function hydrateInputFromS3Pointers(data: any, correlationId?: string, cache?: S3HydrationCache): Promise<any> {
     if (Array.isArray(data)) {
-      return Promise.all(data.map(item => hydrateInputFromS3Pointers(item, correlationId)));
+      return Promise.all(data.map(item => hydrateInputFromS3Pointers(item, correlationId, cache)));
     }
     if (isS3OutputPointerWrapper(data)) {
-      // Core engine operations using hydration inherently need full data without size limits 
-      const resolvedData = await resolveS3Pointer(data._s3_output_pointer, correlationId);
+      // Core engine operations using hydration inherently need full data without size limits
+      const resolvedData = await resolveS3PointerCached(data._s3_output_pointer, correlationId, cache);
       const { _s3_output_pointer, ...otherKeys } = data;
-      
+
       let mergedData = resolvedData;
       if (Object.keys(otherKeys).length > 0) {
-          // Hydrate the other keys just in case they contain nested pointers, 
+          // Hydrate the other keys just in case they contain nested pointers,
           // but AVOID recursing into the potentially massive resolved S3 data.
-          const hydratedOtherKeys = await hydrateInputFromS3Pointers(otherKeys, correlationId);
-          
+          const hydratedOtherKeys = await hydrateInputFromS3Pointers(otherKeys, correlationId, cache);
+
           // Use deepMerge to prevent shallow overwriting of nested objects like 'triggeringEmail'
           if (isObject(resolvedData)) {
               mergedData = deepMerge(resolvedData, hydratedOtherKeys);
@@ -27,14 +65,14 @@ export async function hydrateInputFromS3Pointers(data: any, correlationId?: stri
               mergedData = { content: resolvedData, ...hydratedOtherKeys };
           }
       }
-      
+
       return mergedData;
     }
     if (isObject(data)) {
       const hydratedObject: Record<string, any> = {};
       for (const key in data) {
         if (Object.prototype.hasOwnProperty.call(data, key)) {
-          hydratedObject[key] = await hydrateInputFromS3Pointers(data[key], correlationId);
+          hydratedObject[key] = await hydrateInputFromS3Pointers(data[key], correlationId, cache);
         }
       }
       return hydratedObject;


### PR DESCRIPTION
## Problem

A flow that triggers a sub-flow and consumes its return fails with `Runtime.OutOfMemory` in the orchestrator Lambda — **even when the sub-flow's output was offloaded to S3** and its `steps_output` "looks like only ~1000 lines".

## Root cause

It's the **template renderer re-inflating the whole context**, not the sub-flow merge.

A sub-flow offloads its large fields to S3, so its return is a **mix of small inline fields and `_s3_output_pointer` stubs**. That mix is stored into the parent context cheaply (pointers intact). But then:

- `TemplateService.render()` called `hydrateInputFromS3Pointers(context)` on **every** render — recursively resolving *every* pointer in the whole context, regardless of what the template referenced. Rendering a one-token template (a Lambda ARN, an API URL, a flow id) pulled *every* offloaded blob back into Lambda heap at once, undoing the sub-flow's offloading.
- `renderNestedTemplates` **amplified** it: it renders each config field in parallel, each calling `render()` → K concurrent full re-hydrations of the whole context ⇒ K× every blob resident simultaneously ⇒ `Runtime.OutOfMemory`.

This is why S3 offload didn't help: it only bounds the Step Functions 256KB transport limit; `render()` re-materialized everything in RAM on the next step.

## Fix

1. **Selective hydration** (`template-service.ts`): `render()` statically parses the Handlebars AST, collects the paths the template actually references, and hydrates **only those** pointers — unreferenced offloaded branches stay as pointers and are never downloaded. Falls back to full hydration only for constructs whose deps can't be resolved statically (`#each`/`#with`, `../`, `@root`, bare `this`), so behavior is unchanged for those.
2. **Shared dedup cache** (`hydrationUtils.ts` + `template-renderer.ts`): a new optional `S3HydrationCache` is threaded through `hydrateInputFromS3Pointers`, and `renderNestedTemplates` shares one cache across all fields, so a pointer referenced by many fields is fetched once — killing the K× amplifier.

## Tests

New unit tests in `template-service.test.ts`:
- unreferenced offloaded pointers are **not** downloaded (0 GETs),
- only the referenced field hydrates (1 GET), siblings stay pointers,
- block-helper templates fall back to full hydration,
- a pointer shared across many config fields is fetched once (dedup).

All **490** app-logic unit tests pass; typecheck + ESLint clean on changed files; both packages build.

## Changesets

- `@allma/core-sdk`: **minor** (new optional `S3HydrationCache` / `resolveS3PointerCached` API)
- `@allma/core-cdk`: **patch** (bundled app-logic behavior fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1aNR7XWozRGSGzUX77Wgn