### PR TITLE
fix(ci): update concurrency group keys to unblock zombie run lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ci-v2-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: release-v2-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Updates concurrency group keys in `ci.yml` and `release.yml` to `ci-v2-...` and `release-v2-...`. This bypasses a GitHub Actions backend lock on the old `Release-refs/heads/main` concurrency group key caused by a zombie run.