### PR TITLE
feat(app-logic): add tools and grounding support to Gemini and Bedrock adapters

### DIFF
--- a/packages/app-logic/src/allma-core/llm-adapters/bedrock-adapter.ts
+++ b/packages/app-logic/src/allma-core/llm-adapters/bedrock-adapter.ts
@@ -10,6 +10,7 @@ import {
     LlmProviderAdapter,
     LlmGenerationRequest,
     LlmGenerationResponse,
+    LlmToolCallRequest,
     PermanentStepError,
     TransientStepError
 } from '@allma/core-types';
@@ -131,21 +132,76 @@ export class BedrockAdapter implements LlmProviderAdapter {
         if (sampling.temperature !== undefined) payload.temperature = sampling.temperature;
         if (sampling.topP !== undefined) payload.top_p = sampling.topP;
 
+        if (request.tools && request.tools.length > 0) {
+            payload.tools = request.tools.map((tool: any) => {
+                if (tool.type === 'function') {
+                    return {
+                        name: tool.name,
+                        description: tool.description,
+                        input_schema: tool.parameters,
+                    };
+                }
+                return {
+                    name: tool.name || tool.type,
+                    description: tool.description || `Built-in ${tool.type} tool`,
+                    input_schema: tool.parameters || tool.config || { type: 'object', properties: {} },
+                };
+            });
+        }
+
+        if (request.toolChoice) {
+            if (request.toolChoice === 'auto') {
+                payload.tool_choice = { type: 'auto' };
+            } else if (request.toolChoice === 'none') {
+                payload.tool_choice = { type: 'none' };
+            } else if (request.toolChoice === 'required') {
+                payload.tool_choice = { type: 'any' };
+            } else if (typeof request.toolChoice === 'object' && request.toolChoice.type === 'function') {
+                payload.tool_choice = { type: 'tool', name: request.toolChoice.name };
+            }
+        }
+
         return JSON.stringify(payload);
     }
 
     /**
      * Parses the response from an Anthropic Claude model on Bedrock.
      * @param responseBody - The parsed JSON object from the Bedrock API response.
-     * @returns An object with the extracted responseText and tokenUsage.
+     * @returns An object with the extracted responseText, tokenUsage, and optional toolCalls.
      */
-    private parseAnthropicResponse(responseBody: any): { responseText: string; tokenUsage: { inputTokens: number; outputTokens: number } } {
-        const responseText = responseBody.content?.[0]?.text ?? '';
+    private parseAnthropicResponse(responseBody: any): {
+        responseText: string;
+        tokenUsage: { inputTokens: number; outputTokens: number };
+        toolCalls?: LlmToolCallRequest[];
+    } {
+        const contentBlocks: any[] = responseBody.content ?? [];
+        const textParts: string[] = [];
+        const toolCalls: LlmToolCallRequest[] = [];
+
+        for (const block of contentBlocks) {
+            if (block.type === 'text' && typeof block.text === 'string') {
+                textParts.push(block.text);
+            } else if (block.type === 'tool_use') {
+                toolCalls.push({
+                    ...(block.id && { id: block.id }),
+                    name: block.name,
+                    args: block.input ?? {},
+                });
+            } else if (!block.type && typeof block.text === 'string') {
+                textParts.push(block.text);
+            }
+        }
+
+        const responseText = textParts.join('');
         const tokenUsage = {
             inputTokens: responseBody.usage?.input_tokens ?? 0,
             outputTokens: responseBody.usage?.output_tokens ?? 0,
         };
-        return { responseText, tokenUsage };
+        return {
+            responseText,
+            tokenUsage,
+            ...(toolCalls.length > 0 && { toolCalls }),
+        };
     }
 
     /**
@@ -245,7 +301,11 @@ export class BedrockAdapter implements LlmProviderAdapter {
         }
 
         let body: string;
-        let responseParser: (body: any) => { responseText: string; tokenUsage: { inputTokens: number; outputTokens: number } };
+        let responseParser: (body: any) => {
+            responseText: string;
+            tokenUsage: { inputTokens: number; outputTokens: number };
+            toolCalls?: LlmToolCallRequest[];
+        };
 
         try {
             switch (provider) {
@@ -292,10 +352,15 @@ export class BedrockAdapter implements LlmProviderAdapter {
 
             log_debug('Received raw response from Bedrock', { responseBody }, correlationId);
 
-            const { responseText, tokenUsage } = responseParser(responseBody);
+            const { responseText, tokenUsage, toolCalls } = responseParser(responseBody);
 
             return {
-                success: true, provider: LLMProviderType.AWS_BEDROCK, modelUsed: modelId, responseText, tokenUsage,
+                success: true,
+                provider: LLMProviderType.AWS_BEDROCK,
+                modelUsed: modelId,
+                responseText,
+                tokenUsage,
+                ...(toolCalls && toolCalls.length > 0 && { toolCalls }),
             };
         } catch (error: any) {
             log_error('Error invoking Bedrock model', { modelId, errorName: error.name, errorMessage: error.message }, correlationId);

--- a/packages/app-logic/src/allma-core/llm-adapters/gemini-adapter.ts
+++ b/packages/app-logic/src/allma-core/llm-adapters/gemini-adapter.ts
@@ -4,9 +4,18 @@ import {
   SafetySetting,
   HarmCategory,
   HarmBlockThreshold,
-  GenerateContentConfig
+  GenerateContentConfig,
+  FunctionCallingConfigMode
 } from '@google/genai';
-import { LLMProviderType, ENV_VAR_NAMES, LlmProviderAdapter, LlmGenerationRequest, LlmGenerationResponse } from '@allma/core-types';
+import {
+  LLMProviderType,
+  ENV_VAR_NAMES,
+  LlmProviderAdapter,
+  LlmGenerationRequest,
+  LlmGenerationResponse,
+  LlmToolCallRequest,
+  LlmBuiltInToolType
+} from '@allma/core-types';
 import { log_info, log_debug, log_warn, log_error } from '@allma/core-sdk';
 
 const secretsManagerClient = new SecretsManagerClient({});
@@ -159,6 +168,41 @@ export class GeminiAdapter implements LlmProviderAdapter {
       const client = await this.getClient(correlationId);
       const safetySettings = (customConfig?.safetySettings as SafetySetting[]) || DEFAULT_SAFETY_SETTINGS;
       
+      let geminiTools: any[] | undefined = undefined;
+      let hasGoogleSearch = false;
+
+      if (request.tools && request.tools.length > 0) {
+        const toolsList: any[] = [];
+        const functionDeclarations: any[] = [];
+
+        for (const tool of request.tools) {
+          if (tool.type === LlmBuiltInToolType.GOOGLE_SEARCH) {
+            hasGoogleSearch = true;
+            toolsList.push({ googleSearch: tool.config ?? {} });
+          } else if (tool.type === LlmBuiltInToolType.CODE_EXECUTION) {
+            toolsList.push({ codeExecution: tool.config ?? {} });
+          } else if (tool.type === 'function') {
+            functionDeclarations.push({
+              name: tool.name,
+              description: tool.description,
+              parameters: tool.parameters,
+            });
+          }
+        }
+
+        if (functionDeclarations.length > 0) {
+          toolsList.push({ functionDeclarations });
+        }
+
+        if (toolsList.length > 0) {
+          geminiTools = toolsList;
+        }
+      }
+
+      if (hasGoogleSearch && jsonOutputMode) {
+        log_warn('GeminiAdapter: google_search tool is enabled alongside jsonOutputMode. Omitting responseMimeType to prevent Gemini API conflict.', {}, correlationId);
+      }
+
       const generationConfig: GenerateContentConfig = {
         safetySettings,
         candidateCount: 1,
@@ -167,8 +211,34 @@ export class GeminiAdapter implements LlmProviderAdapter {
         topP: topP ?? 0.95,
         topK: topK ?? 40,
         ...(seed !== undefined && { seed }),
-        ...(jsonOutputMode && { responseMimeType: "application/json" })
+        ...(jsonOutputMode && !hasGoogleSearch && { responseMimeType: "application/json" }),
+        ...(geminiTools && { tools: geminiTools }),
       };
+
+      if (request.toolChoice) {
+        let mode: FunctionCallingConfigMode;
+        let allowedFunctionNames: string[] | undefined = undefined;
+
+        if (request.toolChoice === 'auto') {
+          mode = FunctionCallingConfigMode.AUTO;
+        } else if (request.toolChoice === 'none') {
+          mode = FunctionCallingConfigMode.NONE;
+        } else if (request.toolChoice === 'required') {
+          mode = FunctionCallingConfigMode.ANY;
+        } else if (typeof request.toolChoice === 'object' && request.toolChoice.type === 'function') {
+          mode = FunctionCallingConfigMode.ANY;
+          allowedFunctionNames = [request.toolChoice.name];
+        } else {
+          mode = FunctionCallingConfigMode.AUTO;
+        }
+
+        generationConfig.toolConfig = {
+          functionCallingConfig: {
+            mode,
+            ...(allowedFunctionNames && { allowedFunctionNames }),
+          },
+        };
+      }
       
       log_info(`GeminiAdapter: Requesting content from model: ${modelId}`, { generationConfig }, correlationId);
       
@@ -217,11 +287,39 @@ export class GeminiAdapter implements LlmProviderAdapter {
             };
           }
 
-          const textContent = response.text; //candidate.content?.parts?.map((p: Part) => p.text).join('') || "";
+          const groundingMetadata = candidate.groundingMetadata as Record<string, any> | undefined;
+
+          const toolCalls: LlmToolCallRequest[] = [];
+          if (response.functionCalls && response.functionCalls.length > 0) {
+            for (const fc of response.functionCalls) {
+              if (fc.name) {
+                toolCalls.push({
+                  ...(fc.id && { id: fc.id }),
+                  name: fc.name,
+                  args: (fc.args as Record<string, any>) ?? {},
+                });
+              }
+            }
+          } else if (candidate.content?.parts) {
+            for (const part of candidate.content.parts) {
+              if ((part as any).functionCall) {
+                const fc = (part as any).functionCall;
+                if (fc.name) {
+                  toolCalls.push({
+                    ...(fc.id && { id: fc.id }),
+                    name: fc.name,
+                    args: (fc.args as Record<string, any>) ?? {},
+                  });
+                }
+              }
+            }
+          }
+
+          const textContent = response.text;
 
           log_info(`GeminiAdapter: Successfully received response from ${modelId}`, { finishReason: candidate.finishReason }, correlationId);
 
-          if (!textContent) {
+          if (!textContent && toolCalls.length === 0) {
             throw new Error("No content received from Gemini.");
           }
 
@@ -230,11 +328,13 @@ export class GeminiAdapter implements LlmProviderAdapter {
             success: true,
             provider: LLMProviderType.GEMINI,
             modelUsed: modelId,
-            responseText: textContent,
+            responseText: textContent || null,
             tokenUsage: {
               inputTokens: response.usageMetadata?.promptTokenCount || 0,
               outputTokens: response.usageMetadata?.candidatesTokenCount || 0,
             },
+            ...(groundingMetadata && { groundingMetadata }),
+            ...(toolCalls.length > 0 && { toolCalls }),
           };
 
         } catch (error: any) {

--- a/packages/app-logic/tests/unit/allma-core/llm-adapters/bedrock-adapter.test.ts
+++ b/packages/app-logic/tests/unit/allma-core/llm-adapters/bedrock-adapter.test.ts
@@ -154,4 +154,63 @@ describe('BedrockAdapter.generateContent', () => {
     expect(body.temperature).toBe(0.3);
     expect(body.top_p).toBeUndefined();
   });
+
+  it('builds Anthropic tool payload and tool_choice', async () => {
+    bedrockMock.on(InvokeModelCommand).resolves({
+      body: encode({ content: [{ text: 'ok' }], usage: {} }),
+    });
+
+    await adapter.generateContent(
+      makeRequest({
+        tools: [
+          {
+            type: 'function',
+            name: 'calculator',
+            description: 'Calculate expression',
+            parameters: { type: 'object', properties: { expr: { type: 'string' } } },
+          },
+        ],
+        toolChoice: 'required',
+      })
+    );
+
+    const body = lastSentBody();
+    expect(body.tools).toEqual([
+      {
+        name: 'calculator',
+        description: 'Calculate expression',
+        input_schema: { type: 'object', properties: { expr: { type: 'string' } } },
+      },
+    ]);
+    expect(body.tool_choice).toEqual({ type: 'any' });
+  });
+
+  it('parses tool_use blocks into toolCalls in Anthropic response', async () => {
+    bedrockMock.on(InvokeModelCommand).resolves({
+      body: encode({
+        content: [
+          { type: 'text', text: 'Let me calculate that.' },
+          {
+            type: 'tool_use',
+            id: 'toolu_01A',
+            name: 'calculator',
+            input: { expr: '2+2' },
+          },
+        ],
+        usage: { input_tokens: 20, output_tokens: 15 },
+      }),
+    });
+
+    const result = await adapter.generateContent(makeRequest());
+
+    expect(result.success).toBe(true);
+    expect(result.responseText).toBe('Let me calculate that.');
+    expect(result.toolCalls).toEqual([
+      {
+        id: 'toolu_01A',
+        name: 'calculator',
+        args: { expr: '2+2' },
+      },
+    ]);
+  });
 });

--- a/packages/app-logic/tests/unit/allma-core/llm-adapters/gemini-adapter.test.ts
+++ b/packages/app-logic/tests/unit/allma-core/llm-adapters/gemini-adapter.test.ts
@@ -1,6 +1,6 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
-import { LLMProviderType, LlmMediaKind, type LlmGenerationRequest } from '@allma/core-types';
+import { LLMProviderType, LlmMediaKind, LlmBuiltInToolType, type LlmGenerationRequest } from '@allma/core-types';
 import { mockClient, resetAwsClientMocks } from '../../_helpers/aws-mock.js';
 
 // @google/genai is a third-party SDK, so it is mocked as a collaborator. The secret fetch
@@ -170,6 +170,24 @@ describe('GeminiAdapter.generateContent', () => {
     const passedConfig = generateContentMock.mock.calls[0][0].config;
     expect(passedConfig.responseMimeType).toBeUndefined();
     expect(passedConfig.tools).toEqual([{ googleSearch: {} }]);
+  });
+
+  it('passes code_execution tool in config sent to generateContent', async () => {
+    generateContentMock.mockResolvedValue({
+      text: 'code execution result',
+      candidates: [{ finishReason: 'STOP' }],
+      usageMetadata: {},
+    });
+
+    const result = await adapter.generateContent(
+      makeRequest({
+        tools: [{ type: LlmBuiltInToolType.CODE_EXECUTION }],
+      })
+    );
+
+    expect(result.success).toBe(true);
+    const passedConfig = generateContentMock.mock.calls[0][0].config;
+    expect(passedConfig.tools).toEqual([{ codeExecution: {} }]);
   });
 
   it('handles custom function tool declarations, toolChoice, and extracts functionCalls from response', async () => {

--- a/packages/app-logic/tests/unit/allma-core/llm-adapters/gemini-adapter.test.ts
+++ b/packages/app-logic/tests/unit/allma-core/llm-adapters/gemini-adapter.test.ts
@@ -21,6 +21,13 @@ vi.mock('@google/genai', () => ({
     HARM_CATEGORY_DANGEROUS_CONTENT: 'HARM_CATEGORY_DANGEROUS_CONTENT',
   },
   HarmBlockThreshold: { BLOCK_MEDIUM_AND_ABOVE: 'BLOCK_MEDIUM_AND_ABOVE' },
+  FunctionCallingConfigMode: {
+    MODE_UNSPECIFIED: 'MODE_UNSPECIFIED',
+    AUTO: 'AUTO',
+    ANY: 'ANY',
+    NONE: 'NONE',
+    VALIDATED: 'VALIDATED',
+  },
 }));
 
 import { GeminiAdapter } from '../../../../src/allma-core/llm-adapters/gemini-adapter.js';
@@ -117,6 +124,102 @@ describe('GeminiAdapter.generateContent', () => {
 
     const passedConfig = generateContentMock.mock.calls[0][0].config;
     expect(passedConfig.responseMimeType).toBe('application/json');
+  });
+
+  it('passes google_search tool in config and extracts groundingMetadata from candidate', async () => {
+    generateContentMock.mockResolvedValue({
+      text: 'search result text',
+      candidates: [
+        {
+          finishReason: 'STOP',
+          groundingMetadata: { webSearchQueries: ['test query'] },
+        },
+      ],
+      usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 20 },
+    });
+
+    const result = await adapter.generateContent(
+      makeRequest({
+        tools: [{ type: 'google_search', config: {} }],
+      })
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.responseText).toBe('search result text');
+    expect(result.groundingMetadata).toEqual({ webSearchQueries: ['test query'] });
+
+    const passedConfig = generateContentMock.mock.calls[0][0].config;
+    expect(passedConfig.tools).toEqual([{ googleSearch: {} }]);
+  });
+
+  it('omits responseMimeType when jsonOutputMode is true and google_search tool is present', async () => {
+    generateContentMock.mockResolvedValue({
+      text: '{"result": "ok"}',
+      candidates: [{ finishReason: 'STOP' }],
+      usageMetadata: {},
+    });
+
+    const result = await adapter.generateContent(
+      makeRequest({
+        jsonOutputMode: true,
+        tools: [{ type: 'google_search' }],
+      })
+    );
+
+    expect(result.success).toBe(true);
+    const passedConfig = generateContentMock.mock.calls[0][0].config;
+    expect(passedConfig.responseMimeType).toBeUndefined();
+    expect(passedConfig.tools).toEqual([{ googleSearch: {} }]);
+  });
+
+  it('handles custom function tool declarations, toolChoice, and extracts functionCalls from response', async () => {
+    generateContentMock.mockResolvedValue({
+      text: '',
+      functionCalls: [
+        { id: 'call-1', name: 'get_weather', args: { location: 'San Francisco' } },
+      ],
+      candidates: [{ finishReason: 'STOP' }],
+      usageMetadata: { promptTokenCount: 15, candidatesTokenCount: 10 },
+    });
+
+    const result = await adapter.generateContent(
+      makeRequest({
+        tools: [
+          {
+            type: 'function',
+            name: 'get_weather',
+            description: 'Get weather for location',
+            parameters: { type: 'object', properties: { location: { type: 'string' } } },
+          },
+        ],
+        toolChoice: { type: 'function', name: 'get_weather' },
+      })
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.responseText).toBeNull();
+    expect(result.toolCalls).toEqual([
+      { id: 'call-1', name: 'get_weather', args: { location: 'San Francisco' } },
+    ]);
+
+    const passedConfig = generateContentMock.mock.calls[0][0].config;
+    expect(passedConfig.tools).toEqual([
+      {
+        functionDeclarations: [
+          {
+            name: 'get_weather',
+            description: 'Get weather for location',
+            parameters: { type: 'object', properties: { location: { type: 'string' } } },
+          },
+        ],
+      },
+    ]);
+    expect(passedConfig.toolConfig).toEqual({
+      functionCallingConfig: {
+        mode: 'ANY',
+        allowedFunctionNames: ['get_weather'],
+      },
+    });
   });
 
   it('reports a safety-blocked prompt as an unsuccessful, safety-flagged result', async () => {


### PR DESCRIPTION
Add top-level tool support and grounding metadata handling to Gemini and Bedrock LLM adapters.

- **Gemini Adapter (`gemini-adapter.ts`)**:
  - Convert `LlmToolDeclaration[]` to `@google/genai` `GenerateContentConfig.tools` (`googleSearch`, `codeExecution`, `functionDeclarations`).
  - Add conflict guard: omit `responseMimeType: "application/json"` and log warning if `google_search` is present alongside `jsonOutputMode`.
  - Map `request.toolChoice` to `toolConfig.functionCallingConfig`.
  - Extract `candidate.groundingMetadata` and function calls into `response.groundingMetadata` and `response.toolCalls`.
  - Return `success: true` with `toolCalls` when model response text is empty due to function calls.

- **Bedrock Adapter (`bedrock-adapter.ts`)**:
  - Map `request.tools` and `request.toolChoice` to Anthropic Bedrock format (`tools` array, `tool_choice` object).
  - Parse `tool_use` content blocks into `response.toolCalls`.

- **Unit Tests**:
  - Add unit tests covering tool declarations, grounding metadata extraction, conflict guard, tool choice mapping, and function call extraction for both Gemini and Bedrock adapters.