### PR TITLE
ci: run CI workflow on pushes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
This fixes the build status badge in the README. The badge tracks the `ci.yml` workflow on the `main` branch. However, since the workflow was only configured to run on `pull_request`, the badge has been stuck showing the status of the last run on `main` (which happened to be a failure back in October 2025). By adding `push: branches: [main]`, the CI will run when changes are merged to main, keeping the badge up-to-date and green.