### PR TITLE
ci: add workflow_dispatch triggers for manual execution

### DIFF
--- a/.github/workflows/ci-websites.yml
+++ b/.github/workflows/ci-websites.yml
@@ -13,6 +13,7 @@ on:
     paths:
       - 'allma.cdk/**'
       - 'docs.allma.dev/**'
+  workflow_dispatch:
 
 # Prevent overlapping deploys to the live site; let a newer push supersede an in-flight PR build.
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Adds `workflow_dispatch:` to `ci.yml`, `ci-websites.yml`, and `release.yml` to enable manual workflow execution and re-triggering from CLI/GitHub UI.