### PR TITLE
fix(core-cdk): raise InitializeFlow/FinalizeFlow lambda memory to prevent Runtime.OutOfMemory

### DIFF
--- a/.changeset/finalize-flow-memory.md
+++ b/.changeset/finalize-flow-memory.md
@@ -1,0 +1,17 @@
+---
+"@allma/core-cdk": minor
+---
+
+Give the InitializeFlow and FinalizeFlow lambdas dedicated, larger memory allocations to prevent
+`Runtime.OutOfMemory`.
+
+Both lambdas materialize the entire flow context in memory — Finalize hydrates the (often
+S3-offloaded) context, `JSON.stringify`s it, and re-offloads it; Initialize resolves the initial
+context pointer — yet they ran at the 256 MB `default`, while the `IterativeStepProcessor` that
+builds the very same context runs at 2048 MB. For flows with large contexts (e.g. sub-flows that
+accumulate sizeable `steps_output`), Finalize would OOM at 256 MB when returning.
+
+Adds `lambdaMemorySizes.initializeFlow` (default 1024 MB) and `lambdaMemorySizes.finalizeFlow`
+(default 2048 MB, matching the step processor) to the stage config, and wires them into the two
+lambdas. Both are overridable per stage. Existing stage configs are unaffected — the new keys are
+deep-merged from the defaults.

--- a/packages/core-cdk/lib/config/default-config.ts
+++ b/packages/core-cdk/lib/config/default-config.ts
@@ -40,6 +40,12 @@ export const defaultConfig: StageConfig = {
   lambdaMemorySizes: {
     default: 256,
     iterativeStepProcessor: 2048,
+    // Initialize/Finalize hold the whole flow context in memory (hydrated from S3 when offloaded)
+    // and re-serialize it, so they need headroom well beyond the 256 MB default. Finalize matches
+    // the step processor since it handles the same fully-accumulated context; Initialize is a touch
+    // lower as initial inputs are typically smaller (but still far above 256 MB for safety).
+    initializeFlow: 1024,
+    finalizeFlow: 2048,
     adminApiHandler: 256,
     flowStartRequestListener: 256,
     crawlerWorker: 3008,

--- a/packages/core-cdk/lib/config/stack-config.ts
+++ b/packages/core-cdk/lib/config/stack-config.ts
@@ -158,6 +158,15 @@ export interface StageConfig {
   lambdaMemorySizes: {
     default: number;
     iterativeStepProcessor: number;
+    /**
+     * Memory for the InitializeFlow and FinalizeFlow lambdas. Both materialize the entire flow
+     * context in memory (resolving it from S3 when it was offloaded) and re-serialize it, so — like
+     * {@link iterativeStepProcessor} — they need far more than the `default` 256 MB for flows with
+     * large contexts (e.g. sub-flows that accumulate sizeable `steps_output`). Under-provisioning
+     * here surfaces as `Runtime.OutOfMemory` in AllmaFinalizeFlow / AllmaInitializeFlow.
+     */
+    initializeFlow: number;
+    finalizeFlow: number;
     adminApiHandler: number;
     flowStartRequestListener: number;
     crawlerWorker: number;

--- a/packages/core-cdk/lib/constructs/compute.ts
+++ b/packages/core-cdk/lib/constructs/compute.ts
@@ -181,7 +181,9 @@ export class AllmaCompute extends Construct {
     }));
 
     // --- InitializeFlowExecutionLambda ---
-    this.initializeFlowLambda = this.createNodejsLambda('InitializeFlowLambda', `AllmaInitializeFlow-${stageConfig.stage}`, 'allma-flows/initialize-flow.js', this.orchestrationLambdaRole, defaultLambdaTimeout, defaultLambdaMemory, commonEnvVars);
+    // Initialize resolves the (possibly S3-offloaded) initial context into memory, so it needs more
+    // than the 256 MB default for large inputs — see lambdaMemorySizes.initializeFlow.
+    this.initializeFlowLambda = this.createNodejsLambda('InitializeFlowLambda', `AllmaInitializeFlow-${stageConfig.stage}`, 'allma-flows/initialize-flow.js', this.orchestrationLambdaRole, defaultLambdaTimeout, stageConfig.lambdaMemorySizes.initializeFlow, commonEnvVars);
 
     // --- IterativeStepProcessorLambda ---
     const iterativeStepProcessorMemory = stageConfig.lambdaMemorySizes.iterativeStepProcessor;
@@ -211,7 +213,10 @@ export class AllmaCompute extends Construct {
     );
 
     // --- FinalizeFlowExecutionLambda ---
-    this.finalizeFlowLambda = this.createNodejsLambda('FinalizeFlowLambda', `AllmaFinalizeFlow-${stageConfig.stage}`, 'allma-flows/finalize-flow.js', this.orchestrationLambdaRole, defaultLambdaTimeout, defaultLambdaMemory, commonEnvVars);
+    // Finalize hydrates the entire (possibly S3-offloaded) flow context and re-serializes it, doing
+    // the same context-materialization the step processor does — so it is provisioned to match,
+    // not left at the 256 MB default (which caused Runtime.OutOfMemory). See lambdaMemorySizes.finalizeFlow.
+    this.finalizeFlowLambda = this.createNodejsLambda('FinalizeFlowLambda', `AllmaFinalizeFlow-${stageConfig.stage}`, 'allma-flows/finalize-flow.js', this.orchestrationLambdaRole, defaultLambdaTimeout, stageConfig.lambdaMemorySizes.finalizeFlow, commonEnvVars);
 
     // --- ResumeFlowLambda ---
     const resumeFlowLambdaRole = new iam.Role(this, 'AllmaResumeFlowLambdaRole', {


### PR DESCRIPTION
## Problem

After deploying the template-hydration fix (#76), a sub-flow return still failed — but now in a **different Lambda**, `AllmaFinalizeFlow`, with `Runtime.OutOfMemory` at **256 MB**:

```
INFO Hydrating offloaded context in FinalizeFlow.
INFO Resolving S3 data pointer ... flow_state/<id>/end_...json
REPORT ... Memory Size: 256 MB  Max Memory Used: 256 MB  Status: error  Error Type: Runtime.OutOfMemory
```

## Root cause — memory asymmetry in the orchestration trio

`FinalizeFlow` (and `InitializeFlow`) ran at the **256 MB** `default`, while the `IterativeStepProcessor` that builds the *same* flow context runs at **2048 MB**:

| Lambda | Work | Memory (before) |
|---|---|---|
| `IterativeStepProcessor` | builds/holds the full context | 2048 MB |
| `FinalizeFlow` | hydrates full context from S3 → `JSON.stringify` → re-offload | **256 MB** ← OOM |
| `InitializeFlow` | resolves initial context from S3 → offload | 256 MB (same latent risk) |

`finalize-flow.ts` hydrates the entire (offloaded) context into memory, serializes it to measure size, then offloads it again (another serialize + upload) — the same context-materialization the step processor does, at 1/8th the memory. A flow with a large accumulated `steps_output` exhausts 256 MB.

## Fix

Add dedicated, tunable memory for the two lambdas and wire them in:

- `lambdaMemorySizes.finalizeFlow` → **2048 MB** (matches the step processor; it handles the same fully-accumulated context)
- `lambdaMemorySizes.initializeFlow` → **1024 MB** (initial inputs are typically smaller, but well above 256 MB for safety)

Both are overridable per stage and deep-merged from the defaults, so **existing stage configs are unaffected**.

## Cost note

These lambdas run **once per execution** (and once per sub-flow), not per step, so the memory-seconds impact is modest compared to the per-step `IterativeStepProcessor`. Any stage can tune the values down via `stageConfig.lambdaMemorySizes`.

## Follow-up (not in this PR)

Finalize currently downloads the offloaded context only to re-upload it to the canonical `final_context/<id>` key. When there are no `onCompletionActions` / resume key, that round-trip could be replaced with an S3 server-side copy (no in-memory materialization), removing the OOM class entirely regardless of context size. Filed as a note for a future change to keep this fix focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1aNR7XWozRGSGzUX77Wgn