### PR TITLE
feat(flow-engine): add NONE parallel-aggregation strategy (barrier)

### DIFF
--- a/.changeset/aggregation-none-strategy.md
+++ b/.changeset/aggregation-none-strategy.md
@@ -1,0 +1,20 @@
+---
+"@allma/core-types": minor
+"@allma/core-cdk": patch
+---
+
+Add a `NONE` parallel-aggregation strategy — a barrier that does not collect branch results.
+
+`PARALLEL_FORK_MANAGER` always runs an aggregation step after the branches, and the existing
+strategies (`COLLECT_ARRAY`/`MERGE_OBJECTS`/`SUM`) all resolve every branch's full context from S3
+before combining — which exhausts the aggregator lambda on large fan-outs even when the combined
+result isn't needed.
+
+`strategy: "NONE"` skips resolving and collecting branch contexts entirely (the memory-heavy work),
+writing a small summary to the step output instead of a large array. It still honors
+`failOnBranchError` by reading only each branch's small inline status (no context is hydrated); with
+`failOnBranchError: false` it is pure fire-and-forget and skips fetching branch results altogether.
+Use it for side-effecting branches whose combined output you don't consume downstream.
+
+Adds `AggregationStrategy.NONE` to `@allma/core-types` and its handling in the aggregator; documented
+under the parallel-fork-manager reference. Existing strategies are unchanged.

--- a/docs.allma.dev/docs/reference/step-types/04-flow-control/parallel-fork-manager.md
+++ b/docs.allma.dev/docs/reference/step-types/04-flow-control/parallel-fork-manager.md
@@ -30,10 +30,17 @@ Executes one or more branches of logic concurrently for each item in a collectio
 
 | Property            | Type     | Description                                                                                                                                            |
 | ------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `strategy`          | `string` | How to combine results: `COLLECT_ARRAY` (default), `MERGE_OBJECTS`, or `SUM`.                                                                          |
-| `dataPath`          | `string` | A JSONPath to extract a specific piece of data from each branch's output before aggregating. Recommended to prevent state bloat.                       |
-| `failOnBranchError` | `boolean`| If `true` (default), the entire parallel step fails if any single branch fails.                                                                        |
-| `maxConcurrency`    | `number` | (In-Memory mode only) Limits how many branches run at the same time. `0` means no limit.                                                               |
+| `strategy`          | `string` | How to combine results: `COLLECT_ARRAY` (default), `MERGE_OBJECTS`, `SUM`, or `NONE`.                                                                  |
+| `dataPath`          | `string` | A JSONPath to extract a specific piece of data from each branch's output before aggregating. **Strongly recommended** — without it, `COLLECT_ARRAY`/`MERGE_OBJECTS` pull every branch's entire context into memory, which can exhaust the aggregator on large fan-outs. |
+| `failOnBranchError` | `boolean`| If `true` (default), the entire parallel step fails if any single branch fails. With `NONE`, this is honored from the branch statuses alone (no context is hydrated). |
+| `maxConcurrency`    | `number` | Limits how many branches run at the same time (and, for large fan-outs, how many branch results are resolved concurrently during aggregation). `0` means no limit. |
+
+##### The `NONE` strategy (barrier)
+
+Use `strategy: "NONE"` when branches are **side-effecting** (they write to a store, emit events, etc.) and their combined output is **not needed** downstream. The aggregator then acts as a pure barrier: it **does not resolve or collect** any branch context — avoiding the memory cost that collection strategies incur on large fan-outs — and writes a small summary (`{ "aggregationSkipped": true, "aggregatedData": null, ... }`) to the step output instead of a large array.
+
+- With `failOnBranchError: true`, a failed branch still fails the flow — this is determined from each branch's small status only, so nothing is hydrated.
+- With `failOnBranchError: false`, it is pure fire-and-forget: branch results are never fetched and branch failures are ignored.
 
 ---
 

--- a/packages/app-logic/src/allma-flows/iterative-step-processor/parallel-handler.ts
+++ b/packages/app-logic/src/allma-flows/iterative-step-processor/parallel-handler.ts
@@ -6,6 +6,7 @@ import {
     StepInstance,
     AggregationConfig,
     AggregationStrategy,
+    AllmaError,
     BranchResult,
     ProcessorOutput,
     ProcessorInput,
@@ -183,6 +184,32 @@ function aggregateBranchOutputs(
     return { aggregatedData: aggregatedResult };
 }
 
+/**
+ * Determines whether a branch's (unresolved) output represents a failure by reading ONLY the small,
+ * inline finalize output (`status` / `error`) — it never resolves the branch's S3 context. This lets
+ * the NONE aggregation strategy honor `failOnBranchError` without paying the memory cost of hydration.
+ */
+function isBranchFailed(branchResult: BranchResult): { failed: boolean; error?: AllmaError } {
+    if (branchResult.error) {
+        return { failed: true, error: branchResult.error };
+    }
+    let output = branchResult.output;
+    if (typeof output === 'string') {
+        try {
+            output = JSON.parse(output);
+        } catch {
+            /* not JSON — treat as a non-failure opaque output */
+        }
+    }
+    if (output && typeof output === 'object' && output.status === 'FAILED') {
+        return {
+            failed: true,
+            error: output.errorInfo || { errorName: 'BranchFailed', errorMessage: 'Branch flow failed', isRetryable: false },
+        };
+    }
+    return { failed: false };
+}
+
 export const handleParallelAggregation = async (
     parallelAggregateInput: Exclude<ProcessorInput['parallelAggregateInput'], undefined>,
     runtimeState: FlowRuntimeState,
@@ -203,8 +230,14 @@ export const handleParallelAggregation = async (
 
     let branchOutputs = parallelAggregateInput.branchOutputs || [];
 
+    // The NONE strategy is a barrier that does not collect branch results. With failOnBranchError it
+    // still needs the small per-branch statuses; with failOnBranchError=false it needs nothing at all,
+    // so we can skip fetching the Distributed Map results entirely (pure fire-and-forget).
+    const isNoneStrategy = aggregationConfig.strategy === AggregationStrategy.NONE;
+    const skipBranchFetch = isNoneStrategy && !aggregationConfig.failOnBranchError;
+
     // Check if Distributed Map results exist in S3 (from PARALLEL_FORK_S3)
-    if (parallelAggregateInput.mapResultsDetails?.MapRunArn && parallelAggregateInput.mapResultsDetails?.ResultWriterDetails?.Bucket) {
+    if (!skipBranchFetch && parallelAggregateInput.mapResultsDetails?.MapRunArn && parallelAggregateInput.mapResultsDetails?.ResultWriterDetails?.Bucket) {
         log_info('Detected Distributed Map results. Fetching from S3 manifest...', { mapResultsDetails: parallelAggregateInput.mapResultsDetails }, correlationId);
         try {
             branchOutputs = await fetchDistributedMapResults(parallelAggregateInput.mapResultsDetails, correlationId);
@@ -324,20 +357,52 @@ export const handleParallelAggregation = async (
         return { ...branchResult, output: finalizeOutput };
     };
 
-    const resolveConcurrency = Math.min(
-        Math.max(1, aggregationConfig.maxConcurrency || DEFAULT_AGGREGATION_RESOLVE_CONCURRENCY),
-        MAX_AGGREGATION_RESOLVE_CONCURRENCY,
-    );
-    const resolvedBranchOutputs = await mapWithConcurrency(branchOutputs, resolveBranch, resolveConcurrency);
+    let resolvedBranchOutputs: BranchResult[];
+    let aggregationResult: Record<string, any> | null;
 
-    // dataPath extraction has already been applied per branch above, so clear it here to avoid a
-    // second (redundant) extraction pass in aggregateBranchOutputs.
-    const aggregationResult = aggregateBranchOutputs(
-        resolvedBranchOutputs,
-        { ...aggregationConfig, dataPath: undefined },
-        runtimeState,
-        correlationId
-    );
+    if (isNoneStrategy) {
+        // Barrier: skip resolving/collecting branch contexts entirely (the memory-heavy work that
+        // OOMs on large fan-outs). Only honor failOnBranchError from the small inline branch statuses.
+        resolvedBranchOutputs = [];
+        const failedBranches = aggregationConfig.failOnBranchError
+            ? branchOutputs.map(isBranchFailed).filter(result => result.failed)
+            : [];
+
+        if (failedBranches.length > 0) {
+            log_error('NONE aggregation: one or more branches failed and failOnBranchError is true.', { failedCount: failedBranches.length }, correlationId);
+            runtimeState.errorInfo = {
+                errorName: 'ParallelBranchExecutionError',
+                errorMessage: `One or more parallel branches failed. First error: ${failedBranches[0].error?.errorMessage}`,
+                errorDetails: { branchErrors: failedBranches.map(result => result.error) },
+                isRetryable: false,
+            };
+            runtimeState.status = 'FAILED';
+            aggregationResult = null;
+        } else {
+            // A small summary stands in for the (deliberately uncollected) branch results.
+            aggregationResult = {
+                aggregatedData: null,
+                aggregationSkipped: true,
+                ...(skipBranchFetch ? {} : { branchCount: branchOutputs.length, failedBranchCount: 0 }),
+            };
+            log_info('NONE aggregation strategy: branch results were not collected (barrier only).', { branchCount: skipBranchFetch ? undefined : branchOutputs.length }, correlationId);
+        }
+    } else {
+        const resolveConcurrency = Math.min(
+            Math.max(1, aggregationConfig.maxConcurrency || DEFAULT_AGGREGATION_RESOLVE_CONCURRENCY),
+            MAX_AGGREGATION_RESOLVE_CONCURRENCY,
+        );
+        resolvedBranchOutputs = await mapWithConcurrency(branchOutputs, resolveBranch, resolveConcurrency);
+
+        // dataPath extraction has already been applied per branch above, so clear it here to avoid a
+        // second (redundant) extraction pass in aggregateBranchOutputs.
+        aggregationResult = aggregateBranchOutputs(
+            resolvedBranchOutputs,
+            { ...aggregationConfig, dataPath: undefined },
+            runtimeState,
+            correlationId
+        );
+    }
 
     if (aggregationResult === null) {
         // Explicitly log the failure state of the aggregator

--- a/packages/app-logic/tests/unit/allma-flows/iterative-step-processor/parallel-handler.test.ts
+++ b/packages/app-logic/tests/unit/allma-flows/iterative-step-processor/parallel-handler.test.ts
@@ -348,4 +348,60 @@ describe('handleParallelAggregation', () => {
       Array.from({ length: 50 }, (_, i) => i),
     );
   });
+
+  describe('NONE strategy (barrier)', () => {
+    const none = (failOnBranchError: boolean): AggregationConfig =>
+      ({ strategy: AggregationStrategy.NONE, failOnBranchError } as AggregationConfig);
+
+    it('does not resolve/collect branch contexts — writes a small summary and continues', async () => {
+      stubS3Json({ shouldNeverBeFetched: true });
+      const runtimeState = makeRuntimeState({ currentContextData: {} });
+      const input = aggInput(
+        [
+          { branchId: 'b1', output: { status: 'COMPLETED', finalContextDataS3Pointer: { bucket: 'b', key: 'k1' } } },
+          { branchId: 'b2', output: { status: 'COMPLETED', finalContextDataS3Pointer: { bucket: 'b', key: 'k2' } } },
+        ] as BranchResult[],
+        none(true),
+      );
+
+      const { updatedRuntimeState, nextStepId } = await handleParallelAggregation(input, runtimeState, flow(), 'corr');
+
+      // No branch context was hydrated from S3 — that is the whole point.
+      expect(s3Mock).not.toHaveReceivedCommand(GetObjectCommand);
+      expect(updatedRuntimeState.status).not.toBe('FAILED');
+      const out = updatedRuntimeState.currentContextData.steps_output.parallel;
+      expect(out).toMatchObject({ aggregationSkipped: true, aggregatedData: null, branchCount: 2, failedBranchCount: 0 });
+      expect(nextStepId).toBeUndefined(); // flow() has no default transition target
+    });
+
+    it('still fails the flow when a branch failed and failOnBranchError is true', async () => {
+      const runtimeState = makeRuntimeState({ currentContextData: {} });
+      const input = aggInput(
+        [
+          { branchId: 'b1', output: { status: 'COMPLETED', finalContextDataS3Pointer: { bucket: 'b', key: 'k1' } } },
+          { branchId: 'b2', output: { status: 'FAILED', errorInfo: { errorName: 'BranchBoom', errorMessage: 'kaboom', isRetryable: false } } },
+        ] as BranchResult[],
+        none(true),
+      );
+
+      const { updatedRuntimeState } = await handleParallelAggregation(input, runtimeState, flow(), 'corr');
+
+      expect(updatedRuntimeState.status).toBe('FAILED');
+      expect(updatedRuntimeState.errorInfo?.errorName).toBe('ParallelBranchExecutionError');
+      expect(s3Mock).not.toHaveReceivedCommand(GetObjectCommand);
+    });
+
+    it('ignores branch failures in fire-and-forget mode (failOnBranchError false)', async () => {
+      const runtimeState = makeRuntimeState({ currentContextData: {} });
+      const input = aggInput(
+        [{ branchId: 'b1', output: { status: 'FAILED', errorInfo: { errorName: 'X', errorMessage: 'ignored', isRetryable: false } } }] as BranchResult[],
+        none(false),
+      );
+
+      const { updatedRuntimeState } = await handleParallelAggregation(input, runtimeState, flow(), 'corr');
+
+      expect(updatedRuntimeState.status).not.toBe('FAILED');
+      expect(updatedRuntimeState.currentContextData.steps_output.parallel).toMatchObject({ aggregationSkipped: true });
+    });
+  });
 });

--- a/packages/core-types/src/common/enums.ts
+++ b/packages/core-types/src/common/enums.ts
@@ -43,8 +43,17 @@ export type ExecutionKind = z.infer<typeof ExecutionKindSchema>;
 export enum AggregationStrategy {
   MERGE_OBJECTS = "MERGE_OBJECTS",
   COLLECT_ARRAY = "COLLECT_ARRAY",
-  SUM = "SUM", 
+  SUM = "SUM",
   CUSTOM_MODULE = "CUSTOM_MODULE",
+  /**
+   * Do not collect branch results at all — a pure barrier. The aggregator skips resolving each
+   * branch's context from S3 (the memory-heavy step), which is the right choice when branches are
+   * side-effecting (write to a store, emit events) and their combined output is not needed. It still
+   * honors `failOnBranchError` by reading only the small per-branch statuses; with
+   * `failOnBranchError: false` it is pure fire-and-forget. Writes a small summary to the step output
+   * instead of a large array.
+   */
+  NONE = "NONE",
 }
 export const AggregationStrategySchema = z.nativeEnum(AggregationStrategy);
 


### PR DESCRIPTION
## Why

`PARALLEL_FORK_MANAGER` always runs an aggregation step after its branches, and every existing strategy (`COLLECT_ARRAY`/`MERGE_OBJECTS`/`SUM`) resolves **each branch's full context from S3** before combining. On a large fan-out that exhausts the aggregator lambda (`Runtime.OutOfMemory`) — even when the combined result isn't used at all. There was no way to say "just run the branches, don't collect."

## What

Adds **`strategy: "NONE"`** — a pure barrier:
- **Skips resolving/collecting branch contexts entirely** (the memory-heavy work), writing a small summary (`{ aggregationSkipped: true, aggregatedData: null, branchCount, failedBranchCount }`) to the step output instead of a large array.
- **Still honors `failOnBranchError`** by reading only each branch's small inline status — no context is hydrated. A genuinely failed branch still fails the flow.
- With **`failOnBranchError: false`** it's pure fire-and-forget: branch results are never fetched and branch failures are ignored.

Intended for **side-effecting branches** (write to a store, emit events) whose combined output you don't consume downstream.

## Usage

```json
"aggregationConfig": { "strategy": "NONE", "failOnBranchError": true }
```

## Changes

- `@allma/core-types`: `AggregationStrategy.NONE` (enum + Zod schema picks it up automatically).
- `@allma/core-cdk` (bundled app-logic): `handleParallelAggregation` short-circuits for `NONE` — skips the fetch when fire-and-forget, skips resolution/collection always, and uses a new `isBranchFailed` helper that inspects only the small inline status.
- Reference docs updated under `parallel-fork-manager.md` (also strengthened the `dataPath` guidance).

## Tests

New tests: `NONE` performs **0** S3 `GetObject` (no context hydration), writes the summary, and continues; still FAILS the flow on a failed branch when `failOnBranchError: true`; ignores failures in fire-and-forget mode. All existing aggregation tests unchanged — full suite green (**502**), lint clean, app-logic builds.

## Release note

Adding to the `AggregationStrategy` enum in `@allma/core-types` mechanically cascades `@allma/admin-shell` to a **major** version via its exact-pinned peer dependency. This is the repo's normal cascade behavior, **not** a real API break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1aNR7XWozRGSGzUX77Wgn