### PR TITLE
feat(core-types): add top-level tool schemas for LLM_INVOCATION

### DIFF
--- a/.changeset/llm-tools-schemas.md
+++ b/.changeset/llm-tools-schemas.md
@@ -1,0 +1,5 @@
+---
+"@allma/core-types": minor
+---
+
+Add top-level tool schemas (`LlmBuiltInToolType`, `LlmBuiltInToolSchema`, `LlmFunctionToolSchema`, `LlmToolDeclarationSchema`, `LlmToolChoiceSchema`, `LlmToolCallRequest`) to `LLM_INVOCATION` step payloads and extend `LlmGenerationRequest`/`LlmGenerationResponse`.

--- a/packages/core-types/src/llm/index.ts
+++ b/packages/core-types/src/llm/index.ts
@@ -61,6 +61,66 @@ export const SUPPORTED_LLM_DOCUMENT_MIME_TYPES = [
 ] as const;
 
 /**
+ * Built-in tools supported across LLM providers.
+ */
+export enum LlmBuiltInToolType {
+    GOOGLE_SEARCH = 'google_search',
+    CODE_EXECUTION = 'code_execution',
+    WEB_SEARCH = 'web_search',
+}
+export const LlmBuiltInToolTypeSchema = z.nativeEnum(LlmBuiltInToolType);
+
+/**
+ * Schema for custom function tool definitions.
+ */
+export const LlmFunctionToolSchema = z.object({
+    type: z.literal('function'),
+    name: z.string().min(1).regex(/^[a-zA-Z0-9_-]+$/),
+    description: z.string().min(1),
+    parameters: z.record(z.any()),
+});
+export type LlmFunctionTool = z.infer<typeof LlmFunctionToolSchema>;
+
+/**
+ * Schema for built-in provider tool declarations.
+ */
+export const LlmBuiltInToolSchema = z.object({
+    type: LlmBuiltInToolTypeSchema,
+    config: z.record(z.any()).optional(),
+});
+export type LlmBuiltInTool = z.infer<typeof LlmBuiltInToolSchema>;
+
+/**
+ * Union schema for tool declarations (built-in or function tools).
+ */
+export const LlmToolDeclarationSchema = z.union([
+    LlmBuiltInToolSchema,
+    LlmFunctionToolSchema,
+]);
+export type LlmToolDeclaration = z.infer<typeof LlmToolDeclarationSchema>;
+
+/**
+ * Schema for tool choice specifications.
+ */
+export const LlmToolChoiceSchema = z.union([
+    z.enum(['auto', 'none', 'required']),
+    z.object({
+        type: z.literal('function'),
+        name: z.string().min(1),
+    }),
+]);
+export type LlmToolChoice = z.infer<typeof LlmToolChoiceSchema>;
+
+/**
+ * Represents a tool call request requested by an LLM model response.
+ */
+export interface LlmToolCallRequest {
+    id?: string;
+    name: string;
+    args: Record<string, any>;
+}
+
+/**
  * Standardized input for any LLM provider adapter.
  */
 export interface LlmGenerationRequest {
@@ -78,6 +138,8 @@ export interface LlmGenerationRequest {
     customConfig?: Record<string, any>;
     jsonOutputMode?: boolean;
     correlationId?: string;
+    tools?: LlmToolDeclaration[];
+    toolChoice?: LlmToolChoice;
 }
   
 /**
@@ -96,6 +158,8 @@ export interface LlmGenerationResponse {
     safetyDetails?: any;
     errorMessage?: string;
     errorDetails?: any;
+    groundingMetadata?: Record<string, any>;
+    toolCalls?: LlmToolCallRequest[];
 }
   
 /**

--- a/packages/core-types/src/llm/llm-tools.test.ts
+++ b/packages/core-types/src/llm/llm-tools.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest';
+import {
+  LlmBuiltInToolType,
+  LlmBuiltInToolTypeSchema,
+  LlmBuiltInToolSchema,
+  LlmFunctionToolSchema,
+  LlmToolDeclarationSchema,
+  LlmToolChoiceSchema,
+} from './index.js';
+import {
+  LlmInvocationStepPayloadSchema,
+  LlmInvocationFallbackSchema,
+} from '../steps/system/llm.js';
+
+describe('LLM Tool Schemas', () => {
+  describe('LlmBuiltInToolTypeSchema & LlmBuiltInToolSchema', () => {
+    it('accepts valid built-in tool types', () => {
+      expect(LlmBuiltInToolTypeSchema.safeParse('google_search').success).toBe(true);
+      expect(LlmBuiltInToolTypeSchema.safeParse('code_execution').success).toBe(true);
+      expect(LlmBuiltInToolTypeSchema.safeParse('web_search').success).toBe(true);
+      expect(LlmBuiltInToolTypeSchema.safeParse(LlmBuiltInToolType.GOOGLE_SEARCH).success).toBe(true);
+    });
+
+    it('rejects invalid built-in tool types', () => {
+      expect(LlmBuiltInToolTypeSchema.safeParse('invalid_tool').success).toBe(false);
+    });
+
+    it('validates built-in tools with optional config', () => {
+      expect(LlmBuiltInToolSchema.safeParse({ type: 'google_search' }).success).toBe(true);
+      expect(
+        LlmBuiltInToolSchema.safeParse({
+          type: 'code_execution',
+          config: { timeoutMs: 5000 },
+        }).success,
+      ).toBe(true);
+      expect(LlmBuiltInToolSchema.safeParse({ type: 'unknown_tool' }).success).toBe(false);
+    });
+  });
+
+  describe('LlmFunctionToolSchema', () => {
+    it('accepts valid function tool definitions', () => {
+      const validFunction = {
+        type: 'function',
+        name: 'get_current_weather',
+        description: 'Get the current weather for a location',
+        parameters: {
+          type: 'object',
+          properties: {
+            location: { type: 'string' },
+          },
+          required: ['location'],
+        },
+      };
+      expect(LlmFunctionToolSchema.safeParse(validFunction).success).toBe(true);
+    });
+
+    it('validates tool name regex requirement', () => {
+      const validNames = ['getWeather', 'get_weather_1', 'my-tool-name'];
+      const invalidNames = ['get weather', 'tool@name', '', 'tool!'];
+
+      for (const name of validNames) {
+        expect(
+          LlmFunctionToolSchema.safeParse({
+            type: 'function',
+            name,
+            description: 'desc',
+            parameters: {},
+          }).success,
+        ).toBe(true);
+      }
+
+      for (const name of invalidNames) {
+        expect(
+          LlmFunctionToolSchema.safeParse({
+            type: 'function',
+            name,
+            description: 'desc',
+            parameters: {},
+          }).success,
+        ).toBe(false);
+      }
+    });
+
+    it('rejects empty description or missing parameters', () => {
+      expect(
+        LlmFunctionToolSchema.safeParse({
+          type: 'function',
+          name: 'func',
+          description: '',
+          parameters: {},
+        }).success,
+      ).toBe(false);
+
+      expect(
+        LlmFunctionToolSchema.safeParse({
+          type: 'function',
+          name: 'func',
+          description: 'desc',
+        }).success,
+      ).toBe(false);
+    });
+  });
+
+  describe('LlmToolDeclarationSchema', () => {
+    it('accepts both built-in and function tool declarations', () => {
+      const builtIn = { type: 'web_search' };
+      const func = {
+        type: 'function',
+        name: 'calculate',
+        description: 'Calculate expression',
+        parameters: {},
+      };
+
+      expect(LlmToolDeclarationSchema.safeParse(builtIn).success).toBe(true);
+      expect(LlmToolDeclarationSchema.safeParse(func).success).toBe(true);
+    });
+
+    it('rejects invalid tool declarations', () => {
+      expect(LlmToolDeclarationSchema.safeParse({ type: 'invalid' }).success).toBe(false);
+    });
+  });
+
+  describe('LlmToolChoiceSchema', () => {
+    it('accepts string enum modes', () => {
+      expect(LlmToolChoiceSchema.safeParse('auto').success).toBe(true);
+      expect(LlmToolChoiceSchema.safeParse('none').success).toBe(true);
+      expect(LlmToolChoiceSchema.safeParse('required').success).toBe(true);
+    });
+
+    it('accepts specific function choice object', () => {
+      expect(
+        LlmToolChoiceSchema.safeParse({
+          type: 'function',
+          name: 'get_weather',
+        }).success,
+      ).toBe(true);
+    });
+
+    it('rejects invalid modes or shapes', () => {
+      expect(LlmToolChoiceSchema.safeParse('any').success).toBe(false);
+      expect(LlmToolChoiceSchema.safeParse({ type: 'function' }).success).toBe(false);
+      expect(LlmToolChoiceSchema.safeParse({ type: 'function', name: '' }).success).toBe(false);
+    });
+  });
+
+  describe('LlmInvocationStepPayloadSchema & Fallback integration', () => {
+    it('validates step payload with static tools and toolChoice', () => {
+      const payload = {
+        stepType: 'LLM_INVOCATION',
+        llmProvider: 'GEMINI',
+        modelId: 'gemini-1.5-pro',
+        tools: [
+          { type: 'google_search' },
+          {
+            type: 'function',
+            name: 'lookup_user',
+            description: 'Look up user by ID',
+            parameters: { type: 'object' },
+          },
+        ],
+        toolsPath: '$.steps_output.previous_step.tools',
+        toolChoice: 'auto',
+      };
+
+      expect(LlmInvocationStepPayloadSchema.safeParse(payload).success).toBe(true);
+    });
+
+    it('validates fallback configuration with tools and toolChoice', () => {
+      const fallback = {
+        llmProvider: 'OPENAI',
+        modelId: 'gpt-4o',
+        tools: [{ type: 'web_search' }],
+        toolsPath: '$.context.tools',
+        toolChoice: { type: 'function', name: 'lookup_user' },
+      };
+
+      expect(LlmInvocationFallbackSchema.safeParse(fallback).success).toBe(true);
+    });
+  });
+});

--- a/packages/core-types/src/steps/system/llm.ts
+++ b/packages/core-types/src/steps/system/llm.ts
@@ -1,7 +1,12 @@
 import { z } from 'zod';
 import { StepTypeSchema } from '../../common/enums.js';
 import { S3PointerSchema, JsonPathStringSchema } from '../../common/core.js';
-import { LLMProviderTypeSchema, LlmParametersSchema } from '../../llm/index.js';
+import {
+  LLMProviderTypeSchema,
+  LlmParametersSchema,
+  LlmToolDeclarationSchema,
+  LlmToolChoiceSchema,
+} from '../../llm/index.js';
 import { TemplateContextMappingItemSchema } from '../templating.js';
 
 /**
@@ -53,6 +58,9 @@ export const LlmInvocationFallbackSchema = z.object({
   customConfig: z.object({
     jsonOutputMode: z.boolean().optional(),
   }).passthrough().optional(),
+  tools: z.array(LlmToolDeclarationSchema).optional(),
+  toolsPath: JsonPathStringSchema.optional(),
+  toolChoice: LlmToolChoiceSchema.optional(),
 });
 export type LlmInvocationFallback = z.infer<typeof LlmInvocationFallbackSchema>;
 
@@ -67,6 +75,9 @@ export const LlmInvocationStepPayloadSchema = z.object({
   directPrompt: z.string().optional().describe("Direct Prompt|textarea|Enter a prompt directly. Overrides Prompt Template if used."),
   mediaAttachments: z.array(LlmMediaAttachmentSchema).optional().describe("Media Attachments|json|Static list of images/PDFs to send to the model. Each item has exactly one source: s3Pointer, url, or base64. Only used by multimodal providers (Gemini, Bedrock Anthropic)."),
   mediaAttachmentsPath: JsonPathStringSchema.optional().describe("Dynamic Media Path|text|A JSONPath to an array of media attachment objects in the context (e.g. `$.steps_output.my_step.images`). Use this for a dynamic list."),
+  tools: z.array(LlmToolDeclarationSchema).optional().describe("Tools|json|Static list of tool declarations (built-in or function tools) available for the LLM."),
+  toolsPath: JsonPathStringSchema.optional().describe("Dynamic Tools Path|text|A JSONPath to an array of tool declarations in the context (e.g. `$.steps_output.my_step.tools`). Use this for a dynamic list."),
+  toolChoice: LlmToolChoiceSchema.optional().describe("Tool Choice|json|Tool choice configuration ('auto', 'none', 'required', or a specific function)."),
   inferenceParameters: LlmParametersSchema.optional().describe("Inference Parameters|json|Advanced LLM settings like temperature, topP, etc."),
   customConfig: z.object({
     jsonOutputMode: z.boolean().optional(),


### PR DESCRIPTION
## Summary
Adds top-level tool support schemas and types to `@allma/core-types` for Phase 1 of LLM tool calling in `LLM_INVOCATION`.

### Changes
- Added `LlmBuiltInToolType` enum (`GOOGLE_SEARCH`, `CODE_EXECUTION`, `WEB_SEARCH`) and `LlmBuiltInToolTypeSchema`
- Added `LlmFunctionToolSchema`, `LlmBuiltInToolSchema`, `LlmToolDeclarationSchema`, and `LlmToolChoiceSchema`
- Added `LlmToolCallRequest` interface
- Extended `LlmGenerationRequest` with `tools` and `toolChoice`
- Extended `LlmGenerationResponse` with `groundingMetadata` and `toolCalls`
- Updated `LlmInvocationStepPayloadSchema` and `LlmInvocationFallbackSchema` with `tools`, `toolsPath`, and `toolChoice`
- Added comprehensive unit tests in `packages/core-types/src/llm/llm-tools.test.ts`
- Added changeset for `@allma/core-types` (`minor` bump)