### PR TITLE
fix(flow-engine): finalize sub-flows without materializing the whole context

### DIFF
--- a/.changeset/finalize-flow-lazy-hydration.md
+++ b/.changeset/finalize-flow-lazy-hydration.md
@@ -1,0 +1,20 @@
+---
+"@allma/core-cdk": patch
+---
+
+Stop FinalizeFlow from materializing the whole flow context in memory when it isn't needed —
+removing the root cause of `Runtime.OutOfMemory` on large (e.g. sub-flow) returns rather than only
+raising the lambda's memory ceiling.
+
+Previously FinalizeFlow always hydrated the (often S3-offloaded) context, `JSON.stringify`d it, and
+re-offloaded it — even when it only needed to hand back a pointer. It now inspects the incoming
+context without hydrating and takes a fast path: when the context is already offloaded and neither a
+system-level resume nor `onCompletionActions` require it in memory, the existing S3 pointer is passed
+straight through — no download, no re-serialize, no re-offload — so peak memory is independent of
+context size. When resume or completion actions do need the data, it hydrates exactly as before.
+
+To make that decision cheaply (the resume key lives inside the offloaded blob), context offloading is
+centralized in a new `offloadFlowContextIfLarge` helper that preserves a small set of "sticky"
+top-level markers (currently `_flow_resume_key`) alongside the pointer. This also de-duplicates the
+offload-and-wrap pattern that was copy-pasted across the initializer, step processor, and parallel
+handler. No public API or wire-contract changes.

--- a/packages/app-logic/src/allma-core/utils/context-offload.ts
+++ b/packages/app-logic/src/allma-core/utils/context-offload.ts
@@ -1,0 +1,47 @@
+import { offloadIfLarge } from '@allma/core-sdk';
+import { isS3OutputPointerWrapper } from '@allma/core-types';
+
+/**
+ * Top-level `currentContextData` keys that are copied out alongside the S3 pointer when a flow
+ * context is offloaded, so downstream stages can read them WITHOUT hydrating the (potentially huge)
+ * offloaded blob.
+ *
+ * Currently just the system-level resume key: FinalizeFlow uses it to decide whether it must
+ * materialize the whole context in memory. Being able to answer that from the small pointer wrapper
+ * — rather than downloading the blob just to check — is what lets FinalizeFlow avoid holding a large
+ * context in RAM and thus avoid `Runtime.OutOfMemory` on large (e.g. sub-flow) returns.
+ */
+export const STICKY_CONTEXT_MARKER_KEYS = ['_flow_resume_key'] as const;
+
+/**
+ * Offloads a flow's `currentContextData` to S3 when it exceeds `thresholdBytes`, returning either the
+ * original object (when small enough to stay inline) or a pointer wrapper of the shape
+ * `{ _s3_context_pointer, ...stickyMarkers }`.
+ *
+ * This is the single place the orchestrator converts a large in-flight context into a pointer, so it
+ * also carries the {@link STICKY_CONTEXT_MARKER_KEYS} forward. Behaviour is otherwise identical to
+ * the inline `offloadIfLarge` + wrapper construction it replaces.
+ */
+export async function offloadFlowContextIfLarge(
+  currentContextData: Record<string, any>,
+  bucketName: string,
+  keyPrefix: string,
+  correlationId: string,
+  thresholdBytes: number,
+): Promise<Record<string, any>> {
+  const offloaded = await offloadIfLarge(currentContextData, bucketName, keyPrefix, correlationId, thresholdBytes);
+
+  if (offloaded && isS3OutputPointerWrapper(offloaded)) {
+    const wrapper: Record<string, any> = { _s3_context_pointer: offloaded._s3_output_pointer };
+    for (const key of STICKY_CONTEXT_MARKER_KEYS) {
+      const value = currentContextData?.[key];
+      if (value !== undefined) {
+        wrapper[key] = value;
+      }
+    }
+    return wrapper;
+  }
+
+  // Small enough to stay inline — offloadIfLarge returned the original object unchanged.
+  return offloaded as Record<string, any>;
+}

--- a/packages/app-logic/src/allma-flows/finalize-flow.ts
+++ b/packages/app-logic/src/allma-flows/finalize-flow.ts
@@ -1,13 +1,14 @@
 import { Handler } from 'aws-lambda';
 import {
-  FlowRuntimeState, 
-    AllmaError, 
-    ENV_VAR_NAMES, 
-    S3Pointer, 
+  FlowRuntimeState,
+    AllmaError,
+    ENV_VAR_NAMES,
+    S3Pointer,
     JsonPathString,
     ProcessorInput,
     ApiCallDefinition,
     TemplateContextMappingItem,
+    FlowDefinition,
     isS3Pointer,
     isS3OutputPointerWrapper
  } from '@allma/core-types';
@@ -80,30 +81,44 @@ export const handler: Handler<ProcessorInput, FinalizeOutput> = async (event) =>
     const runtimeState = event.runtimeState;
     const correlationId = runtimeState.flowExecutionId;
 
-    // --- HYDRATE STATE IF IT WAS OFFLOADED BY PREVIOUS STEP ---
-    const s3ContextPointer = (runtimeState.currentContextData as any)._s3_context_pointer;
-    if (s3ContextPointer && isS3Pointer(s3ContextPointer)) {
-        log_info('Hydrating offloaded context in FinalizeFlow.', {}, correlationId);
-        try {
-            const fullContext = await resolveS3Pointer(s3ContextPointer, correlationId);
-            runtimeState.currentContextData = { ...fullContext, ...runtimeState.currentContextData };
-            delete (runtimeState.currentContextData as any)._s3_context_pointer;
-        } catch (e: any) {
-            log_error('Failed to hydrate context in FinalizeFlow', { error: e.message }, correlationId);
-        }
-    }
-    // --- END HYDRATION ---
+    // Inspect the incoming context WITHOUT hydrating it. When a previous step offloaded the context
+    // it arrives as a small pointer wrapper that also carries "sticky" markers (see
+    // offloadFlowContextIfLarge) — notably `_flow_resume_key` — so we can decide below whether the
+    // full context actually has to be materialized in memory. Deferring hydration keeps this lambda's
+    // memory flat for the common terminal case (previously it OOM'd on large sub-flow returns).
+    const incomingContext = (runtimeState.currentContextData || {}) as Record<string, any>;
+    const incomingContextPointer = incomingContext._s3_context_pointer as S3Pointer | undefined;
+    const isContextOffloaded = !!incomingContextPointer && isS3Pointer(incomingContextPointer);
+    const resumeKey = incomingContext._flow_resume_key;
+    const resumePossible = typeof resumeKey === 'string' && resumeKey.length > 0;
 
     let finalStatusFromInput: FlowRuntimeState['status'] = runtimeState.status;
-  
+
     if (finalStatusFromInput === 'RUNNING' || finalStatusFromInput === 'INITIALIZING') {
         finalStatusFromInput = runtimeState.errorInfo ? 'FAILED' : 'COMPLETED';
     }
-  
+
     const endTime = new Date().toISOString();
     log_info(`Finalizing flow execution with status: ${finalStatusFromInput}`, { flowExecutionId: correlationId }, correlationId);
-  
-    let finalOutput: FinalizeOutput; 
+
+    // Load the flow definition once, up front: it drives whether onCompletionActions need the full
+    // context (the fast-path decision below) and is reused to run them. A load failure is non-fatal —
+    // expected when a flow failed on a configuration error — and simply means no completion actions.
+    let flowDef: FlowDefinition | undefined;
+    try {
+        flowDef = await loadFlowDefinition(runtimeState.flowDefinitionId, runtimeState.flowDefinitionVersion, correlationId);
+    } catch (e: any) {
+        log_warn('Could not load flow definition during finalization. Proceeding without onCompletionActions (expected if the flow failed due to a configuration error).', { error: e.message }, correlationId);
+    }
+    const completionActions = flowDef?.onCompletionActions ?? [];
+    const hasCompletionActions = completionActions.length > 0;
+
+    // The whole context is only needed in memory for a system-level resume or to feed
+    // onCompletionActions. Otherwise an already-offloaded context is handed straight back as its S3
+    // pointer — no download, no re-serialize, no re-offload.
+    const needsFullContext = resumePossible || hasCompletionActions;
+
+    let finalOutput: FinalizeOutput;
     let finalContextDataS3Pointer: S3Pointer | undefined;
 
     const shouldLog = runtimeState.enableExecutionLogs || finalStatusFromInput === 'FAILED';
@@ -111,41 +126,66 @@ export const handler: Handler<ProcessorInput, FinalizeOutput> = async (event) =>
     try {
       runtimeState.endTime = endTime;
       runtimeState.status = finalStatusFromInput;
-  
-      const contextDataString = JSON.stringify(runtimeState.currentContextData);
-      const isBranch = !!runtimeState.branchId;
-      // Stricter threshold for branch sub-flows to prevent aggregation failures mapped to States.DataLimitExceeded
-      const offloadThreshold = isBranch ? 10 * 1024 : MAX_CONTEXT_DATA_SIZE_BYTES; 
-      
-      // Determine whether to return data inline or via S3 pointer
-      if (Buffer.byteLength(contextDataString, 'utf-8') > offloadThreshold) {
-          log_info(`Final context data is large (${Buffer.byteLength(contextDataString, 'utf-8')} bytes), storing in S3. Threshold: ${offloadThreshold}`, {}, correlationId);
-          
-          const offloadedContext = await offloadIfLarge(
-              runtimeState.currentContextData,
-              EXECUTION_TRACES_BUCKET_NAME,
-              `final_context/${correlationId}`,
-              correlationId,
-              0 // force offload
-          );
 
-          if (offloadedContext && isS3OutputPointerWrapper(offloadedContext)) {
-              finalContextDataS3Pointer = offloadedContext._s3_output_pointer;
-          }
-
+      if (isContextOffloaded && !needsFullContext) {
+          // FAST PATH: the context already lives in S3 and nothing here needs it in memory, so hand
+          // its pointer straight back. No download, no re-serialize, no re-offload — memory stays flat.
+          finalContextDataS3Pointer = incomingContextPointer;
           finalOutput = {
               status: finalStatusFromInput as FinalizeOutput['status'],
               finalContextDataS3Pointer,
               ...(runtimeState.errorInfo && { errorInfo: runtimeState.errorInfo }),
           };
+          log_info('Final context already offloaded and not required in memory; passing the S3 pointer through without hydration.', { pointer: incomingContextPointer }, correlationId);
       } else {
-          finalOutput = {
-              status: finalStatusFromInput as FinalizeOutput['status'],
-              finalContextData: runtimeState.currentContextData, // Return small context directly
-              ...(runtimeState.errorInfo && { errorInfo: runtimeState.errorInfo }),
-          };
+          // Hydrate the offloaded context now that a downstream consumer (resume/onCompletionActions)
+          // actually needs it in memory.
+          if (isContextOffloaded) {
+              log_info('Hydrating offloaded context in FinalizeFlow.', {}, correlationId);
+              try {
+                  const fullContext = await resolveS3Pointer(incomingContextPointer!, correlationId);
+                  runtimeState.currentContextData = { ...fullContext, ...runtimeState.currentContextData };
+                  delete (runtimeState.currentContextData as any)._s3_context_pointer;
+              } catch (e: any) {
+                  log_error('Failed to hydrate context in FinalizeFlow', { error: e.message }, correlationId);
+              }
+          }
+
+          const contextDataString = JSON.stringify(runtimeState.currentContextData);
+          const isBranch = !!runtimeState.branchId;
+          // Stricter threshold for branch sub-flows to prevent aggregation failures mapped to States.DataLimitExceeded
+          const offloadThreshold = isBranch ? 10 * 1024 : MAX_CONTEXT_DATA_SIZE_BYTES;
+
+          // Determine whether to return data inline or via S3 pointer
+          if (Buffer.byteLength(contextDataString, 'utf-8') > offloadThreshold) {
+              log_info(`Final context data is large (${Buffer.byteLength(contextDataString, 'utf-8')} bytes), storing in S3. Threshold: ${offloadThreshold}`, {}, correlationId);
+
+              const offloadedContext = await offloadIfLarge(
+                  runtimeState.currentContextData,
+                  EXECUTION_TRACES_BUCKET_NAME,
+                  `final_context/${correlationId}`,
+                  correlationId,
+                  0 // force offload
+              );
+
+              if (offloadedContext && isS3OutputPointerWrapper(offloadedContext)) {
+                  finalContextDataS3Pointer = offloadedContext._s3_output_pointer;
+              }
+
+              finalOutput = {
+                  status: finalStatusFromInput as FinalizeOutput['status'],
+                  finalContextDataS3Pointer,
+                  ...(runtimeState.errorInfo && { errorInfo: runtimeState.errorInfo }),
+              };
+          } else {
+              finalOutput = {
+                  status: finalStatusFromInput as FinalizeOutput['status'],
+                  finalContextData: runtimeState.currentContextData, // Return small context directly
+                  ...(runtimeState.errorInfo && { errorInfo: runtimeState.errorInfo }),
+              };
+          }
       }
-  
+
       // Asynchronously update the main flow execution record in DynamoDB via the logger
       if (shouldLog) {
         if (finalStatusFromInput === 'FAILED' && runtimeState._internal && !runtimeState._internal.loggingBootstrapped) {
@@ -178,14 +218,13 @@ export const handler: Handler<ProcessorInput, FinalizeOutput> = async (event) =>
       await handleSystemLevelResume(runtimeState);
   
       try {
-        const flowDef = await loadFlowDefinition(runtimeState.flowDefinitionId, runtimeState.flowDefinitionVersion, correlationId);
         const templateService = TemplateService.getInstance();
 
-        if (flowDef.onCompletionActions && flowDef.onCompletionActions.length > 0) {
-            log_info('Processing onCompletionActions...', { count: flowDef.onCompletionActions.length}, correlationId);
+        if (hasCompletionActions) {
+            log_info('Processing onCompletionActions...', { count: completionActions.length}, correlationId);
             const templateSourceContext = { ...runtimeState, ...runtimeState.currentContextData };
 
-            for (const action of flowDef.onCompletionActions) {
+            for (const action of completionActions) {
                 try {
                     if (action.executeOnStatus !== 'ANY' && action.executeOnStatus !== finalStatusFromInput) {
                         log_debug('Skipping onCompletionAction due to status mismatch.', { actionType: action.actionType, executeOnStatus: action.executeOnStatus, finalStatus: finalStatusFromInput }, correlationId);
@@ -285,7 +324,7 @@ export const handler: Handler<ProcessorInput, FinalizeOutput> = async (event) =>
             }
         }
       } catch (e: any) {
-        log_warn('Could not load flow definition to run onCompletionActions. This is expected if the flow failed due to a configuration error.', { error: e.message }, correlationId);
+        log_warn('Failed while processing onCompletionActions.', { error: e.message }, correlationId);
       }
     } catch (error: any) {
       log_error('Critical error during flow finalization', { error: error.message, stack: error.stack }, correlationId);

--- a/packages/app-logic/src/allma-flows/initialize-flow.ts
+++ b/packages/app-logic/src/allma-flows/initialize-flow.ts
@@ -10,19 +10,17 @@ import {
   ProcessorOutput,
   SfnActionType,
   ENV_VAR_NAMES,
-  isS3OutputPointerWrapper,
 } from '@allma/core-types';
 import {
   log_debug,
   log_error,
   log_info,
   resolveS3Pointer,
-  offloadIfLarge,
-  log_warn,
 } from '@allma/core-sdk';
 import { loadFlowDefinition, loadFlowMetadata } from '../allma-core/config-loader.js';
 import { executionLoggerClient } from '../allma-core/execution-logger-client.js';
-import { AgentService } from '../allma-admin/services/agent.service.js'; 
+import { offloadFlowContextIfLarge } from '../allma-core/utils/context-offload.js';
+import { AgentService } from '../allma-admin/services/agent.service.js';
 
 const EXECUTION_TRACES_BUCKET_NAME = process.env[ENV_VAR_NAMES.ALLMA_EXECUTION_TRACES_BUCKET_NAME];
 const SFN_SAFE_PAYLOAD_LIMIT = 100 * 1024; // 100KB safe threshold
@@ -190,20 +188,13 @@ export const handler: Handler<StartFlowExecutionInput, ProcessorOutput> = async 
 
     // Offload context if large before parsing it to avoid step functions payload limit issues
     if (EXECUTION_TRACES_BUCKET_NAME) {
-        const offloadedContext = await offloadIfLarge(
+        initialState.currentContextData = await offloadFlowContextIfLarge(
             initialState.currentContextData,
             EXECUTION_TRACES_BUCKET_NAME,
             `flow_state/${effectiveFlowExecutionId}/_init`,
             correlationId,
             SFN_SAFE_PAYLOAD_LIMIT
         );
-
-        if (offloadedContext && isS3OutputPointerWrapper(offloadedContext)) {
-            log_warn(`InitializeFlowLambda context size exceeded threshold. Auto-offloaded currentContextData to S3.`, {}, correlationId);
-            initialState.currentContextData = { 
-                _s3_context_pointer: offloadedContext._s3_output_pointer 
-            };
-        }
     }
 
     // 6. Validate the initial state for SFN

--- a/packages/app-logic/src/allma-flows/iterative-step-processor/index.ts
+++ b/packages/app-logic/src/allma-flows/iterative-step-processor/index.ts
@@ -16,9 +16,10 @@ import {
     ENV_VAR_NAMES,
 } from '@allma/core-types';
 import {
-    log_info, log_error, log_debug, log_warn, deepMerge, resolveS3Pointer, isObject, offloadIfLarge,
+    log_info, log_error, log_debug, log_warn, deepMerge, resolveS3Pointer, isObject,
 } from '@allma/core-sdk';
 import { loadFlowDefinition } from '../../allma-core/config-loader.js';
+import { offloadFlowContextIfLarge } from '../../allma-core/utils/context-offload.js';
 import { handleTerminalError } from './error-handler.js';
 import { determineNextSfnAction, resolveNextStep } from './transition-resolver.js';
 import { handleAsyncResume, handleWaitForEvent } from './async-handler.js';
@@ -207,17 +208,13 @@ export const handler: Handler<ProcessorInput, ProcessorOutput | void> = async (e
             };
             
             if (EXECUTION_TRACES_BUCKET_NAME) {
-                const offloadedContext = await offloadIfLarge(
+                runtimeState.currentContextData = await offloadFlowContextIfLarge(
                     runtimeState.currentContextData,
                     EXECUTION_TRACES_BUCKET_NAME,
                     `flow_state/${correlationId}/${runtimeState.currentStepInstanceId || 'end'}`,
                     correlationId,
                     SFN_SAFE_PAYLOAD_LIMIT
                 );
-                if (offloadedContext && isS3OutputPointerWrapper(offloadedContext)) {
-                    log_warn(`IterativeStepProcessor context size exceeded threshold. Auto-offloaded currentContextData to S3.`, {}, correlationId);
-                    runtimeState.currentContextData = { _s3_context_pointer: offloadedContext._s3_output_pointer };
-                }
             }
             return finalOutput;
         }
@@ -307,16 +304,13 @@ export const handler: Handler<ProcessorInput, ProcessorOutput | void> = async (e
                 const forkOutput = await handleParallelFork(stepInstance, runtimeState, correlationId);
                 if (forkOutput) {
                     if (EXECUTION_TRACES_BUCKET_NAME) {
-                        const offloadedContext = await offloadIfLarge(
+                        forkOutput.runtimeState.currentContextData = await offloadFlowContextIfLarge(
                             forkOutput.runtimeState.currentContextData,
                             EXECUTION_TRACES_BUCKET_NAME,
                             `flow_state/${correlationId}/${forkOutput.runtimeState.currentStepInstanceId || 'end'}`,
                             correlationId,
                             SFN_SAFE_PAYLOAD_LIMIT
                         );
-                        if (offloadedContext && isS3OutputPointerWrapper(offloadedContext)) {
-                            forkOutput.runtimeState.currentContextData = { _s3_context_pointer: offloadedContext._s3_output_pointer };
-                        }
                     }
                     
                     // Clear internal state so the aggregator phase gets a new startTime
@@ -355,16 +349,13 @@ export const handler: Handler<ProcessorInput, ProcessorOutput | void> = async (e
                 log_info(`Step '${currentStepInstanceId}' is a synchronous START_FLOW_EXECUTION. Preparing sub-flow.`, {}, correlationId);
                 const syncOutput = await handleSyncFlowStart(stepInstance, runtimeState, correlationId);
                 if (EXECUTION_TRACES_BUCKET_NAME) {
-                    const offloadedContext = await offloadIfLarge(
+                    syncOutput.runtimeState.currentContextData = await offloadFlowContextIfLarge(
                         syncOutput.runtimeState.currentContextData,
                         EXECUTION_TRACES_BUCKET_NAME,
                         `flow_state/${correlationId}/${syncOutput.runtimeState.currentStepInstanceId || 'end'}`,
                         correlationId,
                         SFN_SAFE_PAYLOAD_LIMIT
                     );
-                    if (offloadedContext && isS3OutputPointerWrapper(offloadedContext)) {
-                        syncOutput.runtimeState.currentContextData = { _s3_context_pointer: offloadedContext._s3_output_pointer };
-                    }
                 }
                 // Intentionally preserving currentStepStartTime so the COMPLETED event binds seamlessly.
                 return syncOutput;
@@ -537,20 +528,13 @@ export const handler: Handler<ProcessorInput, ProcessorOutput | void> = async (e
     // The final safety-net offload respects the step's `disableS3Offload` flag, consistent
     // with the per-step output handling in step-executor and parallel-handler.
     if (EXECUTION_TRACES_BUCKET_NAME && !stepInstance?.disableS3Offload) {
-        const offloadedContext = await offloadIfLarge(
+        runtimeState.currentContextData = await offloadFlowContextIfLarge(
             runtimeState.currentContextData,
             EXECUTION_TRACES_BUCKET_NAME,
             `flow_state/${correlationId}/${runtimeState.currentStepInstanceId || 'end'}`,
             correlationId,
             SFN_SAFE_PAYLOAD_LIMIT
         );
-
-        if (offloadedContext && isS3OutputPointerWrapper(offloadedContext)) {
-            log_warn(`IterativeStepProcessor context size exceeded threshold. Auto-offloaded currentContextData to S3.`, {}, correlationId);
-            runtimeState.currentContextData = {
-                _s3_context_pointer: offloadedContext._s3_output_pointer
-            };
-        }
     }
 
     log_debug(`IterativeStepProcessor final output for ${runtimeState.currentStepInstanceId || 'end-of-flow'}:`, finalOutput.pollingTaskInput ? { ...finalOutput, pollingTaskInput: 'OMITTED_FOR_BREVITY' } : finalOutput, correlationId);

--- a/packages/app-logic/src/allma-flows/iterative-step-processor/parallel-handler.ts
+++ b/packages/app-logic/src/allma-flows/iterative-step-processor/parallel-handler.ts
@@ -26,6 +26,7 @@ import { processStepOutput, getSmartValueByJsonPath } from '../../allma-core/dat
 import { executionLoggerClient } from '../../allma-core/execution-logger-client.js';
 import { resolveNextStep } from './transition-resolver.js';
 import { enforceTransitionLimits } from './transition-limits.js';
+import { offloadFlowContextIfLarge } from '../../allma-core/utils/context-offload.js';
 
 // Configure client with adaptive retry strategy to smoothly handle massive traffic spikes
 const s3Client = new S3Client({ maxAttempts: 10, retryMode: 'adaptive' });
@@ -456,17 +457,13 @@ export const handleParallelFork = async (
     if (totalOutputSize > SFN_INLINE_PAYLOAD_LIMIT_BYTES) {
         log_warn(`Branch payload + state is large (${totalOutputSize} bytes). Automatically creating S3 manifest and switching to Distributed Map.`, {}, correlationId);
 
-        const offloadedSharedContext = await offloadIfLarge(
+        runtimeState.currentContextData = await offloadFlowContextIfLarge(
             runtimeState.currentContextData,
             EXECUTION_TRACES_BUCKET_NAME,
             `shared_context/${correlationId}/${stepInstanceConfig.stepInstanceId}`,
             correlationId,
             0 // Force offload for state payload limits
         );
-
-        if (offloadedSharedContext && isS3OutputPointerWrapper(offloadedSharedContext)) {
-            runtimeState.currentContextData = { _s3_context_pointer: offloadedSharedContext._s3_output_pointer };
-        }
 
         const manifestContent = JSON.stringify(branchesToExecute);
         const manifestKey = `manifests/${correlationId}/${stepInstanceConfig.stepInstanceId}-${new Date().toISOString()}.json`;

--- a/packages/app-logic/tests/unit/allma-core/context-offload.test.ts
+++ b/packages/app-logic/tests/unit/allma-core/context-offload.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { mockClient, resetAwsClientMocks } from '../_helpers/aws-mock.js';
+import { offloadFlowContextIfLarge, STICKY_CONTEXT_MARKER_KEYS } from '../../../src/allma-core/utils/context-offload.js';
+
+/**
+ * Unit tests for the shared flow-context offload helper: it must offload only when over the
+ * threshold and, when it does, carry the "sticky" markers (e.g. _flow_resume_key) alongside the
+ * pointer so FinalizeFlow can decide whether it needs the full context without hydrating it.
+ */
+
+const s3Mock = mockClient(S3Client);
+
+beforeEach(() => {
+  resetAwsClientMocks(s3Mock);
+  s3Mock.on(PutObjectCommand).resolves({});
+});
+
+describe('offloadFlowContextIfLarge', () => {
+  it('returns the original object unchanged when under the threshold', async () => {
+    const ctx = { a: 1, _flow_resume_key: 'wa:1' };
+    const result = await offloadFlowContextIfLarge(ctx, 'bucket', 'prefix', 'cid', 1024 * 1024);
+    expect(result).toBe(ctx);
+    expect(s3Mock).toHaveReceivedCommandTimes(PutObjectCommand, 0);
+  });
+
+  it('offloads a large context and preserves sticky markers alongside the pointer', async () => {
+    const ctx = { blob: 'x'.repeat(2048), _flow_resume_key: 'wa:42' };
+    const result = await offloadFlowContextIfLarge(ctx, 'bucket', 'prefix', 'cid', 1024);
+
+    expect(s3Mock).toHaveReceivedCommandTimes(PutObjectCommand, 1);
+    expect(result._s3_context_pointer).toMatchObject({ bucket: 'bucket' });
+    expect(result._flow_resume_key).toBe('wa:42');
+    // The large payload itself is not carried inline — that's the whole point of offloading.
+    expect(result.blob).toBeUndefined();
+  });
+
+  it('omits sticky markers that are absent from the context', async () => {
+    const ctx = { blob: 'x'.repeat(2048) };
+    const result = await offloadFlowContextIfLarge(ctx, 'bucket', 'prefix', 'cid', 1024);
+
+    expect(result._s3_context_pointer).toBeDefined();
+    for (const key of STICKY_CONTEXT_MARKER_KEYS) {
+      expect(key in result).toBe(false);
+    }
+  });
+});

--- a/packages/app-logic/tests/unit/allma-flows/finalize-flow.test.ts
+++ b/packages/app-logic/tests/unit/allma-flows/finalize-flow.test.ts
@@ -1,7 +1,7 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { SNSClient, PublishCommand } from '@aws-sdk/client-sns';
 import { LambdaClient, InvokeCommand } from '@aws-sdk/client-lambda';
-import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { S3Client, PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
 import {
   StepType,
   HttpMethod,
@@ -209,5 +209,80 @@ describe('finalize-flow handler', () => {
     expect(result.status).toBe('COMPLETED');
     expect(result.finalContextData).toEqual({ result: 1 });
     expect(result.finalContextDataS3Pointer).toBeUndefined();
+  });
+
+  const s3GetJson = (payload: unknown) =>
+    s3Mock.on(GetObjectCommand).resolves({
+      ContentType: 'application/json',
+      ContentLength: 512,
+      Body: { transformToString: async () => JSON.stringify(payload) } as never,
+    });
+
+  it('fast-path: passes an already-offloaded context pointer through without hydration or re-offload', async () => {
+    // No onCompletionActions and no resume key => the full context is never needed in memory.
+    mockedLoadDef.mockResolvedValue(makeFlowDefinition());
+    const pointer = { bucket: 'traces-bucket', key: 'flow_state/exec-1/end.json' };
+
+    const result = await invoke({
+      runtimeState: makeRuntimeState({
+        status: 'COMPLETED',
+        currentContextData: { _s3_context_pointer: pointer },
+      }),
+    });
+
+    expect(result.finalContextDataS3Pointer).toEqual(pointer);
+    expect(result.finalContextData).toBeUndefined();
+    // The offloaded blob is neither downloaded nor re-uploaded — memory stays flat.
+    expect(s3Mock).toHaveReceivedCommandTimes(GetObjectCommand, 0);
+    expect(s3Mock).toHaveReceivedCommandTimes(PutObjectCommand, 0);
+  });
+
+  it('hydrates an offloaded context when a preserved _flow_resume_key requires a system-level resume', async () => {
+    process.env[ENV_VAR_NAMES.ALLMA_RESUME_API_URL] = 'http://resume.test/resume';
+    mockedLoadDef.mockResolvedValue(makeFlowDefinition());
+    s3GetJson({ final: 'x', _flow_resume_key: 'wa:777' });
+
+    // The sticky _flow_resume_key rides alongside the pointer (as offloadFlowContextIfLarge preserves it),
+    // so FinalizeFlow can tell resume is needed and then hydrate.
+    await invoke({
+      runtimeState: makeRuntimeState({
+        status: 'COMPLETED',
+        currentContextData: { _s3_context_pointer: { bucket: 'traces-bucket', key: 'flow_state/exec-2/end.json' }, _flow_resume_key: 'wa:777' },
+      }),
+    });
+
+    expect(s3Mock).toHaveReceivedCommandTimes(GetObjectCommand, 1);
+    expect(mockedPostJson).toHaveBeenCalledWith(
+      'http://resume.test/resume',
+      expect.objectContaining({ correlationValue: 'wa:777' }),
+      5000,
+    );
+    delete process.env[ENV_VAR_NAMES.ALLMA_RESUME_API_URL];
+  });
+
+  it('hydrates an offloaded context to run onCompletionActions', async () => {
+    mockedLoadDef.mockResolvedValue(
+      flowWithActions([
+        {
+          actionType: 'SNS_SEND',
+          target: 'arn:aws:sns:us-east-1:123456789012:topic',
+          payloadTemplate: { message: '$.final_message' },
+          executeOnStatus: 'ANY',
+        },
+      ]),
+    );
+    s3GetJson({ final_message: 'done' });
+
+    await invoke({
+      runtimeState: makeRuntimeState({
+        status: 'COMPLETED',
+        currentContextData: { _s3_context_pointer: { bucket: 'traces-bucket', key: 'flow_state/exec-3/end.json' } },
+      }),
+    });
+
+    expect(s3Mock).toHaveReceivedCommandTimes(GetObjectCommand, 1);
+    expect(snsMock).toHaveReceivedCommandTimes(PublishCommand, 1);
+    const snsInput = snsMock.commandCalls(PublishCommand)[0].args[0].input;
+    expect(JSON.parse(snsInput.Message as string)).toEqual({ message: 'done' });
   });
 });


### PR DESCRIPTION
## Why

Follow-up to the FinalizeFlow OOM. #78 raises the lambda's memory ceiling (the immediate unblock); **this PR removes the root cause** so peak memory is independent of context size.

`FinalizeFlow` always hydrated the (often S3-offloaded) flow context, `JSON.stringify`d it, and re-offloaded it — even when it only needed to hand back a pointer. For large contexts (e.g. sub-flow returns) that round-trip is exactly what exhausted the lambda.

But most of it is unnecessary: the context is already in S3; the traces bucket's lifecycle rule is bucket-wide (so the `final_context/` re-key is cosmetic); and every consumer (parent sub-flow, parallel aggregation, logger, admin UI) already resolves the pointer lazily.

## What

**Fast path in `finalize-flow.ts`:** inspect the incoming context *without* hydrating. When it's already offloaded **and** neither a system-level resume nor `onCompletionActions` need it in memory, pass the existing S3 pointer straight through — no download, no re-serialize, no re-offload. When resume/actions *do* need the data, hydrate exactly as before.

**Cheap resume detection:** the resume key (`_flow_resume_key`) normally lives *inside* the offloaded blob, so you couldn't tell whether resume applies without downloading it. Context offloading is now centralized in a new `offloadFlowContextIfLarge` helper that preserves a small set of **sticky top-level markers** (currently `_flow_resume_key`) alongside the pointer, so FinalizeFlow can decide cheaply. This also **de-duplicates** the offload-and-wrap pattern previously copy-pasted across the initializer, step processor, and parallel handler (6 sites → 1 helper).

No public API or wire-contract changes.

## Interaction with #78

Complementary, not redundant:
- **#78 (memory bump)** — immediate safety floor; merge/deploy first to unblock.
- **This PR** — the real fix; makes FinalizeFlow's memory flat regardless of context size. After both land, the raised memory becomes headroom rather than a load-bearing requirement.

## Tests

- `finalize-flow.test.ts`: fast-path passes the pointer through with **0** S3 GET/PUT; offloaded + preserved `_flow_resume_key` hydrates and resumes; offloaded + `onCompletionActions` hydrates and fires the action. All pre-existing finalize tests unchanged.
- `context-offload.test.ts`: helper offloads only over threshold and preserves/omits sticky markers correctly.
- Full suite green (**496** tests), lint clean, app-logic builds.

## Deploy-window note

During a rolling deploy, an execution offloaded by old code (no sticky marker) but finalized by new code could, for a resume-enabled flow with a large context, miss the marker and fast-path — skipping resume. This is a narrow, transient window for one niche feature; steady-state is correct. Flagging for awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1aNR7XWozRGSGzUX77Wgn