### PR TITLE
fix(ui-components): externalize @mantine/* and move to peerDependencies

### DIFF
--- a/.changeset/mantine-peer-deps-external.md
+++ b/.changeset/mantine-peer-deps-external.md
@@ -1,0 +1,5 @@
+---
+"@allma/ui-components": patch
+---
+
+Move @mantine/* packages to peerDependencies and externalize them in tsup config to prevent bundling @mantine into dist bundle

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -37,17 +37,18 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
-    "@mantine/hooks": "^9.0.0",
-    "@mantine/notifications": "^9.0.0"
-  },
   "peerDependencies": {
+    "@mantine/core": "^8.0.0 || ^9.0.0",
+    "@mantine/hooks": "^8.0.0 || ^9.0.0",
+    "@mantine/notifications": "^8.0.0 || ^9.0.0",
     "@tabler/icons-react": "^3.11.0",
     "@uiw/react-json-view": "^2.0.0-alpha.34",
     "react": "^19.1.0"
   },
   "devDependencies": {
     "@mantine/core": "^8.0.0",
+    "@mantine/hooks": "^8.0.0",
+    "@mantine/notifications": "^8.0.0",
     "@tabler/icons-react": "^3.11.0",
     "@uiw/react-json-view": "^2.0.0-alpha.34",
     "@types/react": "^19.1.2",

--- a/packages/ui-components/tsup.config.ts
+++ b/packages/ui-components/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   splitting: false,
   sourcemap: true,
   clean: true,               // Clean the 'dist' directory before building
+  external: [/^@mantine\//, /^react/],
   // Add this banner to the top of all ESM files. This is crucial for
   // components to work correctly in modern React frameworks (like Next.js App Router).
   // It's a best practice for any new component library.


### PR DESCRIPTION
## Summary
In `@allma/ui-components`, `@mantine/core` was listed under `devDependencies` and `@mantine/hooks` / `@mantine/notifications` were under `dependencies`, missing from `peerDependencies`. Consequently, `tsup` inlined `@mantine/*` into the package's `dist` output, leading to `MantineProvider was not found in component tree` runtime errors in consumers.

## Changes
- **`packages/ui-components/package.json`**: Moved `@mantine/core`, `@mantine/hooks`, and `@mantine/notifications` into `peerDependencies` (`^8.0.0 || ^9.0.0`).
- **`packages/ui-components/tsup.config.ts`**: Added `external: [/^@mantine\//, /^react/]` to prevent `tsup` from bundling `@mantine/*` into `dist`.
- **Changeset**: Added a patch changeset for `@allma/ui-components`.