### PR TITLE
chore: remove empty docs changeset to trigger npm publish

### DIFF
--- a/.changeset/docs-llm-tools.md
+++ b/.changeset/docs-llm-tools.md
@@ -1,4 +1,0 @@
----
----
-
-Update LLM_INVOCATION documentation with top-level tools, search grounding, and function calling.


### PR DESCRIPTION
Removes the empty `.changeset/docs-llm-tools.md` file so that `changesets/action` enters publish mode on `main` and runs `changeset publish` for the new package versions (@allma/core-types@1.9.0, @allma/admin-shell@11.0.0).