### PR TITLE
fix(ci): enable cancel-in-progress for Release workflow concurrency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,8 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   release:


### PR DESCRIPTION
Updates `release.yml` concurrency configuration to use `group: ${{ github.workflow }}-${{ github.ref }}` and `cancel-in-progress: true`. This prevents older push events from locking the Release workflow in a queued state indefinitely.