### PR TITLE
fix(ci): use run_id in Release workflow concurrency key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: release-v2-${{ github.ref }}
+  group: release-v3-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Updates `release.yml` concurrency to use `group: release-v3-${{ github.head_ref || github.run_id }}`. This guarantees every release run receives a unique concurrency key, eliminating any possibility of runner queuing locks from prior runs.