### PR TITLE
fix(flow-engine): bound memory of parallel/Distributed-Map aggregation

### DIFF
--- a/.changeset/parallel-aggregate-bounded-memory.md
+++ b/.changeset/parallel-aggregate-bounded-memory.md
@@ -1,0 +1,22 @@
+---
+"@allma/core-cdk": patch
+---
+
+Bound the memory of Distributed-Map / parallel aggregation to prevent `Runtime.OutOfMemory` in the
+IterativeStepProcessor during `PARALLEL_AGGREGATE`.
+
+The aggregator resolved every branch's output with an unbounded `Promise.all`, hydrating all N
+branches' full contexts into memory simultaneously, and only applied the configured
+`aggregationConfig.dataPath` afterwards — so even a `dataPath` couldn't reduce peak memory, because
+the full contexts were already all retained. For a large fan-out (e.g. classifying many items) this
+exhausted the lambda.
+
+Branch resolution is now concurrency-bounded (`min(maxConcurrency, 20)`, default 10), and the
+`dataPath` extraction is applied *during* resolution so each branch's full context is released as
+soon as its (small) result is extracted — only the extracted values are retained. Setting a
+`dataPath` on the aggregation now genuinely bounds aggregator memory. Aggregation semantics
+(COLLECT_ARRAY/MERGE_OBJECTS/SUM, `failOnBranchError`, branch-error preservation, S3-pointer
+resolution, output order) are unchanged.
+
+Note: `COLLECT_ARRAY` with no `dataPath` still collects each branch's whole output — set a `dataPath`
+to collect only the field you need when branch contexts are large.

--- a/packages/app-logic/src/allma-flows/iterative-step-processor/parallel-handler.ts
+++ b/packages/app-logic/src/allma-flows/iterative-step-processor/parallel-handler.ts
@@ -39,6 +39,34 @@ const SFN_INLINE_PAYLOAD_LIMIT_BYTES = 100 * 1024;
 const GLOBAL_MAX_CONCURRENCY_STR = process.env[ENV_VAR_NAMES.MAX_CONCURRENT_STEP_EXECUTIONS];
 const GLOBAL_MAX_CONCURRENCY = GLOBAL_MAX_CONCURRENCY_STR ? parseInt(GLOBAL_MAX_CONCURRENCY_STR, 10) : 20;
 
+// Bounded concurrency for resolving branch outputs during aggregation. An unbounded Promise.all over
+// a Distributed Map's branches would hydrate every branch's full context into memory simultaneously,
+// exhausting the aggregator lambda; we cap how many are resolved at once instead.
+const DEFAULT_AGGREGATION_RESOLVE_CONCURRENCY = 10;
+const MAX_AGGREGATION_RESOLVE_CONCURRENCY = 20;
+
+/**
+ * Maps over `items`, running at most `limit` async tasks concurrently and preserving input order in
+ * the result. Used to bound how many branch contexts are materialized in memory at once during
+ * parallel aggregation.
+ */
+async function mapWithConcurrency<T, R>(
+    items: T[],
+    fn: (item: T, index: number) => Promise<R>,
+    limit: number,
+): Promise<R[]> {
+    const results: R[] = new Array(items.length);
+    const workerCount = Math.min(Math.max(1, limit), items.length || 1);
+    let nextIndex = 0;
+    const worker = async (): Promise<void> => {
+        for (let current = nextIndex++; current < items.length; current = nextIndex++) {
+            results[current] = await fn(items[current], current);
+        }
+    };
+    await Promise.all(Array.from({ length: workerCount }, () => worker()));
+    return results;
+}
+
 function aggregateBranchOutputs(
     branchOutputs: BranchResult[],
     aggregationConfig: AggregationConfig,
@@ -186,7 +214,19 @@ export const handleParallelAggregation = async (
         }
     }
 
-    const resolutionPromises = branchOutputs.map(async (branchResult) => {
+    // Extract the configured dataPath DURING resolution (below), not after. Applying it here — while
+    // each branch's full context is briefly in scope — means only the small extracted value is
+    // retained; the full context is released before the next branch is processed. Combined with the
+    // bounded concurrency below, this keeps the aggregator's memory O(concurrency) instead of
+    // O(branchCount), which is what previously exhausted it. Mirrors aggregateBranchOutputs' own
+    // normalization of `dataPath` (empty / '$.output' => collect the whole branch output).
+    let effectiveDataPath = aggregationConfig.dataPath;
+    if (!effectiveDataPath || effectiveDataPath === '$.output') {
+        effectiveDataPath = '';
+    }
+    const extractsDataPath = effectiveDataPath !== '' && effectiveDataPath !== '$.';
+
+    const resolveBranch = async (branchResult: BranchResult): Promise<BranchResult> => {
         let finalizeOutput = branchResult.output;
 
         // Parse stringified JSON output from SFN RUN_JOB execution if necessary
@@ -255,29 +295,46 @@ export const handleParallelAggregation = async (
                     normalizedOutput = resolvedData.output;
                 }
 
-                let finalOutput = normalizedOutput;
                 if (Object.keys(otherKeys).length > 0) {
                     if (typeof normalizedOutput === 'object' && normalizedOutput !== null && !Array.isArray(normalizedOutput)) {
-                        finalOutput = { ...normalizedOutput, ...otherKeys };
+                        finalizeOutput = { ...normalizedOutput, ...otherKeys };
                     } else {
-                        finalOutput = { content: normalizedOutput, ...otherKeys };
+                        finalizeOutput = { content: normalizedOutput, ...otherKeys };
                     }
+                } else {
+                    finalizeOutput = normalizedOutput;
                 }
-
-                return { ...branchResult, output: finalOutput };
             } catch (e: any) {
                 return { branchId: branchResult.branchId, error: { errorName: 'S3OutputPointerResolutionError', errorMessage: e.message, isRetryable: false } };
             }
         }
 
+        // Extract the dataPath now, while the (potentially large) full context is in scope, so only
+        // the small result survives once this branch returns. A bad path is treated as a branch error,
+        // matching the previous behaviour when extraction lived in aggregateBranchOutputs.
+        if (extractsDataPath) {
+            try {
+                finalizeOutput = JSONPath({ path: effectiveDataPath, json: finalizeOutput, wrap: false });
+            } catch (e: any) {
+                log_warn(`Failed to apply dataPath '${effectiveDataPath}' to a branch output.`, { branchId: branchResult.branchId, error: e.message }, correlationId);
+                return { branchId: branchResult.branchId, error: { errorName: 'DataPathError', errorMessage: `Failed to extract data using path: ${e.message}`, isRetryable: false } };
+            }
+        }
+
         return { ...branchResult, output: finalizeOutput };
-    });
+    };
 
-    const resolvedBranchOutputs = await Promise.all(resolutionPromises);
+    const resolveConcurrency = Math.min(
+        Math.max(1, aggregationConfig.maxConcurrency || DEFAULT_AGGREGATION_RESOLVE_CONCURRENCY),
+        MAX_AGGREGATION_RESOLVE_CONCURRENCY,
+    );
+    const resolvedBranchOutputs = await mapWithConcurrency(branchOutputs, resolveBranch, resolveConcurrency);
 
+    // dataPath extraction has already been applied per branch above, so clear it here to avoid a
+    // second (redundant) extraction pass in aggregateBranchOutputs.
     const aggregationResult = aggregateBranchOutputs(
         resolvedBranchOutputs,
-        aggregationConfig,
+        { ...aggregationConfig, dataPath: undefined },
         runtimeState,
         correlationId
     );

--- a/packages/app-logic/tests/unit/allma-flows/iterative-step-processor/parallel-handler.test.ts
+++ b/packages/app-logic/tests/unit/allma-flows/iterative-step-processor/parallel-handler.test.ts
@@ -304,4 +304,48 @@ describe('handleParallelAggregation', () => {
     expect(s3Mock).toHaveReceivedCommand(GetObjectCommand);
     expect(updatedRuntimeState.currentContextData.steps_output.parallel.aggregatedData).toEqual([{ resolved: true }]);
   });
+
+  it('extracts aggregationConfig.dataPath from each branch during resolution', async () => {
+    const runtimeState = makeRuntimeState({ currentContextData: {} });
+    const input = aggInput(
+      [
+        { branchId: 'b1', output: { a: { b: 5 }, noise: 'drop-me' } },
+        { branchId: 'b2', output: { a: { b: 6 }, noise: 'drop-me' } },
+      ] as BranchResult[],
+      { ...collect, dataPath: '$.a.b' } as AggregationConfig,
+    );
+
+    const { updatedRuntimeState } = await handleParallelAggregation(input, runtimeState, flow(), 'corr');
+
+    // Only the extracted values are collected — the surrounding branch data is dropped.
+    expect(updatedRuntimeState.currentContextData.steps_output.parallel.aggregatedData).toEqual([5, 6]);
+  });
+
+  it('applies dataPath to an S3-offloaded branch context, collecting only the small extracted value', async () => {
+    // The branch offloaded its whole context to S3; with a dataPath only the classification result is
+    // collected, so the large context is extracted-and-released rather than retained in the array.
+    stubS3Json({ steps_output: { classify: { result: 'CATEGORY_A' } }, huge: 'x'.repeat(50 * 1024) });
+    const runtimeState = makeRuntimeState({ currentContextData: {} });
+    const input = aggInput(
+      [{ branchId: 'b1', output: { status: 'COMPLETED', finalContextDataS3Pointer: { bucket: 'b', key: 'k' } } }] as BranchResult[],
+      { ...collect, dataPath: '$.steps_output.classify.result' } as AggregationConfig,
+    );
+
+    const { updatedRuntimeState } = await handleParallelAggregation(input, runtimeState, flow(), 'corr');
+
+    expect(s3Mock).toHaveReceivedCommand(GetObjectCommand);
+    expect(updatedRuntimeState.currentContextData.steps_output.parallel.aggregatedData).toEqual(['CATEGORY_A']);
+  });
+
+  it('preserves branch order when resolving many branches under bounded concurrency', async () => {
+    const runtimeState = makeRuntimeState({ currentContextData: {} });
+    const branchOutputs = Array.from({ length: 50 }, (_, i) => ({ branchId: `b${i}`, output: { i } })) as BranchResult[];
+    const input = aggInput(branchOutputs, { ...collect, dataPath: '$.i', maxConcurrency: 5 } as AggregationConfig);
+
+    const { updatedRuntimeState } = await handleParallelAggregation(input, runtimeState, flow(), 'corr');
+
+    expect(updatedRuntimeState.currentContextData.steps_output.parallel.aggregatedData).toEqual(
+      Array.from({ length: 50 }, (_, i) => i),
+    );
+  });
 });


### PR DESCRIPTION
## Why

`Runtime.OutOfMemory` in `AllmaIterativeStepProcessor` during `PARALLEL_AGGREGATE`, aggregating a Distributed-Map fan-out (`classify_parts_in_parallel`), at 2048 MB.

## Root cause

In `handleParallelAggregation`:
1. **Unbounded `Promise.all`** over all branches — the manifest hands back N small `finalContextDataS3Pointer`s, and the aggregator resolved **every one concurrently**, hydrating all N branches' **full contexts** into memory simultaneously. (`maxConcurrency: 10` only throttles branch *execution*, not aggregation.)
2. **`dataPath` applied too late** — extraction happened in `aggregateBranchOutputs` *after* `Promise.all` had already retained every full context. So even setting a `dataPath` couldn't reduce peak memory. With no `dataPath` (the reported config), each collected element is a branch's **entire** context.

For a large fan-out that's multiple full copies of everything → OOM.

## Fix

- **Bounded resolution concurrency** via a small order-preserving `mapWithConcurrency` helper: at most `min(maxConcurrency, 20)` branches (default 10) are resolved at a time, so we never hold more than that many full contexts at once.
- **`dataPath` extraction moved into resolution**: each branch's full context is resolved, the small `dataPath` value extracted, and the full context released before the next branch — so only the extracted values are retained. **Setting a `dataPath` now genuinely bounds aggregator memory** (it didn't before).

Aggregation semantics are unchanged: strategies (COLLECT_ARRAY/MERGE_OBJECTS/SUM), `failOnBranchError`, branch-error preservation, S3-pointer resolution, and output order all behave identically (extraction was simply relocated earlier).

## Companion flow-config change (the "Both" other half)

For `classify_parts_in_parallel`, set `aggregationConfig.dataPath` to the JSONPath of just the classification result per branch (e.g. `$.steps_output.<classify_step>.result`) instead of leaving it unset. With this PR, that makes each collected element tiny **and** releases each branch's full context during resolution — the two together fully bound the aggregator's memory. Without a `dataPath`, COLLECT_ARRAY still collects each branch's whole output (inherently heavy); the bounded concurrency still caps the transient spike.

## Tests

- `dataPath` extraction during resolution — inline branch outputs and an S3-offloaded branch context (only the extracted value is collected).
- Order preserved across 50 branches under `maxConcurrency: 5`.
- All pre-existing aggregation tests unchanged. Full suite green (**499**), lint clean, app-logic builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1aNR7XWozRGSGzUX77Wgn